### PR TITLE
Move component CSS into Tailwind components layer

### DIFF
--- a/src/ludamus/client/src/filters.css
+++ b/src/ludamus/client/src/filters.css
@@ -1,113 +1,115 @@
-.filter-input:hover {
-  border-color: color-mix(in oklch, var(--theme-border) 50%, var(--color-foreground-muted));
-}
+@layer components {
+  .filter-input:hover {
+    border-color: color-mix(in oklch, var(--theme-border) 50%, var(--color-foreground-muted));
+  }
 
-.filter-input:focus {
-  border-color: var(--theme-primary);
-  outline: none;
-  box-shadow: 0 0 0 3px color-mix(in oklch, var(--theme-primary) 12%, transparent);
-}
+  .filter-input:focus {
+    border-color: var(--theme-primary);
+    outline: none;
+    box-shadow: 0 0 0 3px color-mix(in oklch, var(--theme-primary) 12%, transparent);
+  }
 
-.filter-toggle:hover {
-  background-color: var(--color-bg-tertiary);
-  color: var(--color-foreground);
-  border-color: color-mix(in oklch, var(--theme-border) 50%, var(--color-foreground-muted));
-}
+  .filter-toggle:hover {
+    background-color: var(--color-bg-tertiary);
+    color: var(--color-foreground);
+    border-color: color-mix(in oklch, var(--theme-border) 50%, var(--color-foreground-muted));
+  }
 
-.filter-toggle[aria-expanded="true"] {
-  border-color: var(--theme-primary);
-  color: var(--theme-primary);
-  box-shadow: 0 0 0 3px color-mix(in oklch, var(--theme-primary) 8%, transparent);
-}
-
-.filter-badge.is-visible {
-  display: inline-block;
-  animation: filter-chip-in 0.2s ease-out;
-}
-
-.filter-panel {
-  display: grid;
-  grid-template-rows: 0fr;
-  filter: blur(5px);
-  transition: grid-template-rows 120ms cubic-bezier(0.16, 1, 0.3, 1), opacity 150ms ease, filter 150ms ease;
-  opacity: 0;
-}
-
-.filter-panel.is-open {
-  grid-template-rows: 1fr;
-  opacity: 1;
-  filter: blur(0);
-}
-
-.filter-chips-bar {
-  display: none;
-  flex-wrap: wrap;
-  align-items: center;
-  gap: 0.375rem;
-  padding-top: 0.625rem;
-}
-
-.filter-chips-bar.has-chips {
-  display: flex;
-}
-
-.filter-chip {
-  display: inline-flex;
-  align-items: center;
-  gap: 0.375rem;
-  padding: 0.25rem 0.5rem 0.25rem 0.625rem;
-  border-radius: 9999px;
-  font-size: 0.75rem;
-  font-weight: 500;
-  background: linear-gradient(
-      135deg,
-      color-mix(in oklch, var(--theme-primary) 14%, transparent),
-      color-mix(in oklch, var(--theme-primary) 6%, transparent)
-  );
-  color: var(--theme-primary);
-  border: 1px solid color-mix(in oklch, var(--theme-primary) 22%, transparent);
-  animation: filter-chip-in 0.2s ease-out;
-}
-
-.filter-chip button {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  width: 1rem;
-  height: 1rem;
-  border-radius: 9999px;
-  background: color-mix(in oklch, var(--theme-primary) 18%, transparent);
-  color: var(--theme-primary);
-  cursor: pointer;
-  transition: background 0.1s ease;
-  border: 0;
-  padding: 0;
-  font-size: 0.625rem;
-  line-height: 1;
-}
-
-.filter-chip button:hover {
-  background: color-mix(in oklch, var(--theme-primary) 32%, transparent);
-}
-
-.filter-chips-clear {
-  font-size: 0.6875rem;
-  font-weight: 600;
-  color: var(--color-foreground-muted);
-  cursor: pointer;
-  padding: 0.25rem 0.5rem;
-  border-radius: 9999px;
-  transition: color 0.1s ease;
-  border: 0;
-  background: none;
-  margin-left: 0.25rem;
-}
-
-.filter-chips-clear:hover {
+  .filter-toggle[aria-expanded="true"] {
+    border-color: var(--theme-primary);
     color: var(--theme-primary);
+    box-shadow: 0 0 0 3px color-mix(in oklch, var(--theme-primary) 8%, transparent);
+  }
+
+  .filter-badge.is-visible {
+    display: inline-block;
+    animation: filter-chip-in 0.2s ease-out;
+  }
+
+  .filter-panel {
+    display: grid;
+    grid-template-rows: 0fr;
+    filter: blur(5px);
+    transition: grid-template-rows 120ms cubic-bezier(0.16, 1, 0.3, 1), opacity 150ms ease, filter 150ms ease;
+    opacity: 0;
+  }
+
+  .filter-panel.is-open {
+    grid-template-rows: 1fr;
+    opacity: 1;
+    filter: blur(0);
+  }
+
+  .filter-chips-bar {
+    display: none;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 0.375rem;
+    padding-top: 0.625rem;
+  }
+
+  .filter-chips-bar.has-chips {
+    display: flex;
+  }
+
+  .filter-chip {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.375rem;
+    padding: 0.25rem 0.5rem 0.25rem 0.625rem;
+    border-radius: 9999px;
+    font-size: 0.75rem;
+    font-weight: 500;
+    background: linear-gradient(
+        135deg,
+        color-mix(in oklch, var(--theme-primary) 14%, transparent),
+        color-mix(in oklch, var(--theme-primary) 6%, transparent)
+    );
+    color: var(--theme-primary);
+    border: 1px solid color-mix(in oklch, var(--theme-primary) 22%, transparent);
+    animation: filter-chip-in 0.2s ease-out;
+  }
+
+  .filter-chip button {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 1rem;
+    height: 1rem;
+    border-radius: 9999px;
+    background: color-mix(in oklch, var(--theme-primary) 18%, transparent);
+    color: var(--theme-primary);
+    cursor: pointer;
+    transition: background 0.1s ease;
+    border: 0;
+    padding: 0;
+    font-size: 0.625rem;
+    line-height: 1;
+  }
+
+  .filter-chip button:hover {
+    background: color-mix(in oklch, var(--theme-primary) 32%, transparent);
+  }
+
+  .filter-chips-clear {
+    font-size: 0.6875rem;
+    font-weight: 600;
+    color: var(--color-foreground-muted);
+    cursor: pointer;
+    padding: 0.25rem 0.5rem;
+    border-radius: 9999px;
+    transition: color 0.1s ease;
+    border: 0;
+    background: none;
+    margin-left: 0.25rem;
+  }
+
+  .filter-chips-clear:hover {
+    color: var(--theme-primary);
+  }
 }
 
 @keyframes filter-chip-in {
-    from { opacity: 0; transform: scale(0.85); }
-    to { opacity: 1; transform: scale(1); }
+  from { opacity: 0; transform: scale(0.85); }
+  to { opacity: 1; transform: scale(1); }
 }

--- a/src/ludamus/client/src/index.css
+++ b/src/ludamus/client/src/index.css
@@ -340,6 +340,7 @@ a, button {
   border-radius: 40% 60% 55% 45% / 55% 40% 60% 45%;
 }
 
+@layer components {
 .alert {
   border-radius: 0.5rem;
   padding: 1rem;
@@ -450,6 +451,7 @@ a, button {
 
 .card-body {
   padding: 1.5rem;
+}
 }
 
 /* Select dropdown chevron fix */

--- a/src/ludamus/client/src/progressive-blur.css
+++ b/src/ludamus/client/src/progressive-blur.css
@@ -8,42 +8,44 @@
           </div>
    Customize: --pb-start (default 40%)
 */
-.progressive-blur {
-  --pb-start: 40%;
-}
-.progressive-blur::before {
-  content: "";
-  position: absolute;
-  inset: 0;
-  background: var(--pb-image) center/cover;
-  transform: scale(var(--pb-scale, 1));
-  transition: transform 100ms ease-out;
-  z-index: 0;
-}
-.pb-layers {
-  position: absolute;
-  inset: 0;
-  pointer-events: none;
-  transform: scale(var(--pb-scale, 1));
-  transition: transform 100ms ease-out;
-}
-.pb-layer {
-  --band: calc(var(--pb-start) + (var(--i) - 1) * 13.33%);
-  position: absolute;
-  inset: 0;
-  background: var(--pb-image) center/cover;
-  filter: blur(calc(2px * pow(2, var(--i))));
-  mask: linear-gradient(to bottom,
-    transparent calc(var(--band)),
-    black calc(var(--band) + 13.33%),
-    black calc(var(--band) + 26.67%),
-    transparent calc(var(--band) + 40%));
-  z-index: calc(var(--i) + 1);
-}
-/* Last two layers extend to bottom */
-.pb-layer:nth-last-child(-n+2) {
-  mask: linear-gradient(to bottom,
-    transparent calc(var(--band)),
-    black calc(var(--band) + 13.33%),
-    black 100%);
+@layer components {
+  .progressive-blur {
+    --pb-start: 40%;
+  }
+  .progressive-blur::before {
+    content: "";
+    position: absolute;
+    inset: 0;
+    background: var(--pb-image) center/cover;
+    transform: scale(var(--pb-scale, 1));
+    transition: transform 100ms ease-out;
+    z-index: 0;
+  }
+  .pb-layers {
+    position: absolute;
+    inset: 0;
+    pointer-events: none;
+    transform: scale(var(--pb-scale, 1));
+    transition: transform 100ms ease-out;
+  }
+  .pb-layer {
+    --band: calc(var(--pb-start) + (var(--i) - 1) * 13.33%);
+    position: absolute;
+    inset: 0;
+    background: var(--pb-image) center/cover;
+    filter: blur(calc(2px * pow(2, var(--i))));
+    mask: linear-gradient(to bottom,
+      transparent calc(var(--band)),
+      black calc(var(--band) + 13.33%),
+      black calc(var(--band) + 26.67%),
+      transparent calc(var(--band) + 40%));
+    z-index: calc(var(--i) + 1);
+  }
+  /* Last two layers extend to bottom */
+  .pb-layer:nth-last-child(-n+2) {
+    mask: linear-gradient(to bottom,
+      transparent calc(var(--band)),
+      black calc(var(--band) + 13.33%),
+      black 100%);
+  }
 }

--- a/src/ludamus/client/src/tabs.css
+++ b/src/ludamus/client/src/tabs.css
@@ -1,4 +1,4 @@
-@layer base {
+@layer components {
   .tab-list {
     display: flex;
     border-bottom: 1px solid var(--theme-border);

--- a/src/ludamus/client/src/timetable.css
+++ b/src/ludamus/client/src/timetable.css
@@ -1,89 +1,91 @@
-#timetable-calendar {
-  --minute-px: 1px;
-}
+@layer components {
+  #timetable-calendar {
+    --minute-px: 1px;
+  }
 
-.timetable-header-cell {
-  flex: var(--columns) 1 0;
-  min-width: calc(9rem * var(--columns));
-}
+  .timetable-header-cell {
+    flex: var(--columns) 1 0;
+    min-width: calc(9rem * var(--columns));
+  }
 
-.timetable-time-axis,
-.timetable-column {
-  height: calc(var(--grid-extent) * var(--minute-px) + 20px);
-}
+  .timetable-time-axis,
+  .timetable-column {
+    height: calc(var(--grid-extent) * var(--minute-px) + 20px);
+  }
 
-.timetable-time-label,
-.timetable-slot-line {
-  top: calc(var(--offset) * var(--minute-px) + 20px);
-}
+  .timetable-time-label,
+  .timetable-slot-line {
+    top: calc(var(--offset) * var(--minute-px) + 20px);
+  }
 
-.timetable-session {
-  top: calc(var(--offset) * var(--minute-px) + 20px);
-  height: max(20px, calc(var(--duration) * var(--minute-px)));
-  min-height: max(20px, calc(var(--duration) * var(--minute-px)));
-  left: calc(var(--lane-start) + 2px);
-  width: calc(var(--lane-width) - 4px);
-}
+  .timetable-session {
+    top: calc(var(--offset) * var(--minute-px) + 20px);
+    height: max(20px, calc(var(--duration) * var(--minute-px)));
+    min-height: max(20px, calc(var(--duration) * var(--minute-px)));
+    left: calc(var(--lane-start) + 2px);
+    width: calc(var(--lane-width) - 4px);
+  }
 
-.timetable-column.assign-mode-active {
-  cursor: crosshair;
-}
+  .timetable-column.assign-mode-active {
+    cursor: crosshair;
+  }
 
-.timetable-column.assign-mode-active::after {
-  content: '';
-  position: absolute;
-  inset: 0;
-  background: rgb(var(--theme-primary-rgb) / 0.08);
-  pointer-events: none;
-  z-index: 5;
-}
+  .timetable-column.assign-mode-active::after {
+    content: '';
+    position: absolute;
+    inset: 0;
+    background: rgb(var(--theme-primary-rgb) / 0.08);
+    pointer-events: none;
+    z-index: 5;
+  }
 
-.timetable-preferred-slot {
-  position: absolute;
-  left: 0;
-  right: 0;
-  background: rgba(250, 204, 21, 0.28);
-  border-top: 1px dashed rgba(202, 138, 4, 0.7);
-  border-bottom: 1px dashed rgba(202, 138, 4, 0.7);
-  pointer-events: none;
-  z-index: 6;
-}
+  .timetable-preferred-slot {
+    position: absolute;
+    left: 0;
+    right: 0;
+    background: rgba(250, 204, 21, 0.28);
+    border-top: 1px dashed rgba(202, 138, 4, 0.7);
+    border-bottom: 1px dashed rgba(202, 138, 4, 0.7);
+    pointer-events: none;
+    z-index: 6;
+  }
 
-.timetable-session:hover,
-.timetable-session:focus-within {
-  height: auto !important;
-  z-index: 10;
-  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.18);
-  opacity: 1;
-}
+  .timetable-session:hover,
+  .timetable-session:focus-within {
+    height: auto !important;
+    z-index: 10;
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.18);
+    opacity: 1;
+  }
 
-.timetable-session:hover .timetable-session-body,
-.timetable-session:focus-within .timetable-session-body {
-  height: auto;
-  overflow: visible;
-}
+  .timetable-session:hover .timetable-session-body,
+  .timetable-session:focus-within .timetable-session-body {
+    height: auto;
+    overflow: visible;
+  }
 
-.timetable-session:hover .timetable-session-title,
-.timetable-session:focus-within .timetable-session-title,
-.timetable-session:hover .timetable-session-meta,
-.timetable-session:focus-within .timetable-session-meta {
-  white-space: normal;
-  overflow: visible;
-  text-overflow: clip;
-  overflow-wrap: anywhere;
-}
+  .timetable-session:hover .timetable-session-title,
+  .timetable-session:focus-within .timetable-session-title,
+  .timetable-session:hover .timetable-session-meta,
+  .timetable-session:focus-within .timetable-session-meta {
+    white-space: normal;
+    overflow: visible;
+    text-overflow: clip;
+    overflow-wrap: anywhere;
+  }
 
-.timetable-session:hover .timetable-session-meta.hidden,
-.timetable-session:focus-within .timetable-session-meta.hidden {
-  display: block;
-}
+  .timetable-session:hover .timetable-session-meta.hidden,
+  .timetable-session:focus-within .timetable-session-meta.hidden {
+    display: block;
+  }
 
-#session-list.htmx-request,
-#timetable-grid.htmx-request,
-#conflict-panel.htmx-request,
-#left-pane.htmx-request,
-#timetable-content.htmx-request {
-  opacity: 0.6;
-  transition: opacity 120ms;
-  pointer-events: none;
+  #session-list.htmx-request,
+  #timetable-grid.htmx-request,
+  #conflict-panel.htmx-request,
+  #left-pane.htmx-request,
+  #timetable-content.htmx-request {
+    opacity: 0.6;
+    transition: opacity 120ms;
+    pointer-events: none;
+  }
 }

--- a/src/ludamus/templates/chronology/anonymous_manage.html
+++ b/src/ludamus/templates/chronology/anonymous_manage.html
@@ -58,7 +58,7 @@
                         {% icon "calendar-days" class="w-5 h-5" %}
                         <h5 class="font-semibold mb-0">{% translate "Your Enrollments" %}</h5>
                     </div>
-                    <div class="card-body p-0">
+                    <div class="card-body">
                         <div class="divide-y divide-[var(--theme-border)]">
                             {% for enrollment in enrollments %}
                                 <div class="p-4">

--- a/src/ludamus/templates/chronology/event.html
+++ b/src/ludamus/templates/chronology/event.html
@@ -481,7 +481,7 @@
                     {% translate "Got a game you're dying to play? Propose your own session and find players!" %}
                 </p>
                 <a href="{% url 'web:chronology:session-propose' event_slug=event.slug %}"
-                   class="btn btn-primary text-base px-6 py-3 shadow-lg shadow-coral-500/25">
+                   class="btn btn-primary text-base shadow-lg shadow-coral-500/25">
                     {% translate "Propose a session" %}
                 </a>
             </div>
@@ -489,7 +489,7 @@
     {% endif %}
     <!-- Proposals Section (Superuser Only) -->
     {% if user.is_superuser and event.is_proposal_active and pending_sessions %}
-        <div class="card mt-8 border-(--theme-warning)">
+        <div class="card mt-8">
             <div class="px-6 py-4 flex items-center gap-3 bg-(--theme-warning-bg) border-b border-(--theme-warning-light)">
                 <h3 class="text-base font-semibold flex items-center gap-2 text-(--theme-warning-text)">
                     {% icon "clipboard-document-check" class="w-5 h-5" variant="mini" %}
@@ -565,11 +565,11 @@
                                 <td class="py-3 px-4">
                                     <div class="flex flex-col gap-1.5 grow">
                                         <a href="{% url 'web:chronology:session-accept' session_id=pending.pk %}"
-                                           class="btn btn-teal text-xs py-1.5 px-3">
+                                           class="btn btn-teal text-xs">
                                             {% icon "check" class="w-3.5 h-3.5" variant="mini" %} {% translate "Accept" %}
                                         </a>
                                         <a href="?proposal={{ pending.pk }}"
-                                           class="btn btn-secondary text-xs py-1.5 px-3"
+                                           class="btn btn-secondary text-xs"
                                            aria-controls="proposalModal{{ pending.pk }}"
                                            aria-haspopup="dialog">
                                             {% icon "eye" class="w-3.5 h-3.5" variant="mini" %} {% translate "Review" %}
@@ -860,7 +860,7 @@
                                             <div class="flex items-center gap-2">
                                                 {% with user=participation.user %}
                                                     {% if user and user.slug and user.discord_username %}
-                                                        <button class="btn btn-secondary text-xs py-1 px-2 reveal-discord-btn"
+                                                        <button class="btn btn-secondary text-xs reveal-discord-btn"
                                                                 hx-get="{% url 'web:crowd:user-discord-username' user_slug=user.slug %}"
                                                                 hx-swap="outerHTML"
                                                                 hx-trigger="click once">

--- a/src/ludamus/templates/chronology/propose/parts/category.html
+++ b/src/ludamus/templates/chronology/propose/parts/category.html
@@ -41,7 +41,7 @@
                 {% endfor %}
             </div>
             <div class="flex justify-end pt-6">
-                <button type="submit" class="btn btn-primary py-3 px-6">{% translate "Continue" %} →</button>
+                <button type="submit" class="btn btn-primary">{% translate "Continue" %} →</button>
             </div>
         </form>
     {% endif %}

--- a/src/ludamus/templates/chronology/propose/parts/details.html
+++ b/src/ludamus/templates/chronology/propose/parts/details.html
@@ -223,12 +223,12 @@
             </div>
             <div class="flex flex-col-reverse sm:grid sm:grid-cols-2 gap-3 pt-6">
                 <button type="button"
-                        class="btn btn-secondary py-3"
+                        class="btn btn-secondary"
                         hx-post="{% url 'web:chronology:session-propose-timeslots' event_slug=event.slug %}"
                         hx-target="#wizard-content"
                         hx-swap="outerHTML show:#wizard-content:top"
                         hx-vals='{"back": "1"}'>← {% translate "Back" %}</button>
-                <button type="submit" class="btn btn-primary py-3">{% translate "Continue" %} →</button>
+                <button type="submit" class="btn btn-primary">{% translate "Continue" %} →</button>
             </div>
         </form>
     {% elif submitted|default:False %}

--- a/src/ludamus/templates/chronology/propose/parts/personal.html
+++ b/src/ludamus/templates/chronology/propose/parts/personal.html
@@ -111,12 +111,12 @@
         </div>
         <div class="flex flex-col-reverse sm:grid sm:grid-cols-2 gap-3 pt-6">
             <button type="button"
-                    class="btn btn-secondary py-3"
+                    class="btn btn-secondary"
                     hx-post="{% url 'web:chronology:session-propose-category' event_slug=event.slug %}"
                     hx-target="#wizard-content"
                     hx-swap="outerHTML show:#wizard-content:top"
                     hx-vals='{"back": "1"}'>← {% translate "Back" %}</button>
-            <button type="submit" class="btn btn-primary py-3">{% translate "Continue" %} →</button>
+            <button type="submit" class="btn btn-primary">{% translate "Continue" %} →</button>
         </div>
     </form>
 </div>

--- a/src/ludamus/templates/chronology/propose/parts/review.html
+++ b/src/ludamus/templates/chronology/propose/parts/review.html
@@ -166,12 +166,12 @@
             {% csrf_token %}
             <div class="flex flex-col-reverse sm:grid sm:grid-cols-2 gap-3 pt-6">
                 <button type="button"
-                        class="btn btn-secondary py-3"
+                        class="btn btn-secondary"
                         hx-post="{% url 'web:chronology:session-propose-details' event_slug=event.slug %}"
                         hx-target="#wizard-content"
                         hx-swap="outerHTML show:#wizard-content:top"
                         hx-vals='{"back": "1"}'>← {% translate "Back" %}</button>
-                <button type="submit" class="btn btn-primary py-3">{% translate "Submit Proposal" %}</button>
+                <button type="submit" class="btn btn-primary">{% translate "Submit Proposal" %}</button>
             </div>
         </form>
     {% endif %}

--- a/src/ludamus/templates/chronology/propose/parts/timeslots.html
+++ b/src/ludamus/templates/chronology/propose/parts/timeslots.html
@@ -33,12 +33,12 @@
             </div>
             <div class="flex flex-col-reverse sm:grid sm:grid-cols-2 gap-3 pt-6">
                 <button type="button"
-                        class="btn btn-secondary py-3"
+                        class="btn btn-secondary"
                         hx-post="{% url 'web:chronology:session-propose-personal' event_slug=event.slug %}"
                         hx-target="#wizard-content"
                         hx-swap="outerHTML show:#wizard-content:top"
                         hx-vals='{"back": "1"}'>← {% translate "Back" %}</button>
-                <button type="submit" class="btn btn-primary py-3">{% translate "Continue" %} →</button>
+                <button type="submit" class="btn btn-primary">{% translate "Continue" %} →</button>
             </div>
         </form>
     {% elif submitted|default:False %}

--- a/src/ludamus/templates/components/encounter_card.html
+++ b/src/ludamus/templates/components/encounter_card.html
@@ -42,7 +42,7 @@
     </a>
     {% if is_mine %}
         <button type="button"
-                class="encounter-copy-link btn btn-secondary w-full rounded-none rounded-b-2xl border-0 border-t border-border text-foreground-muted text-sm py-2.5"
+                class="encounter-copy-link btn btn-secondary w-full text-sm"
                 data-url="/e/{{ encounter.share_code }}/"
                 data-copied-text="{% translate "Copied!" %}">
             {% icon "link" class="h-4 w-4 flex-shrink-0" %}

--- a/src/ludamus/templates/crowd/user/avatar.html
+++ b/src/ludamus/templates/crowd/user/avatar.html
@@ -22,7 +22,7 @@
                     {% csrf_token %}
                     <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
                         <label for="avatar-auth0" class="cursor-pointer">
-                            <div class="card h-full {% if not user.use_gravatar %}border-primary ring-1 ring-primary{% endif %}">
+                            <div class="card h-full {% if not user.use_gravatar %}ring-1 ring-primary{% endif %}">
                                 <div class="card-body text-center flex flex-col items-center gap-3">
                                     <img src="{{ user.avatar_url }}"
                                          alt="{% translate "Provider avatar" %}"
@@ -43,7 +43,7 @@
                             </div>
                         </label>
                         <label for="avatar-gravatar" class="cursor-pointer">
-                            <div class="card h-full {% if user.use_gravatar %}border-[var(--theme-primary)] ring-1 ring-[var(--theme-primary)]{% endif %}">
+                            <div class="card h-full {% if user.use_gravatar %}ring-1 ring-[var(--theme-primary)]{% endif %}">
                                 <div class="card-body text-center flex flex-col items-center gap-3">
                                     <img src="{{ gravatar_url }}"
                                          alt="Gravatar"

--- a/src/ludamus/templates/crowd/user/parts/discord_username.html
+++ b/src/ludamus/templates/crowd/user/parts/discord_username.html
@@ -2,7 +2,7 @@
 {% if discord_username %}
     <span class="inline-flex items-center gap-1.5 text-sm">
         <code class="text-foreground">@{{ discord_username }}</code>
-        <button class="btn btn-secondary text-xs py-0.5 px-1.5 copy-discord"
+        <button class="btn btn-secondary text-xs copy-discord"
                 data-discord="@{{ discord_username }}"
                 title="{% translate "Copy to clipboard" %}"
                 onclick="navigator.clipboard.writeText(this.dataset.discord)">

--- a/src/ludamus/templates/notice_board/_rsvp_inline.html
+++ b/src/ludamus/templates/notice_board/_rsvp_inline.html
@@ -1,6 +1,6 @@
 {% load i18n tessera %}
 {% if not is_creator and not is_full and not user_has_rsvpd %}
-    <div class="card border-primary/30">
+    <div class="card">
         <div class="card-body p-5">
             {% if user.is_authenticated %}
                 <form method="post"
@@ -26,7 +26,7 @@
                     <div class="grid grid-cols-2 gap-2">
                         <div class="relative calendar-menu-wrapper">
                             <button type="button"
-                                    class="btn btn-teal text-sm w-full py-2 calendar-toggle-btn">
+                                    class="btn btn-teal text-sm w-full calendar-toggle-btn">
                                 {% icon "calendar" class="h-5 w-5" variant="mini" %}
                                 {% translate "Add to calendar" %}
                             </button>
@@ -44,7 +44,7 @@
                             </div>
                         </div>
                         <button type="button"
-                                class="btn btn-secondary text-sm w-full py-2 rsvp-copy-details"
+                                class="btn btn-secondary text-sm w-full rsvp-copy-details"
                                 data-title="{{ encounter.title }}{% if encounter.game %} — {{ encounter.game }}{% endif %}"
                                 data-time="{{ encounter.start_time|date:'DATE_FORMAT' }}, {{ encounter.start_time|time:'TIME_FORMAT' }}"
                                 data-place="{{ encounter.place }}"
@@ -64,7 +64,7 @@
         </div>
     </div>
 {% elif not is_creator and user_has_rsvpd %}
-    <div class="card border-[var(--theme-success-light)]">
+    <div class="card">
         <div class="card-body py-4">
             <div class="flex items-center justify-center gap-2 text-[var(--theme-success-base)]">
                 {% icon "check-circle" class="h-5 w-5" %}
@@ -76,7 +76,7 @@
                 <div class="grid grid-cols-2 gap-2">
                     <div class="relative calendar-menu-wrapper">
                         <button type="button"
-                                class="btn btn-teal text-sm w-full py-2 calendar-toggle-btn">
+                                class="btn btn-teal text-sm w-full calendar-toggle-btn">
                             {% icon "calendar" class="h-5 w-5" variant="mini" %}
                             {% translate "Add to calendar" %}
                         </button>
@@ -94,7 +94,7 @@
                         </div>
                     </div>
                     <button type="button"
-                            class="btn btn-secondary text-sm w-full py-2 rsvp-copy-details"
+                            class="btn btn-secondary text-sm w-full rsvp-copy-details"
                             data-title="{{ encounter.title }}{% if encounter.game %} — {{ encounter.game }}{% endif %}"
                             data-time="{{ encounter.start_time|date:'DATE_FORMAT' }}, {{ encounter.start_time|time:'TIME_FORMAT' }}"
                             data-place="{{ encounter.place }}"

--- a/src/ludamus/templates/notice_board/detail.html
+++ b/src/ludamus/templates/notice_board/detail.html
@@ -39,7 +39,7 @@
     <div class="grid grid-cols-1 lg:grid-cols-3 gap-6 max-w-5xl mx-auto">
         {# ── LEFT COLUMN: "what is this" ── #}
         <div class="lg:col-span-2 space-y-6">
-            <div class="card {% if encounter.header_image %}rounded-t-none{% endif %}">
+            <div class="card">
                 <div class="card-body space-y-4">
                     {% if encounter.header_image %}
                         <div class="relative aspect-[2/1] overflow-hidden rounded-t-2xl -mb-6">
@@ -198,7 +198,7 @@
                         <div>
                             <div class="font-medium text-foreground">{{ creator.full_name|default:creator.name }}</div>
                             {% if creator.discord_username %}
-                                <button class="btn btn-secondary text-xs py-0.5 px-2 mt-1"
+                                <button class="btn btn-secondary text-xs mt-1"
                                         hx-get="{% url 'web:crowd:user-discord-username' user_slug=creator.slug %}"
                                         hx-swap="outerHTML"
                                         hx-trigger="click once">

--- a/src/ludamus/templates/notice_board/landing.html
+++ b/src/ludamus/templates/notice_board/landing.html
@@ -18,9 +18,9 @@
         </p>
         <div class="mt-6 flex flex-wrap justify-center gap-3">
             <a href="{% url 'web:crowd:auth0:login' %}?screen_hint=signup&next={% url 'web:notice-board:index' %}"
-               class="btn btn-primary text-base px-6 py-2.5">{% translate "Sign up" %}</a>
+               class="btn btn-primary text-base">{% translate "Sign up" %}</a>
             <a href="{% url 'web:crowd:auth0:login' %}?next={% url 'web:notice-board:index' %}"
-               class="btn btn-secondary text-base px-6 py-2.5">{% translate "Log in" %}</a>
+               class="btn btn-secondary text-base">{% translate "Log in" %}</a>
         </div>
     </div>
     <div class="pt-2 pb-4">

--- a/src/ludamus/templates/panel/area-edit.html
+++ b/src/ludamus/templates/panel/area-edit.html
@@ -61,7 +61,7 @@
                 </div>
             </div>
         </form>
-        <div class="card border-danger/20 mt-6">
+        <div class="card mt-6">
             <div class="card-body">
                 <h3 class="text-lg font-semibold text-danger mb-4">{% translate "Danger Zone" %}</h3>
                 <p class="text-sm text-foreground-muted mb-4">{% translate "Deleting an area cannot be undone." %}</p>

--- a/src/ludamus/templates/panel/cfp-edit.html
+++ b/src/ludamus/templates/panel/cfp-edit.html
@@ -141,7 +141,7 @@
                         <span class="text-sm text-foreground-muted">{% translate "min" %}</span>
                         <button type="button"
                                 id="add-duration-btn"
-                                class="btn btn-primary py-1.5 text-sm flex items-center">
+                                class="btn btn-primary text-sm flex items-center">
                             {% icon "plus" class="w-4 h-4 mr-1" %}
                             {% translate "Add" %}
                         </button>

--- a/src/ludamus/templates/panel/parts/timetable-session-list.html
+++ b/src/ludamus/templates/panel/parts/timetable-session-list.html
@@ -11,7 +11,7 @@
 {% if sessions %}
     <div class="space-y-2">
         {% for session in sessions %}
-            <div class="card p-3 cursor-pointer hover:border-primary hover:shadow-sm transition"
+            <div class="card p-3 cursor-pointer transition"
                  data-session-pk="{{ session.pk }}"
                  hx-get="{% url 'panel:timetable-session-detail-part' slug=slug pk=session.pk %}?track={{ filter_track_pk|default:'' }}&category={{ category_pk|default:'' }}&max_duration={{ max_duration_minutes|default:'' }}&search={{ search|urlencode }}"
                  hx-target="#left-pane"


### PR DESCRIPTION
## Summary

Same cascade footgun PR #237 fixed for `modal.css`, applied to the rest of the unlayered class-based CSS.

`.alert` / `.btn` / `.card` / `.icon-btn` (in `index.css`), plus the entire `tabs.css`, `filters.css`, `timetable.css` and `progressive-blur.css`, sat outside any `@layer`. Per the cascade-layers spec, unlayered rules beat layered rules at equal specificity, so utilities like `px-6`, `rounded-none`, `border-danger/20`, etc. were silently ignored when applied to those classes.

This wraps each of those files in `@layer components` so utilities override the defaults as designed.

## Visual preservation

The fix would have made previously-ignored utilities suddenly take effect, changing prod visuals on:
- `/encounters/` landing — Sign up / Log in buttons
- the encounter share-link button at the bottom of "I organize" cards
- the proposal wizard Continue / Back buttons (`py-3`)
- the propose-a-session CTA (`px-6 py-3`)
- the Discord copy buttons in session participants and encounter detail
- the proposal review accept/reject row in the superuser panel
- the avatar selection and Danger Zone cards (border colors)

To keep the rendered HTML identical to prod, drop those utilities at the same time as the layer wrap. Computed-style probe across the public site shows zero diffs vs. main (same property values, just from layered class rules instead of unlayered ones).

## Out of scope

`.btn flex items-center` is left alone in panel templates. `display: inline-flex` (from `.btn`) becomes `display: flex` (from utility) after the wrap; both render identically inside flex parents, which is every usage I checked. Cleaning those up would touch ~30 panel templates with zero visual benefit, so it can wait.

## Test plan

- [ ] Visual diff `/`, `/encounters/`, `/chronology/event/<slug>/`, `/design/` against main — confirmed pixel-identical
- [ ] Walk the propose-session wizard back/forward
- [ ] Confirm "I organize" encounter card share button still renders flush at bottom (button keeps the .btn-secondary border + 0.75rem corners on top, since utilities used to override that no longer apply)
- [ ] Spot-check Danger Zone in panel area-edit (border returns to default theme-border instead of danger/20)