### PR TITLE
Deduplicate tag-attr parsing, enable pylint duplicate-code for src

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -463,7 +463,6 @@ disable=import-outside-toplevel,
         unused-argument,
         invalid-str-returned,
         line-too-long,
-        duplicate-code,
         protected-access,
         no-self-use,
         magic-value-comparison,
@@ -472,7 +471,7 @@ disable=import-outside-toplevel,
         too-few-public-methods,
         too-many-statements,
         no-member,
-        missing-docstring,
+        missing-docstring
 
 
 # Enable the message, report, category or checker with the given id(s). You can

--- a/TODO.md
+++ b/TODO.md
@@ -16,7 +16,6 @@ kanban
     [Split check_proposal_rate_limit into query + command]@{
       assigned: 'GLIMPSE'
     }
-    [Duplicate code detection tooling]@{ assigned: 'agent-readiness' }
     [Technical debt markers tracking]@{ assigned: 'agent-readiness' }
     [Feature flag system]@{ assigned: 'agent-readiness' }
     [Automated release notes]@{ assigned: 'agent-readiness' }
@@ -137,4 +136,5 @@ kanban
     }
     [Dead code detection tooling]@{ assigned: 'agent-readiness' }
     [Program categories - configurable submission forms]@{ assigned: 'panel' }
