### PR TITLE
Add Dokploy deployment setup with PR previews

### DIFF
--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+set -e
+
+echo "Running database migrations..."
+django-admin migrate --noinput
+
+echo "Starting application..."
+exec "$@"


### PR DESCRIPTION
## Summary

- Add entrypoint script to run migrations on container start
- Update Dockerfile prod target to use entrypoint

---

# Dokploy Deployment Guide

Deploy previews for PRs and continuous deployment for production.

## Prerequisites

- VPS with 2GB+ RAM, 30GB+ storage
- Ports 80, 443, 3000 open
- Domain: `zagrajmy.net` with DNS access

## 1. Install Dokploy

```bash
curl -sSL https://dokploy.com/install.sh | sh
```

Access at `http://<server-ip>:3000`, create admin account.

## 2. DNS Configuration

Add these records pointing to your server IP:

```
A    zagrajmy.net             → <server-ip>
A    *.zagrajmy.net           → <server-ip>
A    *.dev.zagrajmy.net       → <server-ip>
```

- `*.zagrajmy.net` — sphere subdomains
- `*.dev.zagrajmy.net` — PR preview deployments

## 3. Connect GitHub

1. **Settings** → **Git Providers** → **GitHub**
2. Create GitHub App or use personal access token
3. Install on the `ludamus` repository
4. Grant access to pull requests

## 4. Create PostgreSQL Database

1. **Create Project** → **Databases** → **PostgreSQL**
2. Note connection details (internal hostname, credentials)

## 5. Create Application

1. **Create Project** → **Applications** → **Application**
2. Select **Docker** as build type
3. Connect GitHub repository, select `main` branch
4. Configure:
   - **Dockerfile Path**: `Dockerfile`
   - **Build Target**: `prod`
   - **Exposed Port**: 8000

## 6. Environment Variables

Add in application **Environment** tab:

```
SECRET_KEY=<generate: python -c "from django.core.management.utils import get_random_secret_key; print(get_random_secret_key())">
ALLOWED_HOSTS=zagrajmy.net,*.zagrajmy.net,*.dev.zagrajmy.net
DB_NAME=<from-postgres>
DB_USER=<from-postgres>
DB_PASSWORD=<from-postgres>
DB_HOST=<postgres-internal-hostname>
DB_PORT=5432
AUTH0_DOMAIN=<your-auth0-domain>
AUTH0_CLIENT_ID=<your-client-id>
AUTH0_CLIENT_SECRET=<your-client-secret>
ROOT_DOMAIN=zagrajmy.net
SUPPORT_EMAIL=<support-email>
ENV=production
USE_POSTGRES=true
```

## 7. Build Arguments

In **Advanced** → **Build Args**:

```
SECRET_KEY=<same-as-env>
```

Required for `collectstatic` during Docker build.

## 8. Production Domain

1. **Domains** tab → Add domain
2. Enter `zagrajmy.net`
3. Enable **HTTPS** (auto Let's Encrypt)

## 9. Enable Preview Deployments

1. **Preview Deployments** tab → Enable
2. Set **Wildcard Domain**: `*.dev.zagrajmy.net`
3. Configure:
   - **Max Previews**: 3 (or as needed)
   - **Labels** (optional): leave empty for all PRs

Preview URLs will be: `preview-ludamus-<id>.dev.zagrajmy.net`

When a PR is opened, Dokploy automatically:
- Builds from the PR branch
- Deploys to preview URL
- Comments on the PR with the link
- Cleans up when PR is closed/merged

## 10. Deploy

Click **Deploy** or push to `main`. Dokploy will:
1. Build Docker image (prod target)
2. Run migrations via entrypoint
3. Start gunicorn

## Troubleshooting

### Check logs
Application → **Deployments** → Select deployment → **Logs**

### Health check failing
Ensure `/` returns HTTP 200. Check `ALLOWED_HOSTS` includes all domains.

### Database connection issues
Verify `DB_HOST` matches PostgreSQL internal hostname (visible in database settings).

## Resources

- [Dokploy Installation](https://docs.dokploy.com/docs/core/installation)
- [Dokploy Preview Deployments](https://docs.dokploy.com/docs/core/applications/preview-deployments)
- [Dokploy Docker Applications](https://docs.dokploy.com/docs/core/applications)
- [Dokploy GitHub Integration](https://docs.dokploy.com/docs/core/git)