### PR TITLE
Remove pixel math from backend timetable layer

### DIFF
--- a/src/ludamus/gates/web/django/theme/static_src/src/timetable.css
+++ b/src/ludamus/gates/web/django/theme/static_src/src/timetable.css
@@ -1,24 +1,28 @@
+#timetable-calendar {
+  --minute-px: 1px;
+}
+
 .timetable-header-cell {
-  flex: var(--span) 1 0;
-  min-width: calc(9rem * var(--span));
+  flex: var(--columns) 1 0;
+  min-width: calc(9rem * var(--columns));
 }
 
 .timetable-time-axis,
 .timetable-column {
-  height: calc(var(--total-height) + 20px);
+  height: calc(var(--grid-extent) * var(--minute-px) + 20px);
 }
 
 .timetable-time-label,
 .timetable-slot-line {
-  top: calc(var(--top) + 20px);
+  top: calc(var(--offset) * var(--minute-px) + 20px);
 }
 
 .timetable-session {
-  top: calc(var(--top) + 20px);
-  height: var(--height);
-  min-height: var(--height);
-  left: calc(var(--left) + 2px);
-  width: calc(var(--width) - 4px);
+  top: calc(var(--offset) * var(--minute-px) + 20px);
+  height: calc(var(--duration) * var(--minute-px));
+  min-height: 20px;
+  left: calc(var(--lane-start) + 2px);
+  width: calc(var(--lane-width) - 4px);
 }
 
 .timetable-column.assign-mode-active {

--- a/src/ludamus/gates/web/django/theme/static_src/src/timetable.css
+++ b/src/ludamus/gates/web/django/theme/static_src/src/timetable.css
@@ -19,8 +19,8 @@
 
 .timetable-session {
   top: calc(var(--offset) * var(--minute-px) + 20px);
-  height: calc(var(--duration) * var(--minute-px));
-  min-height: 20px;
+  height: max(20px, calc(var(--duration) * var(--minute-px)));
+  min-height: max(20px, calc(var(--duration) * var(--minute-px)));
   left: calc(var(--lane-start) + 2px);
   width: calc(var(--lane-width) - 4px);
 }

--- a/src/ludamus/gates/web/django/theme/static_src/src/timetable.ts
+++ b/src/ludamus/gates/web/django/theme/static_src/src/timetable.ts
@@ -32,6 +32,12 @@ const csrfToken = (): string =>
   (document.querySelector("[name=csrfmiddlewaretoken]") as HTMLInputElement)
     .value;
 
+function pxPerMinute(cal: HTMLElement): number {
+  const raw = getComputedStyle(cal).getPropertyValue("--minute-px").trim();
+  const parsed = parseFloat(raw);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : 1;
+}
+
 function parsePreferredSlots(raw: string | undefined): PreferredSlot[] {
   if (!raw) return [];
   try {
@@ -63,13 +69,13 @@ function renderPreferredSlotOverlays(): void {
   const eventStart = cal.dataset.eventStart;
   if (!eventStart) return;
 
-  const slotMinutes = Number(cal.dataset.slotMinutes);
-  const slotHeight = Number(cal.dataset.slotHeight);
-  const totalHeightPx = Number(cal.dataset.totalHeight);
-  if (!slotMinutes || !slotHeight) return;
+  const totalMinutes = Number(cal.dataset.totalMinutes);
+  if (!totalMinutes) return;
 
   const eventStartMs = new Date(eventStart).getTime();
-  const pxPerMs = slotHeight / (slotMinutes * 60_000);
+  const minutePx = pxPerMinute(cal);
+  const pxPerMs = minutePx / 60_000;
+  const totalHeightPx = totalMinutes * minutePx;
   const cols = columns();
   if (!cols.length) return;
 
@@ -143,11 +149,11 @@ document.addEventListener("click", (e) => {
       const cal = calendar()!;
       const eventStart = cal.dataset.eventStart!;
       const slotMinutes = Number(cal.dataset.slotMinutes);
-      const slotHeight = Number(cal.dataset.slotHeight);
+      const pxPerSlot = slotMinutes * pxPerMinute(cal);
 
       const rect = col.getBoundingClientRect();
       const yOffset = e instanceof MouseEvent ? e.clientY - rect.top : 0;
-      const slotIndex = Math.floor(yOffset / slotHeight);
+      const slotIndex = Math.floor(yOffset / pxPerSlot);
       const offsetMinutes = slotIndex * slotMinutes;
 
       const startDt = new Date(eventStart);

--- a/src/ludamus/mills/chronology.py
+++ b/src/ludamus/mills/chronology.py
@@ -13,7 +13,6 @@ from ludamus.pacts import (
 )
 from ludamus.pacts.chronology import (
     TIMETABLE_ROOM_PAGE_SIZE,
-    TIMETABLE_SLOT_HEIGHT_PX,
     TIMETABLE_SLOT_MINUTES,
     AreaGroupDTO,
     ConflictDTO,
@@ -66,9 +65,9 @@ def _slot_windows_by_local_date(
 
 
 def _position_sessions(
-    items: list[AgendaItemDTO], event_start: datetime, px_per_minute: float
+    items: list[AgendaItemDTO], event_start: datetime
 ) -> list[SessionPositionDTO]:
-    # Compute absolute pixel positions for sessions in a single space column.
+    # Compute time-domain positions for sessions in a single space column.
     # Overlapping sessions are placed side by side by splitting the column width.
     if not items:
         return []
@@ -93,17 +92,17 @@ def _position_sessions(
     positions: list[SessionPositionDTO] = []
     for group in groups:
         n = len(group)
-        width_pct = 100.0 / n
+        lane_width_pct = 100.0 / n
         for i, item in enumerate(group):
             offset_min = (item.start_time - event_start).total_seconds() / 60
             duration_min = (item.end_time - item.start_time).total_seconds() / 60
             positions.append(
                 SessionPositionDTO(
                     agenda_item=item,
-                    top_px=round(offset_min * px_per_minute),
-                    height_px=max(20, round(duration_min * px_per_minute)),
-                    left_pct=i * width_pct,
-                    width_pct=width_pct,
+                    start_minutes=round(offset_min),
+                    duration_minutes=round(duration_min),
+                    lane_start_pct=i * lane_width_pct,
+                    lane_width_pct=lane_width_pct,
                 )
             )
 
@@ -148,10 +147,9 @@ class TimetableService:
                 columns=[SpaceColumnDTO(space=s, sessions=[]) for s in spaces],
                 venue_groups=venue_groups,
                 time_labels=[],
-                total_height_px=0,
+                total_minutes=0,
                 event_start_iso="",
                 slot_minutes=TIMETABLE_SLOT_MINUTES,
-                slot_height_px=TIMETABLE_SLOT_HEIGHT_PX,
                 page=space_page,
                 total_pages=total_pages,
                 total_spaces=total_spaces,
@@ -168,15 +166,14 @@ class TimetableService:
         if latest_end != grid_end:
             grid_end += timedelta(hours=1)
 
-        total_minutes = (grid_end - grid_start).total_seconds() / 60
-        num_slots = int(total_minutes / TIMETABLE_SLOT_MINUTES)
-        total_height_px = num_slots * TIMETABLE_SLOT_HEIGHT_PX
-        px_per_minute = TIMETABLE_SLOT_HEIGHT_PX / TIMETABLE_SLOT_MINUTES
+        total_minutes = int((grid_end - grid_start).total_seconds() / 60)
+        num_slots = total_minutes // TIMETABLE_SLOT_MINUTES
 
         slot_delta = timedelta(minutes=TIMETABLE_SLOT_MINUTES)
         time_labels = [
             TimeLabelDTO(
-                time=grid_start + slot_delta * i, top_px=i * TIMETABLE_SLOT_HEIGHT_PX
+                time=grid_start + slot_delta * i,
+                offset_minutes=i * TIMETABLE_SLOT_MINUTES,
             )
             for i in range(num_slots + 1)
         ]
@@ -204,9 +201,7 @@ class TimetableService:
                 SpaceColumnDTO(
                     space=space,
                     sessions=_position_sessions(
-                        items_for_space,
-                        event_start=grid_start,
-                        px_per_minute=px_per_minute,
+                        items_for_space, event_start=grid_start
                     ),
                 )
             )
@@ -216,10 +211,9 @@ class TimetableService:
             columns=columns,
             venue_groups=venue_groups,
             time_labels=time_labels,
-            total_height_px=total_height_px,
+            total_minutes=num_slots * TIMETABLE_SLOT_MINUTES,
             event_start_iso=grid_start.isoformat(),
             slot_minutes=TIMETABLE_SLOT_MINUTES,
-            slot_height_px=TIMETABLE_SLOT_HEIGHT_PX,
             page=space_page,
             total_pages=total_pages,
             total_spaces=total_spaces,

--- a/src/ludamus/pacts/chronology.py
+++ b/src/ludamus/pacts/chronology.py
@@ -9,20 +9,19 @@ from ludamus.pacts.legacy import AgendaItemDTO, SpaceDTO
 
 TIMETABLE_ROOM_PAGE_SIZE = 5
 TIMETABLE_SLOT_MINUTES = 60
-TIMETABLE_SLOT_HEIGHT_PX = 60  # pixels per TIMETABLE_SLOT_MINUTES block
 
 
 class SessionPositionDTO(BaseModel):
     agenda_item: AgendaItemDTO
-    top_px: int
-    height_px: int
-    left_pct: float = 0.0
-    width_pct: float = 100.0
+    start_minutes: int
+    duration_minutes: int
+    lane_start_pct: float = 0.0
+    lane_width_pct: float = 100.0
 
 
 class TimeLabelDTO(BaseModel):
     time: datetime
-    top_px: int
+    offset_minutes: int
 
 
 class SpaceColumnDTO(BaseModel):
@@ -48,10 +47,9 @@ class TimetableGridDTO(BaseModel):
     columns: list[SpaceColumnDTO]
     venue_groups: list[VenueGroupDTO]
     time_labels: list[TimeLabelDTO]
-    total_height_px: int
+    total_minutes: int
     event_start_iso: str
     slot_minutes: int
-    slot_height_px: int
     page: int
     total_pages: int
     total_spaces: int

--- a/src/ludamus/templates/panel/parts/timetable-grid.html
+++ b/src/ludamus/templates/panel/parts/timetable-grid.html
@@ -40,9 +40,8 @@
          id="timetable-calendar"
          data-event-start="{{ grid.event_start_iso }}"
          data-slot-minutes="{{ grid.slot_minutes }}"
-         data-slot-height="{{ grid.slot_height_px }}"
-         data-total-height="{{ grid.total_height_px }}"
-         style="--total-height: {{ grid.total_height_px }}px">
+         data-total-minutes="{{ grid.total_minutes }}"
+         style="--grid-extent: {{ grid.total_minutes }}">
         <!-- Space headers (sticky, three rows: venue / area / space) -->
         <div class="sticky top-0 z-20 border-b border-neutral-700">
             <!-- Venue row -->
@@ -50,7 +49,7 @@
                 <div class="w-16 flex-none shrink-0 bg-neutral-900"></div>
                 {% for venue in grid.venue_groups %}
                     <div class="timetable-header-cell px-3 py-1 border-l border-neutral-700 text-center bg-neutral-900"
-                         style="--span: {{ venue.span }}">
+                         style="--columns: {{ venue.span }}">
                         <div class="text-xs font-semibold text-white uppercase tracking-wide">{{ venue.venue_name }}</div>
                     </div>
                 {% endfor %}
@@ -61,7 +60,7 @@
                 {% for venue in grid.venue_groups %}
                     {% for area in venue.areas %}
                         <div class="timetable-header-cell px-3 py-1 border-l border-neutral-700 text-center bg-neutral-800"
-                             style="--span: {{ area.span }}">
+                             style="--columns: {{ area.span }}">
                             <div class="text-xs font-medium text-white">{{ area.area_name }}</div>
                         </div>
                     {% endfor %}
@@ -84,7 +83,7 @@
             <div class="timetable-time-axis w-16 flex-none relative shrink-0 border-r border-border">
                 {% for label in grid.time_labels %}
                     <div class="timetable-time-label absolute left-0 right-0 flex items-center justify-end -translate-y-1/2"
-                         style="--top: {{ label.top_px }}px">
+                         style="--offset: {{ label.offset_minutes }}">
                         <span class="text-xs text-neutral-400 font-mono pr-2 leading-none">{{ label.time|time:"H:i" }}</span>
                     </div>
                 {% endfor %}
@@ -96,17 +95,17 @@
                     <!-- Slot grid lines -->
                     {% for label in grid.time_labels %}
                         <div class="timetable-slot-line absolute left-0 right-0 border-t border-border"
-                             style="--top: {{ label.top_px }}px"></div>
+                             style="--offset: {{ label.offset_minutes }}"></div>
                     {% endfor %}
                     <!-- Sessions -->
                     {% for pos in col.sessions %}
                         <div class="timetable-session absolute rounded-md overflow-hidden cursor-pointer border text-xs opacity-85 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary {% if pos.agenda_item.session_id in conflict_session_pks %} bg-danger-bg border-danger hover:opacity-100 {% elif pos.agenda_item.session_id in slot_violation_session_pks %} bg-warning-bg border-warning hover:opacity-100 {% else %} bg-info-bg border-info hover:opacity-100 {% endif %}"
                              tabindex="0"
                              title="{{ pos.agenda_item.session_title }}"
-                             style="--top: {{ pos.top_px }}px;
-                                    --height: {{ pos.height_px }}px;
-                                    --left: {{ pos.left_pct }}%;
-                                    --width: {{ pos.width_pct }}%"
+                             style="--offset: {{ pos.start_minutes }};
+                                    --duration: {{ pos.duration_minutes }};
+                                    --lane-start: {{ pos.lane_start_pct }}%;
+                                    --lane-width: {{ pos.lane_width_pct }}%"
                              hx-get="{% url 'panel:timetable-session-detail-part' slug=slug pk=pos.agenda_item.session_id %}?track={{ filter_track_pk|default:'' }}"
                              hx-target="#left-pane"
                              hx-swap="outerHTML">
@@ -119,10 +118,10 @@
                                     {% endif %}
                                     {{ pos.agenda_item.session_title|truncatechars:256 }}
                                 </div>
-                                <div class="timetable-session-meta wrap-anywhere {% if pos.agenda_item.session_id in conflict_session_pks %}text-danger{% elif pos.agenda_item.session_id in slot_violation_session_pks %}text-warning{% else %}text-info{% endif %} {% if pos.height_px <= 32 %}hidden{% endif %}">
+                                <div class="timetable-session-meta timetable-session-presenter wrap-anywhere {% if pos.agenda_item.session_id in conflict_session_pks %}text-danger{% elif pos.agenda_item.session_id in slot_violation_session_pks %}text-warning{% else %}text-info{% endif %} {% if pos.duration_minutes <= 32 %}hidden{% endif %}">
                                     {{ pos.agenda_item.presenter_name }}
                                 </div>
-                                <div class="timetable-session-meta {% if pos.agenda_item.session_id in conflict_session_pks %}text-danger{% elif pos.agenda_item.session_id in slot_violation_session_pks %}text-warning{% else %}text-info{% endif %} {% if pos.height_px <= 52 %}hidden{% endif %}">
+                                <div class="timetable-session-meta timetable-session-duration {% if pos.agenda_item.session_id in conflict_session_pks %}text-danger{% elif pos.agenda_item.session_id in slot_violation_session_pks %}text-warning{% else %}text-info{% endif %} {% if pos.duration_minutes <= 52 %}hidden{% endif %}">
                                     {{ pos.agenda_item.session_duration_minutes }} min
                                 </div>
                             </div>

--- a/tests/integration/web/panel/test_timetable.py
+++ b/tests/integration/web/panel/test_timetable.py
@@ -7,11 +7,7 @@ from django.urls import reverse
 
 from ludamus.adapters.db.django.models import Track
 from ludamus.pacts import EventDTO
-from ludamus.pacts.chronology import (
-    TIMETABLE_SLOT_HEIGHT_PX,
-    TIMETABLE_SLOT_MINUTES,
-    TimetableGridDTO,
-)
+from ludamus.pacts.chronology import TIMETABLE_SLOT_MINUTES, TimetableGridDTO
 from tests.integration.conftest import (
     AgendaItemFactory,
     SessionFactory,
@@ -29,10 +25,9 @@ def _empty_grid():
         columns=[],
         venue_groups=[],
         time_labels=[],
-        total_height_px=0,
+        total_minutes=0,
         event_start_iso="",
         slot_minutes=TIMETABLE_SLOT_MINUTES,
-        slot_height_px=TIMETABLE_SLOT_HEIGHT_PX,
         page=1,
         total_pages=1,
         total_spaces=0,

--- a/tests/integration/web/panel/test_timetable_assign.py
+++ b/tests/integration/web/panel/test_timetable_assign.py
@@ -4,11 +4,7 @@ from http import HTTPStatus
 from django.contrib import messages
 from django.urls import reverse
 
-from ludamus.pacts.chronology import (
-    TIMETABLE_SLOT_HEIGHT_PX,
-    TIMETABLE_SLOT_MINUTES,
-    TimetableGridDTO,
-)
+from ludamus.pacts.chronology import TIMETABLE_SLOT_MINUTES, TimetableGridDTO
 from tests.integration.conftest import AgendaItemFactory, SessionFactory, SpaceFactory
 from tests.integration.utils import assert_response
 
@@ -21,10 +17,9 @@ def _empty_grid():
         columns=[],
         venue_groups=[],
         time_labels=[],
-        total_height_px=0,
+        total_minutes=0,
         event_start_iso="",
         slot_minutes=TIMETABLE_SLOT_MINUTES,
-        slot_height_px=TIMETABLE_SLOT_HEIGHT_PX,
         page=1,
         total_pages=1,
         total_spaces=0,

--- a/tests/unit/test_chronology_mills.py
+++ b/tests/unit/test_chronology_mills.py
@@ -108,10 +108,10 @@ class TestBuildGridOverlappingSessions:
         expected_count = 2
         expected_half_width = 50.0
         assert len(sessions) == expected_count
-        assert sessions[0].width_pct == pytest.approx(expected_half_width)
-        assert sessions[1].width_pct == pytest.approx(expected_half_width)
-        assert sessions[0].left_pct == pytest.approx(0.0)
-        assert sessions[1].left_pct == pytest.approx(expected_half_width)
+        assert sessions[0].lane_width_pct == pytest.approx(expected_half_width)
+        assert sessions[1].lane_width_pct == pytest.approx(expected_half_width)
+        assert sessions[0].lane_start_pct == pytest.approx(0.0)
+        assert sessions[1].lane_start_pct == pytest.approx(expected_half_width)
 
 
 class TestRevertChange:


### PR DESCRIPTION
The mill was multiplying minutes by a hard-coded pixel scale (TIMETABLE_SLOT_HEIGHT_PX) and emitting top_px / height_px / total_height_px / slot_height_px on its DTOs. The template piped those straight into calc() expressions in inline styles, and the JS read the same px values from data attributes. Pixels are a presentation concern; they have no place in pacts or mills.

DTO fields now carry domain values: SessionPositionDTO.start_minutes / duration_minutes / lane_start_pct / lane_width_pct, TimeLabelDTO.offset_minutes, TimetableGridDTO.total_minutes. The TIMETABLE_SLOT_HEIGHT_PX constant is gone, the 20px session-floor ("don't render shorter than this or it becomes unreadable") moved into .timetable-session { min-height: 20px }, and the minute-to-pixel scale lives on a single CSS variable: #timetable-calendar { --minute-px: 1px }.

The template now passes only domain values via custom properties (no "px" suffix in the values, no calc() in style attributes), and CSS multiplies by var(--minute-px) wherever needed. The TS reads --minute-px via getComputedStyle through a pxPerMinute() helper, replacing the data-slot-height / data-total-height attributes (data-total-minutes remains so JS can still bound preferred-slot overlays).