### PR TITLE
Fix login redirect losing event subdomain in proposal wizard

### DIFF
--- a/src/ludamus/adapters/web/django/views.py
+++ b/src/ludamus/adapters/web/django/views.py
@@ -133,7 +133,16 @@ class Auth0LoginActionView(View):
         ).domain
         next_path = request.GET.get("next")
         if request.get_host() != root_domain:
-            url = f'{request.scheme}://{root_domain}{reverse("web:crowd:auth0:login")}?next={next_path}'
+            if next_path:
+                next_path = request.build_absolute_uri(next_path)
+            login_url = (
+                f'{request.scheme}://{root_domain}{reverse("web:crowd:auth0:login")}'
+            )
+            url = (
+                f"{login_url}?{urlencode({'next': next_path})}"
+                if next_path
+                else login_url
+            )
             raise RedirectError(url)
 
         # Generate a secure state token

--- a/tests/integration/web/crowd/test_auth0_login_action.py
+++ b/tests/integration/web/crowd/test_auth0_login_action.py
@@ -36,7 +36,22 @@ class TestAuth0LoginActionView:
         response = client.get(self.URL, HTTP_HOST=non_root_sphere.site.domain)
 
         assert_response(
+            response, HTTPStatus.FOUND, url="http://testserver/crowd/auth0/do/login"
+        )
+
+    def test_error_non_root_domain_preserves_absolute_next(
+        self, client, non_root_sphere
+    ):
+        domain = non_root_sphere.site.domain
+        response = client.get(
+            f"{self.URL}?next=/event/my-event/session/propose/", HTTP_HOST=domain
+        )
+
+        assert_response(
             response,
             HTTPStatus.FOUND,
-            url="http://testserver/crowd/auth0/do/login?next=None",
+            url=(
+                "http://testserver/crowd/auth0/do/login"
+                f"?next=http%3A%2F%2F{domain}%2Fevent%2Fmy-event%2Fsession%2Fpropose%2F"
+            ),
         )


### PR DESCRIPTION
When an unauthenticated user on an event subdomain was redirected to the root domain for Auth0 login, the `next` parameter only preserved the path, not the full URL. After login the user landed on the root domain where the event doesn't exist, producing "Event not found."

Now `Auth0LoginActionView` converts the path to an absolute URL (including the subdomain) before redirecting to root, so the user returns to the correct domain after authentication.