### PR TITLE
Reload Django pages on template change (fix HMR)

### DIFF
--- a/src/ludamus/client/src/django-hmr.ts
+++ b/src/ludamus/client/src/django-hmr.ts
@@ -1,0 +1,7 @@
+/// <reference types="vite/client" />
+
+if (import.meta.hot) {
+  import.meta.hot.on("django-template-reload", () => {
+    window.location.reload();
+  });
+}

--- a/src/ludamus/client/src/modal.ts
+++ b/src/ludamus/client/src/modal.ts
@@ -7,6 +7,7 @@ import {
 interface NavigateEvent {
   canIntercept: boolean;
   hashChange: boolean;
+  navigationType: "push" | "replace" | "reload" | "traverse";
   destination: { url: string };
   intercept: () => void;
 }
@@ -194,6 +195,7 @@ window.addEventListener("pagehide", () => {
 
 if (navigation) {
   navigation.addEventListener("navigate", (e) => {
+    if (e.navigationType !== "push") return;
     if (!e.canIntercept || e.hashChange) return;
 
     const url = new URL(e.destination.url);

--- a/src/ludamus/client/vite.config.ts
+++ b/src/ludamus/client/vite.config.ts
@@ -7,20 +7,27 @@ import { defineConfig, type Plugin } from "vite";
 // The Vite client (client.mjs case "full-reload") only reloads when that
 // path matches location.pathname. We serve HTML from Django (/events/, …)
 // not Vite, so the paths never match and the browser silently ignores the
-// signal. Send a path-less full-reload so the client reloads unconditionally.
+// signal. Send a custom event handled by src/django-hmr.ts so Django-rendered
+// pages reload even when Vite's built-in HTML path matching does not apply.
 const djangoTemplateReload = (): Plugin => ({
   name: "django-template-reload",
-  handleHotUpdate({ file, server }) {
-    if (file.endsWith(".html")) {
-      server.ws.send({ type: "full-reload" });
-      return [];
-    }
+  handleHotUpdate: {
+    order: "pre",
+    handler({ file, server }) {
+      if (file.endsWith(".html")) {
+        server.environments.client.hot.send({
+          type: "custom",
+          event: "django-template-reload",
+        });
+        return [];
+      }
+    },
   },
 });
 
 export default defineConfig({
   base: "/static/vite/",
-  plugins: [tailwindcss(), djangoTemplateReload()],
+  plugins: [djangoTemplateReload(), tailwindcss()],
   server: {
     host: "0.0.0.0",
     port: 5173,
@@ -35,6 +42,7 @@ export default defineConfig({
     manifest: "manifest.json",
     rollupOptions: {
       input: {
+        djangoHmr: resolve(__dirname, "src/django-hmr.ts"),
         index: resolve(__dirname, "src/index.css"),
         "encounter-form": resolve(__dirname, "src/encounter-form.ts"),
         modal: resolve(__dirname, "src/modal.ts"),

--- a/src/ludamus/edges/settings.py
+++ b/src/ludamus/edges/settings.py
@@ -93,6 +93,7 @@ MIDDLEWARE = [
     "django.contrib.auth.middleware.AuthenticationMiddleware",
     "django.contrib.messages.middleware.MessageMiddleware",
     "ludamus.inits.RepositoryInjectionMiddleware",
+    "ludamus.inits.middleware.ServiceInjectionMiddleware",
     "ludamus.adapters.web.django.middlewares.RequestContextMiddleware",
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
     "ludamus.adapters.web.django.middlewares.RedirectErrorMiddleware",
@@ -109,13 +110,16 @@ if DEBUG and env.bool("DEBUG_TOOLBAR", default=False):
 
 ROOT_URLCONF = "ludamus.gates.web.django.urls"
 
-_TEMPLATE_LOADERS = [
+_BASE_TEMPLATE_LOADERS = [
     "django.template.loaders.filesystem.Loader",
     "django.template.loaders.app_directories.Loader",
 ]
 
-if IS_PRODUCTION:
-    _TEMPLATE_LOADERS = [("django.template.loaders.cached.Loader", _TEMPLATE_LOADERS)]
+_TEMPLATE_LOADERS: list[str | tuple[str, list[str]]] = (
+    [("django.template.loaders.cached.Loader", _BASE_TEMPLATE_LOADERS)]
+    if IS_PRODUCTION
+    else list(_BASE_TEMPLATE_LOADERS)
+)
 
 TEMPLATES = [
     {

--- a/src/ludamus/edges/settings.py
+++ b/src/ludamus/edges/settings.py
@@ -93,7 +93,6 @@ MIDDLEWARE = [
     "django.contrib.auth.middleware.AuthenticationMiddleware",
     "django.contrib.messages.middleware.MessageMiddleware",
     "ludamus.inits.RepositoryInjectionMiddleware",
-    "ludamus.inits.middleware.ServiceInjectionMiddleware",
     "ludamus.adapters.web.django.middlewares.RequestContextMiddleware",
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
     "ludamus.adapters.web.django.middlewares.RedirectErrorMiddleware",
@@ -110,12 +109,21 @@ if DEBUG and env.bool("DEBUG_TOOLBAR", default=False):
 
 ROOT_URLCONF = "ludamus.gates.web.django.urls"
 
+_TEMPLATE_LOADERS = [
+    "django.template.loaders.filesystem.Loader",
+    "django.template.loaders.app_directories.Loader",
+]
+
+if IS_PRODUCTION:
+    _TEMPLATE_LOADERS = [("django.template.loaders.cached.Loader", _TEMPLATE_LOADERS)]
+
 TEMPLATES = [
     {
         "BACKEND": "django.template.backends.django.DjangoTemplates",
         "DIRS": [BASE_DIR / "templates"],
-        "APP_DIRS": True,
+        "APP_DIRS": False,
         "OPTIONS": {
+            "loaders": _TEMPLATE_LOADERS,
             "context_processors": [
                 "django.template.context_processors.request",
                 "django.template.context_processors.media",

--- a/src/ludamus/templates/base.html
+++ b/src/ludamus/templates/base.html
@@ -106,7 +106,7 @@
                 <div class="flex flex-col sm:flex-row justify-between items-center gap-4 text-sm text-foreground-muted">
                     <p class="text-center sm:text-left">
                         © {% now "Y" %} Radosław Ganczarek.
-                        <a href="https://github.com/fancysnake/ludamus"
+                        <a href="https://github.com/zagrajmy/ludamus"
                            class="hover:underline text-primary">Source code</a>
                         available under BSD-3-Clause license.
                     </p>

--- a/src/ludamus/templates/base.html
+++ b/src/ludamus/templates/base.html
@@ -53,6 +53,7 @@
             })();
         </script>
         {% vite_hmr_client %}
+        {% vite_asset 'src/django-hmr.ts' %}
         <link rel="stylesheet" href="{% vite_asset_url 'src/index.css' %}">
         {% block extra_head %}
         {% endblock extra_head %}
@@ -105,7 +106,7 @@
                 <div class="flex flex-col sm:flex-row justify-between items-center gap-4 text-sm text-foreground-muted">
                     <p class="text-center sm:text-left">
                         © {% now "Y" %} Radosław Ganczarek.
-                        <a href="https://github.com/zagrajmy/ludamus"
+                        <a href="https://github.com/fancysnake/ludamus"
                            class="hover:underline text-primary">Source code</a>
                         available under BSD-3-Clause license.
                     </p>


### PR DESCRIPTION
Vite's built-in `full-reload` only fires when the changed HTML path matches `location.pathname`, so Django-served HTML (`/events/…`, `/encounters/…`) silently ignores it.

- `vite.config.ts`: send a custom HMR event instead of `full-reload`; bump plugin to `handleHotUpdate.order: "pre"` and register `djangoHmr` as a Vite input.
- `django-hmr.ts` (new): listen for the event, call `window.location.reload()`.
- `base.html`: load `django-hmr.ts` after the Vite HMR client.
- `settings.py`: pass \`OPTIONS.loaders\` explicitly so the cached loader only wraps in production (DEBUG must skip the cache or template edits never reach the browser).
- `modal.ts`: skip the Navigation API interceptor for non-\`push\` navigations. The interceptor was hijacking the HMR reload when the URL contained a modal-trigger param (e.g. \`?session=1\`); restricting it to genuine link clicks lets reloads through and keeps the click→modal flow intact.