### PR TITLE
keep mobile session modal controls clickable

### DIFF
--- a/src/ludamus/gates/web/django/theme/static_src/src/modal.css
+++ b/src/ludamus/gates/web/django/theme/static_src/src/modal.css
@@ -19,6 +19,12 @@
   transform: scale(1) translateY(0);
 }
 
+.modal[open].session-detail-modal {
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
 @starting-style {
   .modal[open] {
     opacity: 0;

--- a/src/ludamus/gates/web/django/theme/static_src/src/modal.css
+++ b/src/ludamus/gates/web/django/theme/static_src/src/modal.css
@@ -15,14 +15,10 @@
 }
 
 .modal[open] {
-  opacity: 1;
-  transform: scale(1) translateY(0);
-}
-
-.modal[open].session-detail-modal {
   display: flex;
   flex-direction: column;
-  overflow: hidden;
+  opacity: 1;
+  transform: scale(1) translateY(0);
 }
 
 @starting-style {

--- a/src/ludamus/templates/chronology/event.html
+++ b/src/ludamus/templates/chronology/event.html
@@ -661,10 +661,10 @@
     <!-- Session Detail Modals -->
     {% for data in sessions %}
         <dialog id="session-{{ data.session.pk }}"
-                class="modal max-w-[800px] w-full bg-transparent h-600 max-h-[90vh]"
+                class="modal session-detail-modal max-w-[800px] w-full bg-transparent h-600 max-h-[90dvh]"
                 aria-labelledby="session-{{ data.session.pk }}-title">
             <!-- Header -->
-            <div class="px-6 py-4 border-b border-border flex items-center justify-between">
+            <div class="px-6 py-4 border-b border-border flex items-center justify-between shrink-0">
                 <h3 id="session-{{ data.session.pk }}-title"
                     class="text-lg font-semibold text-foreground">{{ data.session.title }}</h3>
                 <button data-modal-close="session-{{ data.session.pk }}"
@@ -673,7 +673,7 @@
                 </button>
             </div>
             <!-- Tabs -->
-            <div class="tab-list" role="tablist">
+            <div class="tab-list shrink-0" role="tablist">
                 <button role="tab"
                         aria-selected="true"
                         aria-controls="info-{{ data.session.pk }}"
@@ -693,7 +693,7 @@
                 </button>
             </div>
             <!-- Tab Content -->
-            <div class="tab-content px-6 py-4 flex-1 overflow-y-auto text-foreground">
+            <div class="tab-content px-6 py-4 flex-1 min-h-0 overflow-y-auto text-foreground">
                 <!-- Information Tab -->
                 <div id="info-{{ data.session.pk }}"
                      role="tabpanel"
@@ -902,7 +902,7 @@
                 </div>
             </div>
             <!-- Footer -->
-            <div class="px-6 py-4 flex justify-end gap-2 border-t border-border">
+            <div class="px-6 py-4 flex justify-end gap-2 border-t border-border shrink-0">
                 <button data-modal-close="session-{{ data.session.pk }}"
                         class="btn btn-secondary text-sm">{% translate "Close" %}</button>
                 {% if data.is_enrollment_available %}

--- a/src/ludamus/templates/chronology/event.html
+++ b/src/ludamus/templates/chronology/event.html
@@ -661,7 +661,7 @@
     <!-- Session Detail Modals -->
     {% for data in sessions %}
         <dialog id="session-{{ data.session.pk }}"
-                class="modal session-detail-modal max-w-[800px] w-full bg-transparent h-600 max-h-[90dvh]"
+                class="modal max-w-[800px] w-full bg-transparent h-600 max-h-[90dvh] overflow-hidden"
                 aria-labelledby="session-{{ data.session.pk }}-title">
             <!-- Header -->
             <div class="px-6 py-4 border-b border-border flex items-center justify-between shrink-0">

--- a/tests/e2e/tests/event-details.spec.ts
+++ b/tests/e2e/tests/event-details.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test } from '@playwright/test';
+import { devices, expect, test } from '@playwright/test';
 
 test.describe('Event detail page', () => {
   test.beforeEach(async ({ page }) => {
@@ -33,4 +33,52 @@ test.describe('Event detail page', () => {
     await detailDialog.getByRole('button', { name: 'Close' }).first().click();
     await expect(detailDialog).toBeHidden();
   });
+
+  test(
+    'keeps mobile session modal footer inside the clickable dialog bounds',
+    async ({ browser }) => {
+      const context = await browser.newContext({
+        ...devices['iPhone 14 Pro'],
+        baseURL: process.env.E2E_BASE_URL ?? 'http://localhost:8000',
+      });
+      const page = await context.newPage();
+
+      await page.goto('/chronology/event/autumn-open/');
+      await page
+        .locator('.session-card')
+        .nth(1)
+        .getByRole('link')
+        .click();
+      await page.waitForTimeout(1000);
+
+      const detailDialog = page.getByRole('dialog', {
+        name: 'Cozy Storytellers Circle',
+      });
+      const footerClose = detailDialog.getByRole('button', { name: 'Close' });
+      await expect(footerClose).toBeInViewport();
+
+      const isFooterInsideDialog = await page.evaluate(() => {
+        const dialog = document.querySelector('dialog[open]');
+        const close = dialog?.querySelector('.btn[data-modal-close]');
+        if (!dialog || !close) return false;
+
+        const dialogBox = dialog.getBoundingClientRect();
+        const closeBox = close.getBoundingClientRect();
+        const hit = document.elementFromPoint(
+          closeBox.left + closeBox.width / 2,
+          closeBox.top + closeBox.height / 2,
+        );
+
+        return (
+          closeBox.bottom <= dialogBox.bottom &&
+          (hit === close || close.contains(hit))
+        );
+      });
+      expect(isFooterInsideDialog).toBe(true);
+
+      await footerClose.click();
+      await expect(detailDialog).toBeHidden();
+      await context.close();
+    },
+  );
 });


### PR DESCRIPTION
I need to test this on staging with today's MiM's to be sure.

Fixes the buttons intermittently not working in (content was bigger than the dialog). Slapped a flexbox on it and it works locally and added a test but let's just give it a third pass on staging.