### PR TITLE
Add file dropzone component

### DIFF
--- a/.claude/skills/tessa/SKILL.md
+++ b/.claude/skills/tessa/SKILL.md
@@ -242,6 +242,8 @@ Established pattern from `index.css`:
 9. **Font consistency** — Outfit is the only font. Don't add other font
    families.
 10. **Use `.gradient-border`** for accent top borders, not custom gradient CSS.
+11. Prefer data- and aria- attributes over Django template conditionals inside
+    `class` when styling depends on state.
 
 ## Review Checklist
 

--- a/.gitignore
+++ b/.gitignore
@@ -176,13 +176,6 @@ cython_debug/
 # Learn more at https://abstra.io/docs
 .abstra/
 
-# Visual Studio Code
-#  Visual Studio Code specific template is maintained in a separate VisualStudioCode.gitignore
-#  that can be found at https://github.com/github/gitignore/blob/main/Global/VisualStudioCode.gitignore
-#  and can be added to the global gitignore or merged into this file. However, if you prefer,
-#  you could uncomment the following to ignore the entire vscode folder
-# .vscode/
-
 # Ruff stuff:
 .ruff_cache/
 
@@ -197,7 +190,6 @@ cython_debug/
 .cursorindexingignore
 
 .DS_Store
-.vscode
 *.sqlite3
 seed_local.py
 src/ludamus/static/icon_cache/

--- a/.vscode/.gitignore
+++ b/.vscode/.gitignore
@@ -1,0 +1,3 @@
+*
+!.gitignore
+!settings.json

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,21 @@
+{
+  "[html]": {
+    "editor.formatOnSave": false
+  },
+  "[django-html]": {
+    "editor.formatOnSave": false
+  },
+  "[htmldjango]": {
+    "editor.formatOnSave": false
+  },
+  "files.associations": {
+    "**/templates/**/*.html": "django-html"
+  },
+  "tailwindCSS.includeLanguages": {
+    "django-html": "html",
+    "htmldjango": "html"
+  },
+  "tailwindCSS.experimental.configFile": "src/ludamus/client/src/index.css",
+  "html.format.enable": false,
+  "prettier.enable": false
+}

