### PR TITLE
solve the validator warn and improve encounter form

### DIFF
--- a/src/ludamus/client/src/encounter-form.ts
+++ b/src/ludamus/client/src/encounter-form.ts
@@ -1,0 +1,24 @@
+const start = document.getElementById(
+  "id_start_time",
+) as HTMLInputElement | null;
+const end = document.getElementById(
+  "id_end_time",
+) as HTMLInputElement | null;
+
+const DEFAULT_DURATION_HOURS = 3;
+
+const pad = (n: number): string => String(n).padStart(2, "0");
+
+const toLocalDatetimeValue = (d: Date): string =>
+  `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}` +
+  `T${pad(d.getHours())}:${pad(d.getMinutes())}`;
+
+if (start && end) {
+  start.addEventListener("change", () => {
+    if (end.value || !start.value) return;
+    const d = new Date(start.value);
+    if (Number.isNaN(d.getTime())) return;
+    d.setHours(d.getHours() + DEFAULT_DURATION_HOURS);
+    end.value = toLocalDatetimeValue(d);
+  });
+}

--- a/src/ludamus/client/vite.config.ts
+++ b/src/ludamus/client/vite.config.ts
@@ -36,6 +36,7 @@ export default defineConfig({
     rollupOptions: {
       input: {
         index: resolve(__dirname, "src/index.css"),
+        "encounter-form": resolve(__dirname, "src/encounter-form.ts"),
         modal: resolve(__dirname, "src/modal.ts"),
         tabs: resolve(__dirname, "src/tabs.ts"),
         timetable: resolve(__dirname, "src/timetable.ts"),

--- a/src/ludamus/templates/base.html
+++ b/src/ludamus/templates/base.html
@@ -85,10 +85,8 @@
             <!-- Page Header -->
             {% block header_section %}
                 <div class="mb-6 text-center">
-                    <h1 class="text-2xl sm:text-3xl font-bold text-foreground mb-2">
-                        {% block header %}
-                        {% endblock header %}
-                    </h1>
+                    {% block header %}
+                    {% endblock header %}
                     {% block description %}
                         <p class="mt-2 text-sm sm:text-base text-foreground-muted">
                             {% block description_text %}

--- a/src/ludamus/templates/chronology/accept_proposal.html
+++ b/src/ludamus/templates/chronology/accept_proposal.html
@@ -6,7 +6,7 @@
     {% translate "Accept Proposal" %} - {{ session.title }}
 {% endblock title %}
 {% block header %}
-    {% translate "Accept Proposal" %}
+    <h1 class="text-2xl sm:text-3xl font-bold text-foreground mb-2">{% translate "Accept Proposal" %}</h1>
 {% endblock header %}
 {% block description %}
     {% translate "Select space and time slot for" %} {{ session.title }}

--- a/src/ludamus/templates/chronology/anonymous_enroll.html
+++ b/src/ludamus/templates/chronology/anonymous_enroll.html
@@ -5,7 +5,7 @@
     {% translate "Anonymous Enrollment" %} - {{ session.title }}
 {% endblock title %}
 {% block header %}
-    {% translate "Anonymous Enrollment" %}
+    <h1 class="text-2xl sm:text-3xl font-bold text-foreground mb-2">{% translate "Anonymous Enrollment" %}</h1>
 {% endblock header %}
 {% block description %}
     {% translate "Enroll anonymously in" %} {{ session.title }}

--- a/src/ludamus/templates/chronology/anonymous_manage.html
+++ b/src/ludamus/templates/chronology/anonymous_manage.html
@@ -5,7 +5,7 @@
     {% translate "Manage Anonymous Enrollment" %}
 {% endblock title %}
 {% block header %}
-    {% translate "Manage Anonymous Enrollment" %}
+    <h1 class="text-2xl sm:text-3xl font-bold text-foreground mb-2">{% translate "Manage Anonymous Enrollment" %}</h1>
 {% endblock header %}
 {% block description %}
     {% translate "Enter your code to view and manage your enrollments" %}

--- a/src/ludamus/templates/chronology/enroll_select.html
+++ b/src/ludamus/templates/chronology/enroll_select.html
@@ -5,7 +5,7 @@
     {% translate "Enroll in Session" %} - {{ session.title }}
 {% endblock title %}
 {% block header %}
-    {% translate "Enroll in Session" %}
+    <h1 class="text-2xl sm:text-3xl font-bold text-foreground mb-2">{% translate "Enroll in Session" %}</h1>
 {% endblock header %}
 {% block description %}
     {% translate "Select who to enroll in" %} {{ session.title }}

--- a/src/ludamus/templates/chronology/propose/base.html
+++ b/src/ludamus/templates/chronology/propose/base.html
@@ -5,7 +5,7 @@
     {% translate "Propose Session" %}
 {% endblock title %}
 {% block header %}
-    {% translate "Propose Session" %}
+    <h1 class="text-2xl sm:text-3xl font-bold text-foreground mb-2">{% translate "Propose Session" %}</h1>
 {% endblock header %}
 {% block description %}
     {% translate "Submit a session proposal for" %} {{ event.name }}

--- a/src/ludamus/templates/design.html
+++ b/src/ludamus/templates/design.html
@@ -6,7 +6,7 @@
     {% translate "Design" %}
 {% endblock title %}
 {% block header %}
-    {% translate "Design system" %}
+    <h1 class="text-2xl sm:text-3xl font-bold text-foreground mb-2">{% translate "Design system" %}</h1>
 {% endblock header %}
 {% block description %}
     {% translate "UI components without application logic." %}

--- a/src/ludamus/templates/flatpages/default.html
+++ b/src/ludamus/templates/flatpages/default.html
@@ -5,7 +5,7 @@
     {{ flatpage.title }}
 {% endblock title %}
 {% block header %}
-    {{ flatpage.title }}
+    <h1 class="text-2xl sm:text-3xl font-bold text-foreground mb-2">{{ flatpage.title }}</h1>
 {% endblock header %}
 {% block description %}
 {% endblock description %}

--- a/src/ludamus/templates/notice_board/_form.html
+++ b/src/ludamus/templates/notice_board/_form.html
@@ -1,4 +1,4 @@
-{% load i18n tessera %}
+{% load i18n tessera django_vite %}
 {% tessera_field form.title %}
 {% tessera_field form.description %}
 <div class="md:grid md:grid-cols-2 md:gap-x-4">
@@ -9,3 +9,4 @@
     {% tessera_field form.max_participants %}
     {% tessera_field form.header_image %}
 </div>
+{% vite_asset 'src/encounter-form.ts' %}

--- a/src/ludamus/templates/notice_board/_form.html
+++ b/src/ludamus/templates/notice_board/_form.html
@@ -1,2 +1,11 @@
 {% load i18n tessera %}
-{% tessera_form form %}
+{% tessera_field form.title %}
+{% tessera_field form.description %}
+<div class="md:grid md:grid-cols-2 md:gap-x-4">
+    {% tessera_field form.start_time %}
+    {% tessera_field form.end_time %}
+    {% tessera_field form.game %}
+    {% tessera_field form.place %}
+    {% tessera_field form.max_participants %}
+    {% tessera_field form.header_image %}
+</div>

--- a/src/ludamus/templates/notice_board/create.html
+++ b/src/ludamus/templates/notice_board/create.html
@@ -4,7 +4,7 @@
     {% translate "Create Encounter" %}
 {% endblock title %}
 {% block header %}
-    {% translate "Create Encounter" %}
+    <h1 class="text-2xl sm:text-3xl font-bold text-foreground mb-2">{% translate "Create Encounter" %}</h1>
 {% endblock header %}
 {% block body %}
     <div class="max-w-2xl mx-auto">

--- a/src/ludamus/templates/notice_board/create.html
+++ b/src/ludamus/templates/notice_board/create.html
@@ -7,7 +7,7 @@
     <h1 class="text-2xl sm:text-3xl font-bold text-foreground mb-2">{% translate "Create Encounter" %}</h1>
 {% endblock header %}
 {% block body %}
-    <div class="max-w-2xl mx-auto">
+    <div class="max-w-3xl mx-auto">
         <div class="card">
             <div class="card-body">
                 <form method="post" enctype="multipart/form-data">

--- a/src/ludamus/templates/notice_board/edit.html
+++ b/src/ludamus/templates/notice_board/edit.html
@@ -7,7 +7,7 @@
     <h1 class="text-2xl sm:text-3xl font-bold text-foreground mb-2">{% translate "Edit Encounter" %}</h1>
 {% endblock header %}
 {% block body %}
-    <div class="max-w-2xl mx-auto">
+    <div class="max-w-3xl mx-auto">
         <div class="card">
             <div class="card-body">
                 <form method="post" enctype="multipart/form-data">

--- a/src/ludamus/templates/notice_board/edit.html
+++ b/src/ludamus/templates/notice_board/edit.html
@@ -4,7 +4,7 @@
     {% translate "Edit Encounter" %}
 {% endblock title %}
 {% block header %}
-    {% translate "Edit Encounter" %}
+    <h1 class="text-2xl sm:text-3xl font-bold text-foreground mb-2">{% translate "Edit Encounter" %}</h1>
 {% endblock header %}
 {% block body %}
     <div class="max-w-2xl mx-auto">

--- a/src/ludamus/templates/notice_board/index.html
+++ b/src/ludamus/templates/notice_board/index.html
@@ -5,7 +5,7 @@
     {% translate "Encounters" %}
 {% endblock title %}
 {% block header %}
-    {% translate "Encounters" %}
+    <h1 class="text-2xl sm:text-3xl font-bold text-foreground mb-2">{% translate "Encounters" %}</h1>
 {% endblock header %}
 {% block body %}
     <!-- Dismissible info banner -->


### PR DESCRIPTION
- Move encounter detail `<h1>` out of the section to silence W3C heading validator.
- Pair encounter form fields into a 2-col grid at `md+`; widen wrapper to `max-w-3xl`.
- New `encounter-form.ts`: when start time changes and end time is empty, default end to start + 3h.