+    [Duplicate code detection tooling]@{ assigned: 'agent-readiness' }
 ```

--- a/mise.toml
+++ b/mise.toml
@@ -62,7 +62,7 @@ run = "mise run _lint -- lint-imports --config=pyproject.toml"
 run = "mise run _lint -- mypy src"
 
 [tasks.pylint]
-run = "mise run _lint -- pylint src tests"
+run = "mise run _lint -- pylint src && mise run _lint -- pylint --disable=duplicate-code tests"
 
 [tasks.ruff]
 run = "mise run _lint -- ruff check src tests"

--- a/src/ludamus/adapters/web/django/templatetags/tessera/_utils.py
+++ b/src/ludamus/adapters/web/django/templatetags/tessera/_utils.py
@@ -1,0 +1,21 @@
+"""Shared utilities for tessera template tag parsers."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from django.template.base import FilterExpression, Parser, Token
+
+
+def parse_tag_attrs(parser: Parser, token: Token) -> dict[str, FilterExpression]:
+    """Parse ``key=value`` pairs from a template tag token.
+
+    Returns:
+        Dict mapping attribute names to compiled filter expressions.
+    """
+    attrs: dict[str, FilterExpression] = {}
+    for bit in token.split_contents()[1:]:
+        key, _, value = bit.partition("=")
+        attrs[key] = parser.compile_filter(value)
+    return attrs

--- a/src/ludamus/adapters/web/django/templatetags/tessera/select.py
+++ b/src/ludamus/adapters/web/django/templatetags/tessera/select.py
@@ -10,6 +10,7 @@ from django.utils.html import escape
 from django.utils.safestring import mark_safe
 
 from ._registry import register
+from ._utils import parse_tag_attrs
 
 if TYPE_CHECKING:
     from django.template.base import FilterExpression, Parser, Token
@@ -63,13 +64,7 @@ def do_select(parser: Parser, token: Token) -> SelectNode:
     Returns:
         A SelectNode that renders a themed ``<select>`` wrapping its body.
     """
-    bits = token.split_contents()[1:]
-    attrs: dict[str, FilterExpression] = {}
-
-    for bit in bits:
-        key, _, value = bit.partition("=")
-        attrs[key] = parser.compile_filter(value)
-
+    attrs = parse_tag_attrs(parser, token)
     nodelist = parser.parse(("end_select",))
     parser.delete_first_token()
 

--- a/src/ludamus/adapters/web/django/templatetags/tessera/tabs.py
+++ b/src/ludamus/adapters/web/django/templatetags/tessera/tabs.py
@@ -9,6 +9,7 @@ from django.utils.html import escape
 from django.utils.safestring import mark_safe
 
 from ._registry import register
+from ._utils import parse_tag_attrs
 from .icon import icon
 
 if TYPE_CHECKING:
@@ -56,12 +57,7 @@ def do_tabs(parser: Parser, token: Token) -> TabsNode:
     Returns:
         A TabsNode that renders a themed ``<nav>`` wrapping its body.
     """
-    bits = token.split_contents()[1:]
-    attrs: dict[str, FilterExpression] = {}
-    for bit in bits:
-        key, _, value = bit.partition("=")
-        attrs[key] = parser.compile_filter(value)
-
+    attrs = parse_tag_attrs(parser, token)
     nodelist = parser.parse(("end_tabs",))
     parser.delete_first_token()
     return TabsNode(nodelist, attrs)

--- a/src/ludamus/gates/web/django/panel.py
+++ b/src/ludamus/gates/web/django/panel.py
@@ -6,14 +6,13 @@ import json
 import re
 from collections import defaultdict
 from datetime import date, datetime, timedelta
-from typing import (
+from typing import (  # pylint: disable=unused-import
     TYPE_CHECKING,
     Any,
     Literal,
     Protocol,
-    TypedDict,
     cast,
-)  # pylint: disable=unused-import
+)
 
 from django.contrib import messages
 from django.contrib.auth.mixins import LoginRequiredMixin, UserPassesTestMixin
@@ -53,6 +52,7 @@ from ludamus.pacts import (
     EventUpdateData,
     FieldUsageSummary,
     NotFoundError,
+    PersonalDataFieldCreateData,
     TrackCreateData,
     TrackUpdateData,
 )
@@ -86,25 +86,14 @@ class _FieldRepositoryProtocol[T: _FieldDTO](Protocol):
     def read_by_slug(self, event_pk: int, slug: str) -> T: ...
 
 
-class FieldFormData(TypedDict):
-    name: str
-    question: str
-    field_type: Literal["text", "select", "checkbox"]
-    options: list[str] | None
-    is_multiple: bool
-    allow_custom: bool
-    max_length: int
-    help_text: str
-
-
-def _parse_field_form_data(form: forms.Form) -> FieldFormData:
+def _parse_field_form_data(form: forms.Form) -> PersonalDataFieldCreateData:
     field_type = cast(
         "Literal['text', 'select', 'checkbox']",
         form.cleaned_data.get("field_type") or "text",
     )
     options_text = form.cleaned_data.get("options") or ""
     options = [o.strip() for o in options_text.split("\n") if o.strip()] or None
-    return FieldFormData(
+    return PersonalDataFieldCreateData(
         name=form.cleaned_data["name"],
         question=form.cleaned_data["question"],
         field_type=field_type,
@@ -113,6 +102,7 @@ def _parse_field_form_data(form: forms.Form) -> FieldFormData:
         allow_custom=form.cleaned_data.get("allow_custom") or False,
         max_length=form.cleaned_data.get("max_length") or 0,
         help_text=form.cleaned_data.get("help_text") or "",
+        is_public=form.cleaned_data.get("is_public") or False,
     )
 
 
@@ -1059,18 +1049,7 @@ class PersonalDataFieldCreatePageView(PanelAccessMixin, EventContextMixin, View)
         parsed = _parse_field_form_data(form)
 
         field = self.request.di.uow.personal_data_fields.create(
-            current_event.pk,
-            {
-                "name": parsed["name"],
-                "question": parsed["question"],
-                "field_type": parsed["field_type"],
-                "options": parsed["options"],
-                "is_multiple": parsed["is_multiple"],
-                "allow_custom": parsed["allow_custom"],
-                "max_length": parsed["max_length"],
-                "help_text": parsed["help_text"],
-                "is_public": form.cleaned_data.get("is_public", False),
-            },
+            current_event.pk, parsed
         )
 
         category_requirements, _order = _parse_field_requirements(
@@ -1343,19 +1322,7 @@ class SessionFieldCreatePageView(PanelAccessMixin, EventContextMixin, View):
         parsed = _parse_field_form_data(form)
 
         field = self.request.di.uow.session_fields.create(
-            current_event.pk,
-            {
-                "name": parsed["name"],
-                "question": parsed["question"],
-                "field_type": parsed["field_type"],
-                "options": parsed["options"],
-                "is_multiple": parsed["is_multiple"],
-                "allow_custom": parsed["allow_custom"],
-                "max_length": parsed["max_length"],
-                "help_text": parsed["help_text"],
-                "icon": form.cleaned_data.get("icon") or "",
-                "is_public": form.cleaned_data.get("is_public", False),
-            },
+            current_event.pk, {**parsed, "icon": form.cleaned_data.get("icon") or ""}
         )
 
         category_requirements, _order = _parse_field_requirements(


### PR DESCRIPTION
- Extract shared parse_tag_attrs utility from select.py and tabs.py
- Enable pylint duplicate-code check for src (disable only for tests)
- Replace local FieldFormData TypedDict with PersonalDataFieldCreateData
- Move duplicate-code TODO item to Done in kanban