--- a/src/ludamus/adapters/web/django/templatetags/tessera/button.py
+++ b/src/ludamus/adapters/web/django/templatetags/tessera/button.py
@@ -35,6 +35,7 @@ def render_button(
     classes = [
         variant_class.get(variant, variant_class["primary"]),
         size_classes.get(size, size_classes["md"]),
+        "max-md:w-full",
     ]
 
     if disabled:

--- a/src/ludamus/adapters/web/django/templatetags/tessera/button.py
+++ b/src/ludamus/adapters/web/django/templatetags/tessera/button.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from django.utils.html import format_html
 
 
-def render_button(  # noqa: PLR0913
+def render_button(
     text: str,
     *,
     button_type: str = "submit",

--- a/src/ludamus/adapters/web/django/templatetags/tessera/button.py
+++ b/src/ludamus/adapters/web/django/templatetags/tessera/button.py
@@ -11,7 +11,6 @@ def render_button(  # noqa: PLR0913
     button_type: str = "submit",
     variant: str = "primary",
     size: str = "md",
-    full_width: bool = False,
     disabled: bool = False,
 ) -> str:
     """Render a styled button.
@@ -37,9 +36,6 @@ def render_button(  # noqa: PLR0913
         variant_class.get(variant, variant_class["primary"]),
         size_classes.get(size, size_classes["md"]),
     ]
-
-    if full_width:
-        classes.append("w-full")
 
     if disabled:
         classes.append("opacity-50 cursor-not-allowed")

--- a/src/ludamus/adapters/web/django/templatetags/tessera/errors.py
+++ b/src/ludamus/adapters/web/django/templatetags/tessera/errors.py
@@ -33,7 +33,7 @@ def render_help_text(field: BoundField) -> str:
     Returns:
         HTML string of the help text, or empty string if none.
     """
-    if not field.help_text:
+    if not field.help_text or field.errors:
         return ""
 
     return format_html(

--- a/src/ludamus/adapters/web/django/templatetags/tessera/file_input.py
+++ b/src/ludamus/adapters/web/django/templatetags/tessera/file_input.py
@@ -23,6 +23,8 @@ def render_file_input(field: BoundField) -> str:
     )
     initial = field.value()
     initial_url = getattr(initial, "url", None) if initial else None
+    is_image_field = isinstance(field.field, ImageField)
+    dropzone_state = ("image" if is_image_field else "file") if initial_url else "empty"
     return render_to_string(
         "components/file-dropzone.html",
         {
@@ -30,9 +32,9 @@ def render_file_input(field: BoundField) -> str:
             "id": field.id_for_label,
             "required": field.field.required,
             "accept": accept,
-            "is_image": isinstance(field.field, ImageField),
             "has_errors": bool(field.errors),
             "initial_url": initial_url,
             "initial_name": str(initial) if initial_url else "",
+            "dropzone_state": dropzone_state,
         },
     )

--- a/src/ludamus/adapters/web/django/templatetags/tessera/file_input.py
+++ b/src/ludamus/adapters/web/django/templatetags/tessera/file_input.py
@@ -1,0 +1,38 @@
+"""File input (dropzone) renderer."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from django.forms import ImageField
+from django.template.loader import render_to_string
+
+if TYPE_CHECKING:
+    from django.forms import BoundField
+
+
+def render_file_input(field: BoundField) -> str:
+    """Render a styled drag-and-drop file input.
+
+    Returns:
+        HTML string of the dropzone element.
+    """
+    attrs = field.field.widget.attrs
+    accept = attrs.get("accept") or (
+        "image/*" if isinstance(field.field, ImageField) else ""
+    )
+    initial = field.value()
+    initial_url = getattr(initial, "url", None) if initial else None
+    return render_to_string(
+        "components/file-dropzone.html",
+        {
+            "name": field.html_name,
+            "id": field.id_for_label,
+            "required": field.field.required,
+            "accept": accept,
+            "is_image": isinstance(field.field, ImageField),
+            "has_errors": bool(field.errors),
+            "initial_url": initial_url,
+            "initial_name": str(initial) if initial_url else "",
+        },
+    )

--- a/src/ludamus/adapters/web/django/templatetags/tessera/form.py
+++ b/src/ludamus/adapters/web/django/templatetags/tessera/form.py
@@ -7,6 +7,7 @@ from typing import TYPE_CHECKING
 from django.forms.widgets import (
     CheckboxInput,
     CheckboxSelectMultiple,
+    FileInput,
     RadioSelect,
     Select,
     SelectMultiple,
@@ -18,6 +19,7 @@ from ._registry import register
 from .button import render_button
 from .checkbox import render_checkbox_field, render_multi_choice_field
 from .errors import render_errors, render_form_errors, render_help_text
+from .file_input import render_file_input
 from .form_select import render_select
 from .input import render_input
 from .label import render_label
@@ -59,6 +61,7 @@ def tessera_field(field: BoundField, *, layout: str = "vertical") -> str:
     is_radio = isinstance(widget, RadioSelect)
     is_select = isinstance(widget, (Select, SelectMultiple))
     is_textarea = isinstance(widget, Textarea)
+    is_file = isinstance(widget, FileInput)
 
     parts = []
 
@@ -80,6 +83,8 @@ def tessera_field(field: BoundField, *, layout: str = "vertical") -> str:
             parts.append(render_select(field))
         elif is_textarea:
             parts.append(render_textarea(field))
+        elif is_file:
+            parts.append(render_file_input(field))
         else:
             parts.append(render_input(field))
 

--- a/src/ludamus/adapters/web/django/templatetags/tessera/form.py
+++ b/src/ludamus/adapters/web/django/templatetags/tessera/form.py
@@ -65,7 +65,12 @@ def tessera_field(field: BoundField, *, layout: str = "vertical") -> str:
 
     parts = []
 
-    container_class = "mb-4" if layout == "vertical" else "mb-4 sm:flex sm:items-start"
+    container_class = "flex not-last:mb-4"
+    if layout == "vertical":
+        container_class += " flex-col"
+    else:
+        container_class += " max-sm:flex-col"
+
     parts.append(f'<div class="{container_class}">')
 
     if is_checkbox and not is_multi_checkbox:

--- a/src/ludamus/adapters/web/django/templatetags/tessera/form.py
+++ b/src/ludamus/adapters/web/django/templatetags/tessera/form.py
@@ -117,7 +117,7 @@ def tessera_errors(form: BaseForm) -> str:
 
 
 @register.simple_tag
-def tessera_button(  # noqa: PLR0913
+def tessera_button(
     text: str,
     *,
     button_type: str = "submit",
@@ -135,9 +135,5 @@ def tessera_button(  # noqa: PLR0913
         {% tessera_button "Cancel" button_type="button" variant="secondary" %}
     """
     return render_button(
-        text,
-        button_type=button_type,
-        variant=variant,
-        size=size,
-        disabled=disabled,
+        text, button_type=button_type, variant=variant, size=size, disabled=disabled
     )

--- a/src/ludamus/adapters/web/django/templatetags/tessera/form.py
+++ b/src/ludamus/adapters/web/django/templatetags/tessera/form.py
@@ -123,7 +123,6 @@ def tessera_button(  # noqa: PLR0913
     button_type: str = "submit",
     variant: str = "primary",
     size: str = "md",
-    full_width: bool = False,
     disabled: bool = False,
 ) -> str:
     """Render a styled button.
@@ -140,6 +139,5 @@ def tessera_button(  # noqa: PLR0913
         button_type=button_type,
         variant=variant,
         size=size,
-        full_width=full_width,
         disabled=disabled,
     )

--- a/src/ludamus/client/src/encounter-form.ts
+++ b/src/ludamus/client/src/encounter-form.ts
@@ -22,3 +22,90 @@ if (start && end) {
     end.value = toLocalDatetimeValue(d);
   });
 }
+
+const formatBytes = (bytes: number): string => {
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+};
+
+const initDropzone = (label: HTMLLabelElement): void => {
+  const input = label.querySelector<HTMLInputElement>("[data-dropzone-input]");
+  const empty = label.querySelector<HTMLElement>("[data-dropzone-empty]");
+  const selected = label.querySelector<HTMLElement>("[data-dropzone-selected]");
+  const nameEl = label.querySelector<HTMLElement>("[data-dropzone-name]");
+  const sizeEl = label.querySelector<HTMLElement>("[data-dropzone-size]");
+  const preview = label.querySelector<HTMLImageElement>(
+    "[data-dropzone-preview]",
+  );
+  const clearBtn = label.querySelector<HTMLButtonElement>(
+    "[data-dropzone-clear]",
+  );
+  if (!input || !empty || !selected || !nameEl || !sizeEl || !clearBtn) return;
+
+  let previewUrl: string | null = null;
+  const revokePreview = (): void => {
+    if (previewUrl) {
+      URL.revokeObjectURL(previewUrl);
+      previewUrl = null;
+    }
+  };
+
+  const showFile = (file: File): void => {
+    nameEl.textContent = file.name;
+    sizeEl.textContent = formatBytes(file.size);
+    if (preview && file.type.startsWith("image/")) {
+      revokePreview();
+      previewUrl = URL.createObjectURL(file);
+      preview.src = previewUrl;
+    }
+    empty.classList.add("hidden");
+    selected.classList.remove("hidden");
+  };
+
+  const showEmpty = (): void => {
+    revokePreview();
+    selected.classList.add("hidden");
+    empty.classList.remove("hidden");
+  };
+
+  input.addEventListener("change", () => {
+    const file = input.files?.[0];
+    if (file) showFile(file);
+    else showEmpty();
+  });
+
+  clearBtn.addEventListener("click", (e) => {
+    e.preventDefault();
+    e.stopPropagation();
+    input.value = "";
+    showEmpty();
+  });
+
+  const setDragover = (on: boolean): void => {
+    label.classList.toggle("border-primary", on);
+    label.classList.toggle("bg-primary-light", on);
+  };
+
+  label.addEventListener("dragover", (e) => {
+    e.preventDefault();
+    setDragover(true);
+  });
+  label.addEventListener("dragleave", (e) => {
+    if (e.target === label) setDragover(false);
+  });
+  label.addEventListener("drop", (e) => {
+    e.preventDefault();
+    setDragover(false);
+    const file = e.dataTransfer?.files?.[0];
+    if (!file) return;
+    const dt = new DataTransfer();
+    dt.items.add(file);
+    input.files = dt.files;
+    input.dispatchEvent(new Event("change", { bubbles: true }));
+  });
+};
+
+document
+  .querySelectorAll<HTMLLabelElement>("[data-dropzone]")
+  .forEach(initDropzone);

--- a/src/ludamus/client/src/encounter-form.ts
+++ b/src/ludamus/client/src/encounter-form.ts
@@ -29,15 +29,6 @@ const formatBytes = (bytes: number): string => {
   return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
 };
 
-type DropzoneState = "empty" | "image" | "file";
-
-const setDropzoneState = (
-  label: HTMLLabelElement,
-  state: DropzoneState,
-): void => {
-  label.dataset.state = state;
-};
-
 const initDropzone = (label: HTMLLabelElement): void => {
   const input = label.querySelector<HTMLInputElement>("[data-dropzone-input]");
   const nameEls = label.querySelectorAll<HTMLElement>("[data-dropzone-name]");
@@ -63,7 +54,7 @@ const initDropzone = (label: HTMLLabelElement): void => {
     if (!file) {
       revokePreview();
       if (preview) preview.removeAttribute("src");
-      setDropzoneState(label, "empty");
+      label.dataset.state = "empty";
       return;
     }
     nameEls.forEach((el) => {
@@ -79,11 +70,11 @@ const initDropzone = (label: HTMLLabelElement): void => {
       revokePreview();
       previewUrl = URL.createObjectURL(file);
       preview!.src = previewUrl;
-      setDropzoneState(label, "image");
+      label.dataset.state = "image";
     } else {
       revokePreview();
       if (preview) preview.removeAttribute("src");
-      setDropzoneState(label, "file");
+      label.dataset.state = "file";
     }
   });
 

--- a/src/ludamus/client/src/encounter-form.ts
+++ b/src/ludamus/client/src/encounter-form.ts
@@ -51,7 +51,14 @@ const initDropzone = (label: HTMLLabelElement): void => {
     }
   };
 
-  const showFile = (file: File): void => {
+  input.addEventListener("change", () => {
+    const file = input.files?.[0];
+    if (!file) {
+      revokePreview();
+      selected.classList.add("hidden");
+      empty.classList.remove("hidden");
+      return;
+    }
     nameEl.textContent = file.name;
     sizeEl.textContent = formatBytes(file.size);
     if (preview && file.type.startsWith("image/")) {
@@ -61,47 +68,12 @@ const initDropzone = (label: HTMLLabelElement): void => {
     }
     empty.classList.add("hidden");
     selected.classList.remove("hidden");
-  };
-
-  const showEmpty = (): void => {
-    revokePreview();
-    selected.classList.add("hidden");
-    empty.classList.remove("hidden");
-  };
-
-  input.addEventListener("change", () => {
-    const file = input.files?.[0];
-    if (file) showFile(file);
-    else showEmpty();
   });
 
   clearBtn.addEventListener("click", (e) => {
     e.preventDefault();
     e.stopPropagation();
     input.value = "";
-    showEmpty();
-  });
-
-  const setDragover = (on: boolean): void => {
-    label.classList.toggle("border-primary", on);
-    label.classList.toggle("bg-primary-light", on);
-  };
-
-  label.addEventListener("dragover", (e) => {
-    e.preventDefault();
-    setDragover(true);
-  });
-  label.addEventListener("dragleave", (e) => {
-    if (e.target === label) setDragover(false);
-  });
-  label.addEventListener("drop", (e) => {
-    e.preventDefault();
-    setDragover(false);
-    const file = e.dataTransfer?.files?.[0];
-    if (!file) return;
-    const dt = new DataTransfer();
-    dt.items.add(file);
-    input.files = dt.files;
     input.dispatchEvent(new Event("change", { bubbles: true }));
   });
 };

--- a/src/ludamus/client/src/encounter-form.ts
+++ b/src/ludamus/client/src/encounter-form.ts
@@ -29,19 +29,26 @@ const formatBytes = (bytes: number): string => {
   return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
 };
 
+type DropzoneState = "empty" | "image" | "file";
+
+const setDropzoneState = (
+  label: HTMLLabelElement,
+  state: DropzoneState,
+): void => {
+  label.dataset.state = state;
+};
+
 const initDropzone = (label: HTMLLabelElement): void => {
   const input = label.querySelector<HTMLInputElement>("[data-dropzone-input]");
-  const empty = label.querySelector<HTMLElement>("[data-dropzone-empty]");
-  const selected = label.querySelector<HTMLElement>("[data-dropzone-selected]");
-  const nameEl = label.querySelector<HTMLElement>("[data-dropzone-name]");
-  const sizeEl = label.querySelector<HTMLElement>("[data-dropzone-size]");
+  const nameEls = label.querySelectorAll<HTMLElement>("[data-dropzone-name]");
+  const sizeEls = label.querySelectorAll<HTMLElement>("[data-dropzone-size]");
   const preview = label.querySelector<HTMLImageElement>(
     "[data-dropzone-preview]",
   );
-  const clearBtn = label.querySelector<HTMLButtonElement>(
-    "[data-dropzone-clear]",
-  );
-  if (!input || !empty || !selected || !nameEl || !sizeEl || !clearBtn) return;
+  const clearBtns =
+    label.querySelectorAll<HTMLButtonElement>("[data-dropzone-clear]");
+  if (!input || nameEls.length === 0 || sizeEls.length === 0) return;
+  if (clearBtns.length === 0) return;
 
   let previewUrl: string | null = null;
   const revokePreview = (): void => {
@@ -55,26 +62,38 @@ const initDropzone = (label: HTMLLabelElement): void => {
     const file = input.files?.[0];
     if (!file) {
       revokePreview();
-      selected.classList.add("hidden");
-      empty.classList.remove("hidden");
+      if (preview) preview.removeAttribute("src");
+      setDropzoneState(label, "empty");
       return;
     }
-    nameEl.textContent = file.name;
-    sizeEl.textContent = formatBytes(file.size);
-    if (preview && file.type.startsWith("image/")) {
+    nameEls.forEach((el) => {
+      el.textContent = file.name;
+    });
+    sizeEls.forEach((el) => {
+      el.textContent = formatBytes(file.size);
+    });
+    const useImageLayout =
+      Boolean(preview) &&
+      /^image\/(png|jpe?g|gif|webp|avif)$/.test(file.type);
+    if (useImageLayout) {
       revokePreview();
       previewUrl = URL.createObjectURL(file);
-      preview.src = previewUrl;
+      preview!.src = previewUrl;
+      setDropzoneState(label, "image");
+    } else {
+      revokePreview();
+      if (preview) preview.removeAttribute("src");
+      setDropzoneState(label, "file");
     }
-    empty.classList.add("hidden");
-    selected.classList.remove("hidden");
   });
 
-  clearBtn.addEventListener("click", (e) => {
-    e.preventDefault();
-    e.stopPropagation();
-    input.value = "";
-    input.dispatchEvent(new Event("change", { bubbles: true }));
+  clearBtns.forEach((clearBtn) => {
+    clearBtn.addEventListener("click", (e) => {
+      e.preventDefault();
+      e.stopPropagation();
+      input.value = "";
+      input.dispatchEvent(new Event("change", { bubbles: true }));
+    });
   });
 };
 

--- a/src/ludamus/client/src/index.css
+++ b/src/ludamus/client/src/index.css
@@ -389,6 +389,12 @@ a, button {
   transition: all 0.2s;
 }
 
+@media (max-width: 640px) {
+  .btn {
+    width: 100%;
+  }
+}
+
 .btn:focus {
   outline: none;
   box-shadow: 0 0 0 2px var(--theme-primary), 0 0 0 4px var(--color-background);

--- a/src/ludamus/client/src/index.css
+++ b/src/ludamus/client/src/index.css
@@ -389,12 +389,6 @@ a, button {
   transition: all 0.2s;
 }
 
-@media (max-width: 640px) {
-  .btn {
-    width: 100%;
-  }
-}
-
 .btn:focus {
   outline: none;
   box-shadow: 0 0 0 2px var(--theme-primary), 0 0 0 4px var(--color-background);

--- a/src/ludamus/gates/web/django/notice_board/forms.py
+++ b/src/ludamus/gates/web/django/notice_board/forms.py
@@ -34,7 +34,7 @@ class EncounterForm(forms.Form):
     MAX_IMAGE_SIZE = 2 * 1024 * 1024  # 2 MB
 
     header_image = forms.ImageField(
-        label=_lazy("Header image"),
+        label=_lazy("Cover image"),
         required=False,
         help_text=_lazy("Max 2 MB. JPG, PNG, or WebP."),
     )

--- a/src/ludamus/gates/web/django/notice_board/forms.py
+++ b/src/ludamus/gates/web/django/notice_board/forms.py
@@ -26,10 +26,7 @@ class EncounterForm(forms.Form):
     )
     place = forms.CharField(label=_lazy("Place"), max_length=255, required=False)
     max_participants = forms.IntegerField(
-        label=_lazy("Max participants"),
-        min_value=0,
-        initial=0,
-        required=False
+        label=_lazy("Max participants"), min_value=0, initial=0, required=False
     )
     MAX_IMAGE_SIZE = 2 * 1024 * 1024  # 2 MB
 

--- a/src/ludamus/gates/web/django/notice_board/forms.py
+++ b/src/ludamus/gates/web/django/notice_board/forms.py
@@ -29,7 +29,7 @@ class EncounterForm(forms.Form):
         label=_lazy("Max participants"),
         min_value=0,
         initial=0,
-        help_text=_lazy("Enter 0 for no participant limit."),
+        required=False
     )
     MAX_IMAGE_SIZE = 2 * 1024 * 1024  # 2 MB
 

--- a/src/ludamus/locale/pl/LC_MESSAGES/django.po
+++ b/src/ludamus/locale/pl/LC_MESSAGES/django.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-05-01 22:40+0200\n"
+"POT-Creation-Date: 2026-05-03 10:53+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -772,27 +772,22 @@ msgid "time conflict"
 msgstr "konflikt czasowy"
 
 #: src/ludamus/adapters/web/django/views.py:1561
-#, python-brace-format
 msgid "Enrolled: {}"
 msgstr "Zapisani: {}"
 
 #: src/ludamus/adapters/web/django/views.py:1565
-#, python-brace-format
 msgid "Added to waiting list: {}"
 msgstr "Dodani do listy oczekujących: {}"
 
 #: src/ludamus/adapters/web/django/views.py:1567
-#, python-brace-format
 msgid "Cancelled: {}"
 msgstr "Anulowani: {}"
 
 #: src/ludamus/adapters/web/django/views.py:1570
-#, python-brace-format
 msgid "Skipped (already enrolled or conflicts): {}"
 msgstr "Pominięci (już zapisani lub konflikty): {}"
 
 #: src/ludamus/adapters/web/django/views.py:1593
-#, python-brace-format
 msgid ""
 "Not enough spots available. {} spots requested, {} available. Please use "
 "waiting list for some users."
@@ -813,7 +808,6 @@ msgid "You don't have permission to accept proposals for this event."
 msgstr "Nie masz uprawnień do akceptowania propozycji dla tego wydarzenia."
 
 #: src/ludamus/adapters/web/django/views.py:1726
-#, python-brace-format
 msgid "Proposal '{}' has been accepted and added to the agenda."
 msgstr "Zgłoszenie '{}' zostało zaakceptowane i dodane do programu."
 
@@ -1299,7 +1293,6 @@ msgid "Please wait before submitting another proposal."
 msgstr "Poczekaj chwilę przed przesłaniem kolejnego zgłoszenia."
 
 #: src/ludamus/gates/web/django/chronology/views.py:696
-#, python-brace-format
 msgid "Session proposal '{}' submitted successfully!"
 msgstr "Zgłoszenie punktu programu '{}' zostało pomyślnie przesłane!"
 
@@ -1772,15 +1765,15 @@ msgstr "Wróć"
 msgid "Go to Home"
 msgstr "Przejdź do strony głównej"
 
-#: src/ludamus/templates/base.html:116
+#: src/ludamus/templates/base.html:115
 msgid "Contact"
 msgstr "Kontakt"
 
-#: src/ludamus/templates/base.html:118
+#: src/ludamus/templates/base.html:117
 msgid "Privacy Policy"
 msgstr "Polityka prywatności"
 
-#: src/ludamus/templates/base.html:120
+#: src/ludamus/templates/base.html:119
 msgid "Terms of Service"
 msgstr "Regulamin"
 
@@ -2082,7 +2075,7 @@ msgid "Waiting"
 msgstr "Oczekuję"
 
 #: src/ludamus/templates/chronology/anonymous_manage.html:86
-#: src/ludamus/templates/panel/base.html:59
+#: src/ludamus/templates/panel/base.html:60
 #: src/ludamus/templates/panel/venue-copy.html:44
 msgid "Event"
 msgstr "Wydarzenie"
@@ -2171,7 +2164,7 @@ msgstr "Dołącz do listy oczekujących"
 #: src/ludamus/templates/panel/space-edit.html:19
 #: src/ludamus/templates/panel/time-slot-create.html:20
 #: src/ludamus/templates/panel/time-slot-edit.html:20
-#: src/ludamus/templates/panel/timetable.html:20
+#: src/ludamus/templates/panel/timetable.html:21
 #: src/ludamus/templates/panel/track-create.html:19
 #: src/ludamus/templates/panel/track-edit.html:19
 #: src/ludamus/templates/panel/venue-copy.html:17
@@ -2237,7 +2230,7 @@ msgid "Completed"
 msgstr "Ukończone"
 
 #: src/ludamus/templates/chronology/event.html:53
-#: src/ludamus/templates/panel/base.html:180
+#: src/ludamus/templates/panel/base.html:181
 #: src/ludamus/templates/panel/proposal-settings.html:63
 msgid "Proposals Open"
 msgstr "Zgłoszenia otwarte"
@@ -2580,7 +2573,7 @@ msgid "Information"
 msgstr "Informacje"
 
 #: src/ludamus/templates/chronology/event.html:726
-#: src/ludamus/templates/notice_board/detail.html:209
+#: src/ludamus/templates/notice_board/detail.html:206
 msgid "Show Discord"
 msgstr "Pokaż Discord"
 
@@ -2728,7 +2721,7 @@ msgstr ""
 "widoczne tylko dla organizatorów."
 
 #: src/ludamus/templates/chronology/propose/parts/details.html:119
-#: src/ludamus/templates/panel/base.html:110
+#: src/ludamus/templates/panel/base.html:111
 #: src/ludamus/templates/panel/track-create.html:12
 #: src/ludamus/templates/panel/track-edit.html:12
 #: src/ludamus/templates/panel/tracks.html:5
@@ -2827,7 +2820,7 @@ msgstr "Organizujesz"
 
 #: src/ludamus/templates/components/encounter_card.html:39
 #: src/ludamus/templates/notice_board/_organizer_summary.html:13
-#: src/ludamus/templates/notice_board/detail.html:131
+#: src/ludamus/templates/notice_board/detail.html:128
 msgid "attending"
 msgstr "uczestników"
 
@@ -2875,6 +2868,18 @@ msgstr[3] ""
 "                        %(counter)s punktów programu\n"
 "                    "
 
+#: src/ludamus/templates/components/file-dropzone.html:20
+msgid "Click to upload"
+msgstr "Kliknij, aby przesłać"
+
+#: src/ludamus/templates/components/file-dropzone.html:21
+msgid "or drag and drop"
+msgstr "lub przeciągnij i upuść"
+
+#: src/ludamus/templates/components/file-dropzone.html:47
+msgid "Remove file"
+msgstr "Usuń plik"
+
 # Login Required Page
 #: src/ludamus/templates/components/label.html:8
 #: src/ludamus/templates/panel/personal-data-fields.html:100
@@ -2882,27 +2887,27 @@ msgstr[3] ""
 msgid "required"
 msgstr "wymagane"
 
-#: src/ludamus/templates/components/navbar.html:27
+#: src/ludamus/templates/components/navbar.html:29
 #: src/ludamus/templates/index.html:5
 msgid "Events"
 msgstr "Wydarzenia"
 
-#: src/ludamus/templates/components/navbar.html:33
+#: src/ludamus/templates/components/navbar.html:37
 #: src/ludamus/templates/notice_board/index.html:5
 #: src/ludamus/templates/notice_board/index.html:8
 msgid "Encounters"
 msgstr "Spotkania"
 
-#: src/ludamus/templates/components/navbar.html:64
+#: src/ludamus/templates/components/navbar.html:68
 msgid "Panel"
 msgstr "Panel"
 
-#: src/ludamus/templates/components/navbar.html:70
+#: src/ludamus/templates/components/navbar.html:74
 #: src/ludamus/templates/crowd/user/edit.html:4
 msgid "Edit profile"
 msgstr "Edycja profilu"
 
-#: src/ludamus/templates/components/navbar.html:75
+#: src/ludamus/templates/components/navbar.html:79
 msgid "Log out"
 msgstr "Wyloguj się"
 
@@ -3364,7 +3369,7 @@ msgstr "Edytuj połączenie"
 #: src/ludamus/templates/multiverse/panel/connections/list.html:8
 #: src/ludamus/templates/multiverse/panel/sphere-settings.html:5
 #: src/ludamus/templates/multiverse/panel/sphere-settings.html:8
-#: src/ludamus/templates/panel/base.html:128
+#: src/ludamus/templates/panel/base.html:129
 msgid "Sphere settings"
 msgstr "Ustawienia sfery"
 
@@ -3452,7 +3457,7 @@ msgid "Copy details"
 msgstr "Kopiuj szczegóły"
 
 #: src/ludamus/templates/notice_board/_rsvp_inline.html:63
-#: src/ludamus/templates/notice_board/detail.html:124
+#: src/ludamus/templates/notice_board/detail.html:121
 msgid "No spots left"
 msgstr "Brak wolnych miejsc"
 
@@ -3478,66 +3483,66 @@ msgstr "Wypisz się"
 msgid "Create Encounter"
 msgstr "Utwórz spotkanie"
 
-#: src/ludamus/templates/notice_board/detail.html:54
-#: src/ludamus/templates/notice_board/detail.html:68
+#: src/ludamus/templates/notice_board/detail.html:55
+#: src/ludamus/templates/notice_board/detail.html:69
 msgid "Your encounter"
 msgstr "Twoje spotkanie"
 
-#: src/ludamus/templates/notice_board/detail.html:56
-#: src/ludamus/templates/notice_board/detail.html:70
+#: src/ludamus/templates/notice_board/detail.html:57
+#: src/ludamus/templates/notice_board/detail.html:71
 msgid "You're attending this encounter"
 msgstr "Bierzesz udział w tym spotkaniu"
 
-#: src/ludamus/templates/notice_board/detail.html:58
-#: src/ludamus/templates/notice_board/detail.html:72
+#: src/ludamus/templates/notice_board/detail.html:59
+#: src/ludamus/templates/notice_board/detail.html:73
 msgid "invites you to an encounter"
 msgstr "zaprasza Cię na spotkanie"
 
-#: src/ludamus/templates/notice_board/detail.html:87
+#: src/ludamus/templates/notice_board/detail.html:84
 msgid "Game"
 msgstr "Gra"
 
-#: src/ludamus/templates/notice_board/detail.html:95
+#: src/ludamus/templates/notice_board/detail.html:92
 msgid "When"
 msgstr "Kiedy"
 
-#: src/ludamus/templates/notice_board/detail.html:109
+#: src/ludamus/templates/notice_board/detail.html:106
 msgid "Where"
 msgstr "Gdzie"
 
-#: src/ludamus/templates/notice_board/detail.html:120
+#: src/ludamus/templates/notice_board/detail.html:117
 msgid "Spots"
 msgstr "Miejsca"
 
-#: src/ludamus/templates/notice_board/detail.html:126
+#: src/ludamus/templates/notice_board/detail.html:123
 msgid "1 spot left"
 msgstr "1 wolne miejsce"
 
-#: src/ludamus/templates/notice_board/detail.html:128
+#: src/ludamus/templates/notice_board/detail.html:125
 msgid "spots left"
 msgstr "wolnych miejsc"
 
-#: src/ludamus/templates/notice_board/detail.html:173
+#: src/ludamus/templates/notice_board/detail.html:170
 msgid "Attending"
 msgstr "Uczestnicy"
 
-#: src/ludamus/templates/notice_board/detail.html:187
+#: src/ludamus/templates/notice_board/detail.html:184
 msgid "No one has signed up yet. Share the encounter with friends!"
 msgstr "Nikt się jeszcze nie zapisał. Udostępnij spotkanie znajomym!"
 
-#: src/ludamus/templates/notice_board/detail.html:189
+#: src/ludamus/templates/notice_board/detail.html:186
 msgid "No one has signed up yet. Be the first!"
 msgstr "Nikt się jeszcze nie zapisał. Bądź pierwszy!"
 
-#: src/ludamus/templates/notice_board/detail.html:198
+#: src/ludamus/templates/notice_board/detail.html:195
 msgid "Organized by"
 msgstr "Organizator"
 
-#: src/ludamus/templates/notice_board/detail.html:220
+#: src/ludamus/templates/notice_board/detail.html:217
 msgid "Time until encounter"
 msgstr "Czas do spotkania"
 
-#: src/ludamus/templates/notice_board/detail.html:225
+#: src/ludamus/templates/notice_board/detail.html:222
 msgid "The encounter has started!"
 msgstr "Spotkanie się rozpoczęło!"
 
@@ -3690,7 +3695,7 @@ msgid "New Space"
 msgstr "Nowa przestrzeń"
 
 #: src/ludamus/templates/panel/area-detail.html:35
-#: src/ludamus/templates/panel/base.html:105
+#: src/ludamus/templates/panel/base.html:106
 #: src/ludamus/templates/panel/venue-create.html:12
 #: src/ludamus/templates/panel/venue-detail.html:5
 #: src/ludamus/templates/panel/venue-detail.html:30
@@ -3765,18 +3770,18 @@ msgstr "Czy na pewno chcesz usunąć tę strefę?"
 msgid "Delete Area"
 msgstr "Usuń strefę"
 
-#: src/ludamus/templates/panel/base.html:54
+#: src/ludamus/templates/panel/base.html:55
 msgid "Backoffice"
 msgstr "Panel organizatora"
 
-#: src/ludamus/templates/panel/base.html:85
-#: src/ludamus/templates/panel/base.html:164
+#: src/ludamus/templates/panel/base.html:86
+#: src/ludamus/templates/panel/base.html:165
 #: src/ludamus/templates/panel/index.html:5
 #: src/ludamus/templates/panel/index.html:8
 msgid "Dashboard"
 msgstr "Pulpit"
 
-#: src/ludamus/templates/panel/base.html:90
+#: src/ludamus/templates/panel/base.html:91
 #: src/ludamus/templates/panel/cfp-create.html:12
 #: src/ludamus/templates/panel/cfp-edit.html:13
 #: src/ludamus/templates/panel/cfp.html:6
@@ -3784,7 +3789,7 @@ msgstr "Pulpit"
 msgid "Call for Proposals"
 msgstr "Nabór zgłoszeń"
 
-#: src/ludamus/templates/panel/base.html:95
+#: src/ludamus/templates/panel/base.html:96
 #: src/ludamus/templates/panel/display-settings.html:28
 #: src/ludamus/templates/panel/index.html:58
 #: src/ludamus/templates/panel/proposal-create.html:12
@@ -3798,7 +3803,7 @@ msgstr "Nabór zgłoszeń"
 msgid "Proposals"
 msgstr "Zgłoszenia"
 
-#: src/ludamus/templates/panel/base.html:100
+#: src/ludamus/templates/panel/base.html:101
 #: src/ludamus/templates/panel/facilitator-create.html:12
 #: src/ludamus/templates/panel/facilitator-detail.html:5
 #: src/ludamus/templates/panel/facilitator-detail.html:12
@@ -3812,11 +3817,11 @@ msgstr "Zgłoszenia"
 msgid "Facilitators"
 msgstr "Twórcy programu"
 
-#: src/ludamus/templates/panel/base.html:115
+#: src/ludamus/templates/panel/base.html:116
 msgid "Harmonogram"
 msgstr "Harmonogram"
 
-#: src/ludamus/templates/panel/base.html:120
+#: src/ludamus/templates/panel/base.html:121
 #: src/ludamus/templates/panel/display-settings.html:8
 #: src/ludamus/templates/panel/proposal-settings.html:8
 #: src/ludamus/templates/panel/settings.html:5
@@ -3824,23 +3829,23 @@ msgstr "Harmonogram"
 msgid "Event Settings"
 msgstr "Ustawienia wydarzenia"
 
-#: src/ludamus/templates/panel/base.html:124
+#: src/ludamus/templates/panel/base.html:125
 msgid "Sphere"
 msgstr "Sfera"
 
-#: src/ludamus/templates/panel/base.html:138
+#: src/ludamus/templates/panel/base.html:139
 msgid "Back to website"
 msgstr "Wróć do strony"
 
-#: src/ludamus/templates/panel/base.html:146
+#: src/ludamus/templates/panel/base.html:147
 msgid "Organizer"
 msgstr "Organizator"
 
-#: src/ludamus/templates/panel/base.html:177
+#: src/ludamus/templates/panel/base.html:178
 msgid "Event:"
 msgstr "Wydarzenie:"
 
-#: src/ludamus/templates/panel/base.html:182
+#: src/ludamus/templates/panel/base.html:183
 msgid "Proposals Closed"
 msgstr "Zgłoszenia zamknięte"
 
@@ -4269,17 +4274,17 @@ msgid "Search…"
 msgstr "Szukaj…"
 
 #: src/ludamus/templates/panel/parts/timetable-browse-pane.html:19
-#: src/ludamus/templates/panel/timetable.html:96
+#: src/ludamus/templates/panel/timetable.html:97
 msgid "Loading…"
 msgstr "Ładowanie…"
 
 #: src/ludamus/templates/panel/parts/timetable-conflict-panel.html:6
-#: src/ludamus/templates/panel/timetable.html:88
+#: src/ludamus/templates/panel/timetable.html:89
 msgid "All clear"
 msgstr "Brak problemów"
 
 #: src/ludamus/templates/panel/parts/timetable-conflict-panel.html:10
-#: src/ludamus/templates/panel/timetable.html:85
+#: src/ludamus/templates/panel/timetable.html:86
 #, python-format
 msgid "%(count)s conflict"
 msgid_plural "%(count)s conflicts"
@@ -4308,7 +4313,7 @@ msgstr "%(name)s prowadzi równocześnie: %(title)s"
 
 #: src/ludamus/templates/panel/parts/timetable-conflict-panel.html:38
 #: src/ludamus/templates/panel/timetable-problems.html:85
-#: src/ludamus/templates/panel/timetable.html:39
+#: src/ludamus/templates/panel/timetable.html:40
 msgid "Track:"
 msgstr "Blok:"
 
@@ -4726,7 +4731,7 @@ msgid "Track"
 msgstr "Blok programowy"
 
 #: src/ludamus/templates/panel/proposals.html:40
-#: src/ludamus/templates/panel/timetable.html:43
+#: src/ludamus/templates/panel/timetable.html:44
 msgid "All tracks"
 msgstr "Wszystkie bloki"
 
@@ -4985,7 +4990,7 @@ msgstr ""
 #: src/ludamus/templates/panel/timetable-log.html:15
 #: src/ludamus/templates/panel/timetable-overview.html:15
 #: src/ludamus/templates/panel/timetable-problems.html:15
-#: src/ludamus/templates/panel/timetable.html:27
+#: src/ludamus/templates/panel/timetable.html:28
 msgid "Activity Log"
 msgstr "Dziennik zmian"
 
@@ -4996,9 +5001,9 @@ msgstr "Dziennik zmian harmonogramu"
 #: src/ludamus/templates/panel/timetable-log.html:14
 #: src/ludamus/templates/panel/timetable-overview.html:14
 #: src/ludamus/templates/panel/timetable-problems.html:14
-#: src/ludamus/templates/panel/timetable.html:6
-#: src/ludamus/templates/panel/timetable.html:9
-#: src/ludamus/templates/panel/timetable.html:26
+#: src/ludamus/templates/panel/timetable.html:7
+#: src/ludamus/templates/panel/timetable.html:10
+#: src/ludamus/templates/panel/timetable.html:27
 msgid "Schedule"
 msgstr "Harmonogram"
 
@@ -5007,7 +5012,7 @@ msgstr "Harmonogram"
 #: src/ludamus/templates/panel/timetable-overview.html:8
 #: src/ludamus/templates/panel/timetable-overview.html:16
 #: src/ludamus/templates/panel/timetable-problems.html:16
-#: src/ludamus/templates/panel/timetable.html:28
+#: src/ludamus/templates/panel/timetable.html:29
 msgid "Organizer Overview"
 msgstr "Przegląd harmonogramu"
 
@@ -5016,7 +5021,7 @@ msgstr "Przegląd harmonogramu"
 #: src/ludamus/templates/panel/timetable-problems.html:5
 #: src/ludamus/templates/panel/timetable-problems.html:8
 #: src/ludamus/templates/panel/timetable-problems.html:17
-#: src/ludamus/templates/panel/timetable.html:29
+#: src/ludamus/templates/panel/timetable.html:30
 msgid "Problems"
 msgstr "Problemy"
 
@@ -5142,11 +5147,11 @@ msgstr "Otwórz w harmonogramie"
 msgid "All scheduled sessions are inside their preferred slots."
 msgstr "Wszystkie zaplanowane punkty programu są w preferowanych przedziałach."
 
-#: src/ludamus/templates/panel/timetable.html:16
+#: src/ludamus/templates/panel/timetable.html:17
 msgid "Click a position on the grid to place the session"
 msgstr "Kliknij pozycję na siatce, aby umieścić punkt programu"
 
-#: src/ludamus/templates/panel/timetable.html:54
+#: src/ludamus/templates/panel/timetable.html:55
 msgid "Day:"
 msgstr "Dzień:"
 

--- a/src/ludamus/templates/chronology/enroll_select.html
+++ b/src/ludamus/templates/chronology/enroll_select.html
@@ -14,7 +14,7 @@
     <div class="max-w-4xl mx-auto">
         {# Session Details Card #}
         <div class="card mb-4">
-            <div class="card-header bg-[var(--theme-primary)] text-white flex items-center gap-2">
+            <div class="card-header bg-primary text-white flex items-center gap-2">
                 {% icon "calendar" class="w-5 h-5" %}
                 <h5 class="font-semibold mb-0">{{ session.title }}</h5>
             </div>

--- a/src/ludamus/templates/chronology/event.html
+++ b/src/ludamus/templates/chronology/event.html
@@ -662,7 +662,7 @@
     <!-- Session Detail Modals -->
     {% for data in sessions %}
         <dialog id="session-{{ data.session.pk }}"
-                class="modal max-w-200 w-[calc(100%-.5rem)] bg-transparent h-600 max-h-[90dvh] overflow-hidden"
+                class="modal max-w-200 w-[calc(100%-0.5rem)] bg-transparent h-600 max-h-[90dvh] overflow-hidden"
                 aria-labelledby="session-{{ data.session.pk }}-title">
             <!-- Header -->
             <div class="px-6 py-4 border-b border-border flex items-center justify-between shrink-0">

--- a/src/ludamus/templates/chronology/session_tags.html
+++ b/src/ludamus/templates/chronology/session_tags.html
@@ -8,7 +8,7 @@
             {% endfor %}
             {% if row.overflow_count %}
                 <div class="session-tags-more relative inline-block">
-                    <div class="session-tags-popover absolute z-30 min-w-[14rem] max-w-[20rem] rounded-xl border border-[var(--theme-border)] bg-[var(--color-bg-secondary)] p-2 shadow-[var(--theme-shadow-lg)] opacity-0 pointer-events-none transition-opacity duration-150 flex flex-wrap gap-1">
+                    <div class="session-tags-popover absolute z-30 min-w-56 max-w-[20rem] rounded-xl border border-border bg-bg-secondary p-2 shadow-(--theme-shadow-lg) opacity-0 pointer-events-none transition-opacity duration-150 flex flex-wrap gap-1">
                         {% for val in row.overflow_values %}
                             {% include "components/_field_pill.html" with value=val icon=row.icon title=val size="md" %}
                         {% endfor %}

--- a/src/ludamus/templates/components/file-dropzone.html
+++ b/src/ludamus/templates/components/file-dropzone.html
@@ -2,7 +2,7 @@
 <label for="{{ id }}"
        data-dropzone
        data-state="{{ dropzone_state }}"
-       class="group relative flex flex-col items-center justify-center w-full min-h-44 sm:min-h-48 px-4 py-6 bg-bg-tertiary border border-border rounded-lg cursor-pointer transition-colors hover:bg-bg-secondary hover:ring hover:-ring-offset-1 hover:ring-border hover:border-primary/40 has-[input[aria-invalid=true]]:border-danger overflow-hidden">
+       class="group relative flex flex-col items-center justify-center w-full min-h-44 sm:min-h-48 px-4 py-6 bg-bg-tertiary border border-border rounded-lg cursor-pointer transition-colors hover:bg-bg-secondary hover:border-primary/40 has-[input[aria-invalid=true]]:border-danger overflow-hidden">
     <input type="file"
            id="{{ id }}"
            name="{{ name }}"
@@ -13,7 +13,7 @@
            class="absolute inset-0 w-full h-full opacity-0 cursor-pointer">
     <div data-dropzone-empty
          class="pointer-events-none flex flex-col items-center text-center hidden group-data-[state=empty]:flex">
-        <span class="mb-3 inline-flex items-center justify-center w-11 h-11 rounded-full bg-bg-secondary text-foreground-secondary border border-border transition-colors group-hover:text-primary group-hover:border-primary/30">
+        <span class="mb-3 inline-flex items-center justify-center w-11 h-11 rounded-full bg-bg-secondary text-foreground-secondary border border-border transition-colors hover:duration-0 group-hover:text-primary group-hover:border-primary/30">
             {% icon "arrow-up-tray" class="w-5 h-5" %}
         </span>
         <p class="text-sm text-foreground">

--- a/src/ludamus/templates/components/file-dropzone.html
+++ b/src/ludamus/templates/components/file-dropzone.html
@@ -1,0 +1,45 @@
+{# File input rendered as drag-and-drop zone. Pass `name` and `id`. #}
+{# Optional: required, accept, is_image, has_errors, initial_url, initial_name #}
+{% load i18n tessera %}
+<label for="{{ id }}"
+       data-dropzone
+       class="group relative flex flex-col items-center justify-center w-full min-h-44 sm:min-h-48 px-4 py-6 bg-bg-tertiary border border-dashed rounded-2xl cursor-pointer transition-colors hover:bg-bg-secondary {% if has_errors %}border-danger{% else %}border-border hover:border-primary/40{% endif %}">
+    <div data-dropzone-empty class="flex flex-col items-center text-center {% if initial_url %}hidden{% endif %}">
+        <span class="mb-3 inline-flex items-center justify-center w-11 h-11 rounded-full bg-bg-secondary text-foreground-secondary border border-border transition-colors group-hover:text-primary group-hover:border-primary/30">
+            {% icon "arrow-up-tray" class="w-5 h-5" %}
+        </span>
+        <p class="text-sm text-foreground">
+            <span class="font-semibold text-primary">{% translate "Click to upload" %}</span>
+            <span class="text-foreground-secondary">{% translate "or drag and drop" %}</span>
+        </p>
+    </div>
+    <div data-dropzone-selected class="flex items-center gap-3 w-full max-w-md {% if not initial_url %}hidden{% endif %}">
+        {% if is_image %}
+            <img data-dropzone-preview
+                 src="{{ initial_url|default:'' }}"
+                 alt=""
+                 class="w-16 h-16 rounded-lg object-cover bg-bg-secondary border border-border shrink-0">
+        {% else %}
+            <span class="inline-flex items-center justify-center w-16 h-16 rounded-lg bg-bg-secondary border border-border text-foreground-secondary shrink-0">
+                {% icon "document" class="w-6 h-6" %}
+            </span>
+        {% endif %}
+        <div class="flex-1 min-w-0 text-left">
+            <p data-dropzone-name class="text-sm font-medium text-foreground truncate">{{ initial_name }}</p>
+            <p data-dropzone-size class="text-xs text-foreground-muted"></p>
+        </div>
+        <button type="button"
+                data-dropzone-clear
+                class="p-1.5 rounded-md text-foreground-muted hover:text-danger hover:bg-bg-secondary transition-colors shrink-0 [&_svg]:pointer-events-none"
+                aria-label="{% translate 'Remove file' %}">
+            {% icon "x-mark" class="w-4 h-4" %}
+        </button>
+    </div>
+    <input type="file"
+           id="{{ id }}"
+           name="{{ name }}"
+           data-dropzone-input
+           {% if accept %}accept="{{ accept }}"{% endif %}
+           {% if required and not initial_url %}required{% endif %}
+           class="sr-only">
+</label>

--- a/src/ludamus/templates/components/file-dropzone.html
+++ b/src/ludamus/templates/components/file-dropzone.html
@@ -22,27 +22,29 @@
         </p>
     </div>
     <div data-dropzone-selected
-         class="pointer-events-none relative z-10 flex items-center gap-3 w-full max-w-md {% if not initial_url %}hidden{% endif %}">
+         class="pointer-events-none {% if not initial_url %}hidden{% endif %} {% if is_image %}absolute inset-0 z-10 rounded-2xl overflow-hidden{% else %}relative z-10 flex items-center gap-3 w-full max-w-md{% endif %}">
         {% if is_image %}
             <img data-dropzone-preview
                  src="{{ initial_url|default:'' }}"
                  alt=""
-                 width="64"
-                 height="64"
-                 class="w-16 h-16 rounded-lg object-cover bg-bg-secondary border border-border shrink-0">
+                 width="800"
+                 height="400"
+                 class="absolute inset-0 w-full h-full object-cover">
         {% else %}
             <span class="inline-flex items-center justify-center w-16 h-16 rounded-lg bg-bg-secondary border border-border text-foreground-secondary shrink-0">
                 {% icon "document" class="w-6 h-6" %}
             </span>
         {% endif %}
-        <div class="flex-1 min-w-0 text-left">
-            <p data-dropzone-name
-               class="text-sm font-medium text-foreground truncate">{{ initial_name }}</p>
-            <p data-dropzone-size class="text-xs text-foreground-muted"></p>
+        <div class="{% if is_image %}absolute bottom-2 left-2 right-2 px-3 py-2 rounded-xl bg-bg-secondary/85 backdrop-blur-sm border border-border shadow-sm flex items-center gap-3{% endif %}">
+            <div class="flex-1 min-w-0 text-left">
+                <p data-dropzone-name
+                   class="text-sm font-medium text-foreground truncate">{{ initial_name }}</p>
+                <p data-dropzone-size class="text-xs text-foreground-muted"></p>
+            </div>
+            <button type="button"
+                    data-dropzone-clear
+                    class="pointer-events-auto p-1.5 rounded-md text-foreground-muted hover:text-danger hover:bg-bg-secondary transition-colors shrink-0 [&_svg]:pointer-events-none"
+                    aria-label="{% translate "Remove file" %}">{% icon "x-mark" class="w-4 h-4" %}</button>
         </div>
-        <button type="button"
-                data-dropzone-clear
-                class="pointer-events-auto p-1.5 rounded-md text-foreground-muted hover:text-danger hover:bg-bg-secondary transition-colors shrink-0 [&_svg]:pointer-events-none"
-                aria-label="{% translate "Remove file" %}">{% icon "x-mark" class="w-4 h-4" %}</button>
     </div>
 </label>

--- a/src/ludamus/templates/components/file-dropzone.html
+++ b/src/ludamus/templates/components/file-dropzone.html
@@ -1,18 +1,18 @@
-{# File input rendered as drag-and-drop zone. Pass `name` and `id`. #}
-{# Optional: required, accept, is_image, has_errors, initial_url, initial_name #}
 {% load i18n tessera %}
 <label for="{{ id }}"
        data-dropzone
-       class="group relative flex flex-col items-center justify-center w-full min-h-44 sm:min-h-48 px-4 py-6 bg-bg-tertiary border border-dashed rounded-2xl cursor-pointer transition-colors hover:bg-bg-secondary {% if has_errors %}border-danger{% else %}border-border hover:border-primary/40{% endif %}">
+       data-state="{{ dropzone_state }}"
+       class="group relative flex flex-col items-center justify-center w-full min-h-44 sm:min-h-48 px-4 py-6 bg-bg-tertiary border border-border rounded-lg cursor-pointer transition-colors hover:bg-bg-secondary hover:ring hover:-ring-offset-1 hover:ring-border hover:border-primary/40 has-[input[aria-invalid=true]]:border-danger overflow-hidden">
     <input type="file"
            id="{{ id }}"
            name="{{ name }}"
            data-dropzone-input
+           aria-invalid="{{ has_errors|yesno:'true,false' }}"
            {% if accept %}accept="{{ accept }}"{% endif %}
            {% if required and not initial_url %}required{% endif %}
            class="absolute inset-0 w-full h-full opacity-0 cursor-pointer">
     <div data-dropzone-empty
-         class="pointer-events-none flex flex-col items-center text-center {% if initial_url %}hidden{% endif %}">
+         class="pointer-events-none flex flex-col items-center text-center hidden group-data-[state=empty]:flex">
         <span class="mb-3 inline-flex items-center justify-center w-11 h-11 rounded-full bg-bg-secondary text-foreground-secondary border border-border transition-colors group-hover:text-primary group-hover:border-primary/30">
             {% icon "arrow-up-tray" class="w-5 h-5" %}
         </span>
@@ -22,29 +22,36 @@
         </p>
     </div>
     <div data-dropzone-selected
-         class="pointer-events-none {% if not initial_url %}hidden{% endif %} {% if is_image %}absolute inset-0 z-10 rounded-2xl overflow-hidden{% else %}relative z-10 flex items-center gap-3 w-full max-w-md{% endif %}">
-        {% if is_image %}
+         class="pointer-events-none hidden group-data-[state=image]:absolute group-data-[state=image]:-inset-px group-data-[state=image]:z-10 group-data-[state=image]:block group-data-[state=image]:rounded-lg group-data-[state=image]:overflow-hidden group-data-[state=file]:relative group-data-[state=file]:z-10 group-data-[state=file]:flex group-data-[state=file]:items-center group-data-[state=file]:gap-3 group-data-[state=file]:w-full group-data-[state=file]:max-w-md">
+        <div class="pointer-events-none absolute inset-0 hidden group-data-[state=image]:block">
             <img data-dropzone-preview
                  src="{{ initial_url|default:'' }}"
                  alt=""
                  width="800"
                  height="400"
                  class="absolute inset-0 w-full h-full object-cover">
-        {% else %}
-            <span class="inline-flex items-center justify-center w-16 h-16 rounded-lg bg-bg-secondary border border-border text-foreground-secondary shrink-0">
-                {% icon "document" class="w-6 h-6" %}
-            </span>
-        {% endif %}
-        <div class="{% if is_image %}absolute bottom-2 left-2 right-2 px-3 py-2 rounded-xl bg-background border border-border shadow-sm flex items-center gap-3{% endif %}">
-            <div class="flex-1 min-w-0 text-left">
-                <p data-dropzone-name
-                   class="text-sm font-medium text-foreground truncate">{{ initial_name }}</p>
-                <p data-dropzone-size class="text-xs text-foreground-muted"></p>
+            <div class="absolute inset-x-0 bottom-0 pt-12 pb-2 px-3 bg-linear-to-t from-black via-black/55 to-transparent">
+                <p data-dropzone-name class="text-sm font-medium text-white truncate">{{ initial_name }}</p>
+                <p data-dropzone-size class="text-xs text-white/75"></p>
             </div>
             <button type="button"
                     data-dropzone-clear
-                    class="pointer-events-auto p-1.5 rounded-md text-foreground-muted hover:text-danger hover:bg-bg-secondary transition-colors shrink-0 [&_svg]:pointer-events-none"
+                    class="pointer-events-auto absolute top-2 right-2 p-1.5 rounded-md text-white hover:bg-white/15 transition-colors shrink-0 [&_svg]:pointer-events-none"
                     aria-label="{% translate "Remove file" %}">{% icon "x-mark" class="w-4 h-4" %}</button>
+        </div>
+        <div class="pointer-events-none hidden group-data-[state=file]:flex group-data-[state=file]:items-center group-data-[state=file]:gap-3 group-data-[state=file]:w-full group-data-[state=file]:max-w-md group-data-[state=file]:relative">
+            <span class="inline-flex items-center justify-center w-16 h-16 rounded-lg bg-bg-secondary border border-border text-foreground-secondary shrink-0">
+                {% icon "document" class="w-6 h-6" %}
+            </span>
+            <div class="relative flex-1 min-w-0">
+                <p data-dropzone-name
+                   class="text-sm font-medium text-foreground truncate pr-10">{{ initial_name }}</p>
+                <p data-dropzone-size class="text-xs text-foreground-muted"></p>
+                <button type="button"
+                        data-dropzone-clear
+                        class="pointer-events-auto absolute top-0 right-0 p-1.5 rounded-md text-foreground-muted hover:text-danger hover:bg-bg-secondary transition-colors shrink-0 [&_svg]:pointer-events-none"
+                        aria-label="{% translate "Remove file" %}">{% icon "x-mark" class="w-4 h-4" %}</button>
+            </div>
         </div>
     </div>
 </label>

--- a/src/ludamus/templates/components/file-dropzone.html
+++ b/src/ludamus/templates/components/file-dropzone.html
@@ -4,7 +4,15 @@
 <label for="{{ id }}"
        data-dropzone
        class="group relative flex flex-col items-center justify-center w-full min-h-44 sm:min-h-48 px-4 py-6 bg-bg-tertiary border border-dashed rounded-2xl cursor-pointer transition-colors hover:bg-bg-secondary {% if has_errors %}border-danger{% else %}border-border hover:border-primary/40{% endif %}">
-    <div data-dropzone-empty class="flex flex-col items-center text-center {% if initial_url %}hidden{% endif %}">
+    <input type="file"
+           id="{{ id }}"
+           name="{{ name }}"
+           data-dropzone-input
+           {% if accept %}accept="{{ accept }}"{% endif %}
+           {% if required and not initial_url %}required{% endif %}
+           class="absolute inset-0 w-full h-full opacity-0 cursor-pointer">
+    <div data-dropzone-empty
+         class="pointer-events-none flex flex-col items-center text-center {% if initial_url %}hidden{% endif %}">
         <span class="mb-3 inline-flex items-center justify-center w-11 h-11 rounded-full bg-bg-secondary text-foreground-secondary border border-border transition-colors group-hover:text-primary group-hover:border-primary/30">
             {% icon "arrow-up-tray" class="w-5 h-5" %}
         </span>
@@ -13,11 +21,14 @@
             <span class="text-foreground-secondary">{% translate "or drag and drop" %}</span>
         </p>
     </div>
-    <div data-dropzone-selected class="flex items-center gap-3 w-full max-w-md {% if not initial_url %}hidden{% endif %}">
+    <div data-dropzone-selected
+         class="pointer-events-none relative z-10 flex items-center gap-3 w-full max-w-md {% if not initial_url %}hidden{% endif %}">
         {% if is_image %}
             <img data-dropzone-preview
                  src="{{ initial_url|default:'' }}"
                  alt=""
+                 width="64"
+                 height="64"
                  class="w-16 h-16 rounded-lg object-cover bg-bg-secondary border border-border shrink-0">
         {% else %}
             <span class="inline-flex items-center justify-center w-16 h-16 rounded-lg bg-bg-secondary border border-border text-foreground-secondary shrink-0">
@@ -25,21 +36,13 @@
             </span>
         {% endif %}
         <div class="flex-1 min-w-0 text-left">
-            <p data-dropzone-name class="text-sm font-medium text-foreground truncate">{{ initial_name }}</p>
+            <p data-dropzone-name
+               class="text-sm font-medium text-foreground truncate">{{ initial_name }}</p>
             <p data-dropzone-size class="text-xs text-foreground-muted"></p>
         </div>
         <button type="button"
                 data-dropzone-clear
-                class="p-1.5 rounded-md text-foreground-muted hover:text-danger hover:bg-bg-secondary transition-colors shrink-0 [&_svg]:pointer-events-none"
-                aria-label="{% translate 'Remove file' %}">
-            {% icon "x-mark" class="w-4 h-4" %}
-        </button>
+                class="pointer-events-auto p-1.5 rounded-md text-foreground-muted hover:text-danger hover:bg-bg-secondary transition-colors shrink-0 [&_svg]:pointer-events-none"
+                aria-label="{% translate "Remove file" %}">{% icon "x-mark" class="w-4 h-4" %}</button>
     </div>
-    <input type="file"
-           id="{{ id }}"
-           name="{{ name }}"
-           data-dropzone-input
-           {% if accept %}accept="{{ accept }}"{% endif %}
-           {% if required and not initial_url %}required{% endif %}
-           class="sr-only">
 </label>

--- a/src/ludamus/templates/components/file-dropzone.html
+++ b/src/ludamus/templates/components/file-dropzone.html
@@ -35,7 +35,7 @@
                 {% icon "document" class="w-6 h-6" %}
             </span>
         {% endif %}
-        <div class="{% if is_image %}absolute bottom-2 left-2 right-2 px-3 py-2 rounded-xl bg-bg-secondary/85 backdrop-blur-sm border border-border shadow-sm flex items-center gap-3{% endif %}">
+        <div class="{% if is_image %}absolute bottom-2 left-2 right-2 px-3 py-2 rounded-xl bg-background border border-border shadow-sm flex items-center gap-3{% endif %}">
             <div class="flex-1 min-w-0 text-left">
                 <p data-dropzone-name
                    class="text-sm font-medium text-foreground truncate">{{ initial_name }}</p>

--- a/src/ludamus/templates/components/navbar.html
+++ b/src/ludamus/templates/components/navbar.html
@@ -20,7 +20,7 @@
                 </a>
                 {% if current_sphere.enabled_pages|length > 1 %}
                     {% with ns=request.resolver_match.namespace %}
-                        <div class="hidden sm:flex items-center gap-1">
+                        <div class="items-center gap-1">
                             {% if "events" in current_sphere.enabled_pages %}
                                 <a href="{% url 'web:events' %}"
                                    aria-current="{% if 'notice-board' not in ns %}page{% endif %}"

--- a/src/ludamus/templates/components/navbar.html
+++ b/src/ludamus/templates/components/navbar.html
@@ -20,7 +20,7 @@
                 </a>
                 {% if current_sphere.enabled_pages|length > 1 %}
                     {% with ns=request.resolver_match.namespace %}
-                        <div class="items-center gap-1">
+                        <div class="flex items-center gap-0.5">
                             {% if "events" in current_sphere.enabled_pages %}
                                 <a href="{% url 'web:events' %}"
                                    aria-current="{% if 'notice-board' not in ns %}page{% endif %}"

--- a/src/ludamus/templates/notice_board/_form.html
+++ b/src/ludamus/templates/notice_board/_form.html
@@ -1,4 +1,5 @@
 {% load i18n tessera django_vite %}
+{% tessera_field form.header_image %}
 {% tessera_field form.title %}
 {% tessera_field form.description %}
 <div class="md:grid md:grid-cols-2 md:gap-x-4">
@@ -7,6 +8,5 @@
     {% tessera_field form.game %}
     {% tessera_field form.place %}
     {% tessera_field form.max_participants %}
-    {% tessera_field form.header_image %}
 </div>
 {% vite_asset 'src/encounter-form.ts' %}

--- a/src/ludamus/templates/notice_board/_form.html
+++ b/src/ludamus/templates/notice_board/_form.html
@@ -1,12 +1,19 @@
 {% load i18n tessera django_vite %}
-{% tessera_field form.header_image %}
-{% tessera_field form.title %}
-{% tessera_field form.description %}
-<div class="md:grid md:grid-cols-2 md:gap-x-4">
-    {% tessera_field form.start_time %}
-    {% tessera_field form.end_time %}
-    {% tessera_field form.game %}
-    {% tessera_field form.place %}
-    {% tessera_field form.max_participants %}
+<div class="md:flex md:gap-x-6">
+    <div class="flex-1">
+        {% tessera_field form.title %}
+        {% tessera_field form.header_image %}
+        {% tessera_field form.description %}
+    </div>
+    <div class="flex flex-col">
+        {% tessera_field form.game %}
+        {% tessera_field form.place %}
+        <div class="flex max-md:flex-col gap-2">
+            {% tessera_field form.start_time %}
+            {% tessera_field form.end_time %}
+        </div>
+        {% tessera_field form.max_participants %}
+        <div class="mt-2 md:mt-auto md:ml-auto md:pt-4">{% tessera_button submit_label %}</div>
+    </div>
 </div>
 {% vite_asset 'src/encounter-form.ts' %}

--- a/src/ludamus/templates/notice_board/_form.html
+++ b/src/ludamus/templates/notice_board/_form.html
@@ -1,5 +1,5 @@
 {% load i18n tessera django_vite %}
-<div class="md:flex md:gap-x-6">
+<div class="flex max-md:flex-col gap-4 md:gap-x-6">
     <div class="flex-1">
         {% tessera_field form.title %}
         {% tessera_field form.header_image %}

--- a/src/ludamus/templates/notice_board/_form.html
+++ b/src/ludamus/templates/notice_board/_form.html
@@ -8,7 +8,7 @@
     <div class="flex flex-col">
         {% tessera_field form.game %}
         {% tessera_field form.place %}
-        <div class="flex max-md:flex-col gap-2">
+        <div class="flex max-md:flex-col gap-2 max-md:mb-4">
             {% tessera_field form.start_time %}
             {% tessera_field form.end_time %}
         </div>

--- a/src/ludamus/templates/notice_board/create.html
+++ b/src/ludamus/templates/notice_board/create.html
@@ -7,13 +7,12 @@
     <h1 class="text-2xl sm:text-3xl font-bold text-foreground mb-2">{% translate "Create Encounter" %}</h1>
 {% endblock header %}
 {% block body %}
-    <div class="max-w-3xl mx-auto">
+    <div class="w-full max-w-5xl mx-auto">
         <div class="card">
             <div class="card-body">
                 <form method="post" enctype="multipart/form-data">
                     {% csrf_token %}
-                    {% include "notice_board/_form.html" %}
-                    {% tessera_button "Create Encounter" %}
+                    {% include "notice_board/_form.html" with submit_label="Create Encounter" %}
                 </form>
             </div>
         </div>

--- a/src/ludamus/templates/notice_board/detail.html
+++ b/src/ludamus/templates/notice_board/detail.html
@@ -39,46 +39,43 @@
     <div class="grid grid-cols-1 lg:grid-cols-3 gap-6 max-w-5xl mx-auto">
         {# ── LEFT COLUMN: "what is this" ── #}
         <div class="lg:col-span-2 space-y-6">
-            {# Hero image + title #}
-            {% if encounter.header_image %}
-                <div class="relative aspect-[2/1] overflow-hidden rounded-t-2xl -mb-6">
-                    <img src="{{ MEDIA_URL }}{{ encounter.header_image }}"
-                         alt="{{ encounter.title }}"
-                         width="800"
-                         height="400"
-                         class="w-full h-full object-cover">
-                    <div class="absolute inset-0 bg-gradient-to-t from-black/80 via-black/30 to-transparent"></div>
-                    <div class="absolute bottom-0 left-0 right-0 px-6 pb-6">
-                        <p class="text-sm italic text-white/90 drop-shadow-lg">
-                            {% if is_creator %}
-                                {% translate "Your encounter" %}
-                            {% elif user_has_rsvpd %}
-                                {% translate "You're attending this encounter" %}
-                            {% else %}
-                                {{ creator.full_name|default:creator.name }} {% translate "invites you to an encounter" %}
-                            {% endif %}
-                        </p>
-                        <h1 class="text-2xl font-bold text-white drop-shadow-lg mt-1">{{ encounter.title }}</h1>
-                    </div>
-                </div>
-            {% else %}
-                <div>
-                    <p class="text-sm italic text-foreground-secondary">
-                        {% if is_creator %}
-                            {% translate "Your encounter" %}
-                        {% elif user_has_rsvpd %}
-                            {% translate "You're attending this encounter" %}
-                        {% else %}
-                            {{ creator.full_name|default:creator.name }} {% translate "invites you to an encounter" %}
-                        {% endif %}
-                    </p>
-                    <h1 class="text-2xl font-bold text-foreground mt-1">{{ encounter.title }}</h1>
-                </div>
-            {% endif %}
-            {# Quick facts + description card #}
             <div class="card {% if encounter.header_image %}rounded-t-none{% endif %}">
                 <div class="card-body space-y-4">
-                    {# Quick facts grid #}
+                    {% if encounter.header_image %}
+                        <div class="relative aspect-[2/1] overflow-hidden rounded-t-2xl -mb-6">
+                            <img src="{{ MEDIA_URL }}{{ encounter.header_image }}"
+                                 alt="{{ encounter.title }}"
+                                 width="800"
+                                 height="400"
+                                 class="w-full h-full object-cover">
+                            <div class="absolute inset-0 bg-gradient-to-t from-black/80 via-black/30 to-transparent"></div>
+                            <div class="absolute bottom-0 left-0 right-0 px-6 pb-6">
+                                <p class="text-sm italic text-white/90 drop-shadow-lg">
+                                    {% if is_creator %}
+                                        {% translate "Your encounter" %}
+                                    {% elif user_has_rsvpd %}
+                                        {% translate "You're attending this encounter" %}
+                                    {% else %}
+                                        {{ creator.full_name|default:creator.name }} {% translate "invites you to an encounter" %}
+                                    {% endif %}
+                                </p>
+                                <h1 class="text-2xl font-bold text-white drop-shadow-lg mt-1">{{ encounter.title }}</h1>
+                            </div>
+                        </div>
+                    {% else %}
+                        <div>
+                            <p class="text-sm italic text-foreground-secondary">
+                                {% if is_creator %}
+                                    {% translate "Your encounter" %}
+                                {% elif user_has_rsvpd %}
+                                    {% translate "You're attending this encounter" %}
+                                {% else %}
+                                    {{ creator.full_name|default:creator.name }} {% translate "invites you to an encounter" %}
+                                {% endif %}
+                            </p>
+                            <h1 class="text-2xl font-bold text-foreground mt-1">{{ encounter.title }}</h1>
+                        </div>
+                    {% endif %}
                     <div class="grid grid-cols-1 sm:grid-cols-2 gap-3">
                         {% if encounter.game %}
                             <div class="flex items-center gap-2.5 p-3 rounded-lg bg-bg-tertiary">

--- a/src/ludamus/templates/notice_board/edit.html
+++ b/src/ludamus/templates/notice_board/edit.html
@@ -7,13 +7,12 @@
     <h1 class="text-2xl sm:text-3xl font-bold text-foreground mb-2">{% translate "Edit Encounter" %}</h1>
 {% endblock header %}
 {% block body %}
-    <div class="max-w-3xl mx-auto">
+    <div class="w-full max-w-5xl mx-auto">
         <div class="card">
             <div class="card-body">
                 <form method="post" enctype="multipart/form-data">
                     {% csrf_token %}
-                    {% include "notice_board/_form.html" %}
-                    {% tessera_button "Save Changes" %}
+                    {% include "notice_board/_form.html" with submit_label="Save Changes" %}
                 </form>
                 <div class="mt-6 pt-4 border-t border-border">
                     <form method="post"

--- a/tests/unit/adapters/web/django/templatetags/test_tessera_forms.py
+++ b/tests/unit/adapters/web/django/templatetags/test_tessera_forms.py
@@ -424,3 +424,7 @@ class TestTesseraButtonBranches:
     def test_unknown_size_falls_back_to_md(self) -> None:
         html = tessera_button("Go", size="unknown")
         assert "py-2" in html
+
+    def test_full_width_on_mobile(self) -> None:
+        html = tessera_button("Go")
+        assert "max-md:w-full" in html

--- a/tests/unit/adapters/web/django/templatetags/test_tessera_forms.py
+++ b/tests/unit/adapters/web/django/templatetags/test_tessera_forms.py
@@ -400,15 +400,11 @@ class TestTesseraFormLayout:
 
 
 # ---------------------------------------------------------------------------
-# tessera_button — variant, size, full_width branches
+# tessera_button — variant, size
 # ---------------------------------------------------------------------------
 
 
 class TestTesseraButtonBranches:
-    def test_full_width(self) -> None:
-        html = tessera_button("Go", full_width=True)
-        assert "w-full" in html
-
     def test_secondary_variant(self) -> None:
         html = tessera_button("Cancel", variant="secondary")
         assert "btn-secondary" in html


### PR DESCRIPTION
- Move the encounter detail hero image **inside** the card so the gradient overlay and title lie on the card border (not above an empty band).
- Add a drag-and-drop **cover image** dropzone. Native click + drop on a full-size hidden file input — minimal JS for filename/size/preview and clear.
- Restructure the encounter form into a 2-column layout on desktop (`max-w-5xl`): cover image, title, description on the left; start/end times, max participants, game, place plus the submit button on the right. Single-column stack on mobile.

### Create / Edit (desktop)

| Create | Edit |
|---|---|
| ![desktop create](https://files.catbox.moe/jkpc2s.png) | ![desktop edit](https://files.catbox.moe/bgvp51.png) |

### Create / Edit (mobile, 390px)

| Create | Edit |
|---|---|
| ![mobile create](https://files.catbox.moe/l7qm1r.png) | ![mobile edit](https://files.catbox.moe/3c8rt2.png) |