### PR TITLE
Wire impeccable UI anti-pattern detection into CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,9 @@ concurrency:
   group: ${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   checks:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,14 @@ jobs:
       - run: mise run p install
       - run: mise run prcheck
 
+  impeccable:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: jdx/mise-action@v2
+      - run: mise install
+      - run: mise run impeccable
+
   test:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -3,6 +3,9 @@ name: Deploy on production
 on:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   build:
     name: Rebuild and upstart dockers

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -3,6 +3,9 @@ name: Deploy on staging
 on:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   build:
     name: Rebuild and upstart dockers

--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -6,6 +6,9 @@ on:
     - cron: '0 2 * * *'  # 2:00 AM UTC daily, on main branch
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   mutation:
     runs-on: ubuntu-latest

--- a/mise.toml
+++ b/mise.toml
@@ -76,6 +76,9 @@ run = "ast-grep scan --error src"
 [tasks.vulture]
 run = "vulture --config=pyproject.toml src"
 
+[tasks.impeccable]
+run = "python scripts/impeccable_lint.py"
+
 [tasks.check]
 depends = [
   "black",
@@ -88,6 +91,7 @@ depends = [
   "pylint",
   "vulture",
   "ast-grep",
+  "impeccable",
 ]
 
 [tasks.prcheck]

--- a/scripts/impeccable_lint.py
+++ b/scripts/impeccable_lint.py
@@ -1,0 +1,164 @@
+#!/usr/bin/env python3
+"""Wrap `npx impeccable detect` with project-specific ignore rules.
+
+With no args, scans tracked HTML/CSS/JS files. Positional args override.
+Exits 1 if any finding remains after filtering.
+
+Under `GITHUB_ACTIONS=true`, also emits GitHub Actions workflow commands
+(`::error file=...,line=...,title=...::message`) so findings surface inline
+on the PR "Files changed" tab.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+# v3 is merged to pbakaus/impeccable main but not yet on npm (latest is 2.1.7).
+# Pinned to main HEAD; bump to `impeccable@3.x.x` once published.
+IMPECCABLE_SPEC = "github:pbakaus/impeccable#346ce25952a6d4150433e8fb1369cb59571ebc30"
+
+IGNORE_PATH_SUBSTRINGS: tuple[str, ...] = (
+    "e2e/playwright-report/",
+    "tailwind.min.js",
+)
+IGNORE_ANTIPATTERNS: frozenset[str] = frozenset({"tiny-text"})
+
+SCAN_GLOBS: tuple[str, ...] = ("*.html", "*.css", "*.js", "*.jsx", "*.tsx")
+
+SNIPPET_MAX = 120
+
+
+def tracked_ui_files() -> list[str]:
+    result = subprocess.run(
+        ["git", "ls-files", "--", *SCAN_GLOBS],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    files = [line for line in result.stdout.splitlines() if line]
+    return [f for f in files if not _path_ignored(f)]
+
+
+def _path_ignored(path: str) -> bool:
+    return any(sub in path for sub in IGNORE_PATH_SUBSTRINGS)
+
+
+def _extract_json_array(text: str) -> str | None:
+    # Strip npm warnings etc. that may prefix the JSON payload.
+    start = text.find("[")
+    end = text.rfind("]")
+    if start == -1 or end == -1 or end < start:
+        return None
+    return text[start : end + 1]
+
+
+def run_detect(paths: list[str]) -> list[dict]:
+    cmd = ["npx", "--yes", IMPECCABLE_SPEC, "detect", "--json", *paths]
+    result = subprocess.run(cmd, check=False, capture_output=True, text=True)
+    # impeccable emits JSON on stdout when empty and on stderr when findings exist.
+    # Sources may prefix the payload with npm warnings (e.g. git-sourced installs).
+    for stream in (result.stdout, result.stderr):
+        payload = _extract_json_array(stream or "")
+        if payload is None:
+            continue
+        try:
+            data = json.loads(payload)
+        except json.JSONDecodeError:
+            continue
+        return data if isinstance(data, list) else []
+    sys.stderr.write(f"impeccable failed (exit {result.returncode}):\n")
+    sys.stderr.write(result.stdout)
+    sys.stderr.write(result.stderr)
+    sys.exit(result.returncode or 1)
+
+
+def filter_findings(findings: list[dict]) -> list[dict]:
+    return [
+        f
+        for f in findings
+        if not _path_ignored(f.get("file", ""))
+        and f.get("antipattern") not in IGNORE_ANTIPATTERNS
+    ]
+
+
+def _relative_path(file_path: str, repo_root: Path) -> str:
+    try:
+        return str(Path(file_path).resolve().relative_to(repo_root))
+    except (ValueError, OSError):
+        return file_path
+
+
+def format_finding(finding: dict, repo_root: Path) -> str:
+    file_path = _relative_path(finding.get("file", ""), repo_root)
+    line = finding.get("line", "")
+    antipattern = finding.get("antipattern", "?")
+    name = finding.get("name", "")
+    snippet = " ".join((finding.get("snippet") or "").split())
+    if len(snippet) > SNIPPET_MAX:
+        snippet = snippet[: SNIPPET_MAX - 3] + "..."
+    head = f"{file_path}:{line} [{antipattern}] {name}"
+    return f"{head}\n  {snippet}" if snippet else head
+
+
+def _escape_message(text: str) -> str:
+    # https://docs.github.com/en/actions/reference/workflow-commands-for-github-actions#example-setting-an-error-message
+    return text.replace("%", "%25").replace("\r", "%0D").replace("\n", "%0A")
+
+
+def _escape_property(text: str) -> str:
+    return _escape_message(text).replace(":", "%3A").replace(",", "%2C")
+
+
+def format_workflow_command(finding: dict, repo_root: Path) -> str:
+    file_path = _relative_path(finding.get("file", ""), repo_root)
+    raw_line = finding.get("line")
+    line = raw_line if isinstance(raw_line, int) and raw_line > 0 else 1
+    antipattern = finding.get("antipattern", "impeccable")
+    name = finding.get("name") or antipattern
+    snippet = " ".join((finding.get("snippet") or "").split())
+    message = f"{name}: {snippet}" if snippet else name
+    params = (
+        f"file={_escape_property(file_path)},"
+        f"line={line},"
+        f"title={_escape_property(f'impeccable/{antipattern}')}"
+    )
+    return f"::error {params}::{_escape_message(message)}"
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "paths",
+        nargs="*",
+        help="Paths to scan (default: tracked HTML/CSS/JS files).",
+    )
+    args = parser.parse_args()
+
+    repo_root = Path.cwd().resolve()
+    paths = args.paths or tracked_ui_files()
+    if not paths:
+        print("impeccable: no files to scan", file=sys.stderr)
+        return 0
+
+    filtered = filter_findings(run_detect(paths))
+    in_github_actions = os.environ.get("GITHUB_ACTIONS") == "true"
+
+    for finding in filtered:
+        print(format_finding(finding, repo_root))
+        if in_github_actions:
+            print(format_workflow_command(finding, repo_root))
+
+    if filtered:
+        print(f"\nimpeccable: {len(filtered)} issue(s)", file=sys.stderr)
+        return 1
+    print("impeccable: no issues", file=sys.stderr)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/ludamus/templates/base_tailwind.html
+++ b/src/ludamus/templates/base_tailwind.html
@@ -105,17 +105,11 @@
                 border-right: 2px solid #d97706;
                 border-bottom: 2px solid #d97706;
             }
-
-            /* TEMP: impeccable CI annotation smoke test — reverted in follow-up commit */
-            .ci-impeccable-test {
-                border-left: 4px solid #4a5d7a;
-            }
         </style>
         {% block extra_head %}
         {% endblock extra_head %}
     </head>
     <body class="relative flex flex-col min-h-screen font-sans antialiased bg-background text-foreground">
-        <div class="ci-impeccable-test"></div>
         {% include "components/navbar.html" %}
         <!-- Flash Messages -->
         {% if messages %}

--- a/src/ludamus/templates/base_tailwind.html
+++ b/src/ludamus/templates/base_tailwind.html
@@ -105,11 +105,17 @@
                 border-right: 2px solid #d97706;
                 border-bottom: 2px solid #d97706;
             }
+
+            /* TEMP: impeccable CI annotation smoke test — reverted in follow-up commit */
+            .ci-impeccable-test {
+                border-left: 4px solid #4a5d7a;
+            }
         </style>
         {% block extra_head %}
         {% endblock extra_head %}
     </head>
     <body class="relative flex flex-col min-h-screen font-sans antialiased bg-background text-foreground">
+        <div class="ci-impeccable-test"></div>
         {% include "components/navbar.html" %}
         <!-- Flash Messages -->
         {% if messages %}


### PR DESCRIPTION
## Summary

- Add `scripts/impeccable_lint.py`, a thin wrapper around `npx impeccable detect --json` that:
  - Scans tracked HTML/CSS/JS files by default (via `git ls-files`)
  - Filters out `e2e/playwright-report/`, `tailwind.min.js`, and the `tiny-text` antipattern per project policy
  - Emits GitHub Actions workflow commands (`::error file=...,line=...,title=...::msg`) under `GITHUB_ACTIONS=true` so findings surface inline on the PR "Files changed" tab
  - Exits 1 on any unfiltered finding
- Add `mise run impeccable` task; append to `mise run check`
- Add separate `impeccable` CI job (parallel to `checks` / `test`)
- Pin impeccable to `pbakaus/impeccable@346ce25` (v3 HEAD, merged upstream but not yet published to npm; bump to `impeccable@3.x.x` once available)

## Why a separate job, not `prcheck`?

Own 10-error annotation budget (GitHub's workflow-command cap), own status check, keeps prcheck's Python-only toolchain clean from Node.

## Test plan

- [x] `mise run impeccable` → 0 issues
- [x] CI `impeccable` job is green on this PR
- [x] Annotations appear inline on PR "Files changed" tab when a change introduces a finding on a changed line