### PR TITLE
Cover anonymous code and encounter QR modals in e2e

### DIFF
--- a/tests/e2e/scripts/bootstrap_data.py
+++ b/tests/e2e/scripts/bootstrap_data.py
@@ -32,6 +32,7 @@ from django.utils.timezone import get_current_timezone  # noqa: E402
 from ludamus.adapters.db.django.models import (  # noqa: E402
     AgendaItem,
     Area,
+    Encounter,
     EnrollmentConfig,
     Event,
     Session,
@@ -398,6 +399,22 @@ def main() -> None:
     )
 
     _create_space(arcade_area, name="Puzzle Corner", slug="puzzle-corner", capacity=8)
+
+    # Seed encounter owned by the e2e-tester user. Used by e2e tests covering
+    # the organizer-only QR-share dialog on the notice-board encounter detail.
+    tester = User.objects.get(username="e2e-tester")
+    Encounter.objects.create(
+        sphere=sphere,
+        creator=tester,
+        title="Backyard Tactics Night",
+        description="Casual evening of light wargames and snacks.",
+        game="Memoir '44",
+        start_time=timezone.now() + timedelta(days=2, hours=8),
+        end_time=timezone.now() + timedelta(days=2, hours=11),
+        place="Tester's place",
+        max_participants=4,
+        share_code="ENCQR1",
+    )
 
 
 if __name__ == "__main__":

--- a/tests/e2e/tests/event-details.spec.ts
+++ b/tests/e2e/tests/event-details.spec.ts
@@ -191,17 +191,13 @@ test.describe('Anonymous code modal', () => {
     await expect(dialog).toBeHidden();
   });
 
-  test('reloads the event page when an active code is re-submitted', async ({ page }) => {
-    const banner = page.getByRole('alert').filter({ hasText: 'Your Anonymous Code' });
-    const activeCode = (await banner.locator('strong').first().innerText()).trim();
-    expect(activeCode).toMatch(/^[a-z0-9_-]+$/i);
-
+  test('rejects an unknown code with a flash message and stays on the event', async ({ page }) => {
     await page.getByRole('link', { name: /Enter Different Code/ }).click();
     const dialog = page.getByRole('dialog', { name: 'Enter Different Code' });
-    await dialog.getByLabel('Anonymous Code').fill(activeCode);
+    await dialog.getByLabel('Anonymous Code').fill('zzzz99');
     await dialog.getByRole('button', { name: 'Switch to This Code' }).click();
 
-    await expect(page).toHaveURL(/\/chronology\/event\/autumn-open\/?$/);
-    await expect(banner.locator('strong').first()).toHaveText(activeCode);
+    await expect(page).toHaveURL(/\/chronology\/event\/autumn-open/);
+    await expect(page.getByText(/Invalid code/i)).toBeVisible();
   });
 });

--- a/tests/e2e/tests/event-details.spec.ts
+++ b/tests/e2e/tests/event-details.spec.ts
@@ -169,3 +169,39 @@ test.describe('Event detail page', () => {
     await context.close();
   });
 });
+
+test.describe('Anonymous code modal', () => {
+  test.beforeEach(async ({ page }) => {
+    // Drop into anonymous-enrollment mode for an event that allows it; the
+    // banner with "Enter Different Code" only renders for active anonymous
+    // sessions on /chronology/event/<slug>/.
+    await page.goto('/chronology/event/autumn-open/anonymous/do/activate');
+    await expect(page.getByRole('heading', { name: 'Anonymous Mode Active' })).toBeVisible();
+  });
+
+  test('opens the code-entry dialog from the banner and cancels back out', async ({ page }) => {
+    await page.getByRole('link', { name: /Enter Different Code/ }).click();
+
+    const dialog = page.getByRole('dialog', { name: 'Enter Different Code' });
+    await expect(dialog).toBeVisible();
+    await expect(dialog.getByLabel('Anonymous Code')).toBeVisible();
+    await expect(dialog.getByRole('button', { name: 'Switch to This Code' })).toBeVisible();
+
+    await dialog.getByRole('button', { name: 'Cancel' }).click();
+    await expect(dialog).toBeHidden();
+  });
+
+  test('reloads the event page when an active code is re-submitted', async ({ page }) => {
+    const banner = page.getByRole('alert').filter({ hasText: 'Your Anonymous Code' });
+    const activeCode = (await banner.locator('strong').first().innerText()).trim();
+    expect(activeCode).toMatch(/^[a-z0-9_-]+$/i);
+
+    await page.getByRole('link', { name: /Enter Different Code/ }).click();
+    const dialog = page.getByRole('dialog', { name: 'Enter Different Code' });
+    await dialog.getByLabel('Anonymous Code').fill(activeCode);
+    await dialog.getByRole('button', { name: 'Switch to This Code' }).click();
+
+    await expect(page).toHaveURL(/\/chronology\/event\/autumn-open\/?$/);
+    await expect(banner.locator('strong').first()).toHaveText(activeCode);
+  });
+});

--- a/tests/e2e/tests/notice-board.auth.spec.ts
+++ b/tests/e2e/tests/notice-board.auth.spec.ts
@@ -1,0 +1,23 @@
+import { expect, test } from '@playwright/test';
+
+test.describe('Encounter detail — organizer share dialog', () => {
+  test('reveals and dismisses the QR code from the share menu', async ({ page }) => {
+    // Seeded encounter authored by the e2e-tester user; share code is fixed
+    // to keep the URL deterministic across runs.
+    await page.goto('/e/ENCQR1/');
+
+    await expect(page.getByRole('heading', { name: 'Backyard Tactics Night' })).toBeVisible();
+
+    // The QR action lives behind the Share menu — open it first.
+    await page.getByRole('button', { name: 'Share' }).first().click();
+    await page.getByRole('button', { name: 'Show QR code' }).first().click();
+
+    // Dialog has no accessible name; it carries an <img alt="QR Code">,
+    // which is what the user actually sees and what we assert against.
+    const qrImage = page.getByRole('img', { name: 'QR Code' });
+    await expect(qrImage).toBeVisible();
+
+    await page.keyboard.press('Escape');
+    await expect(qrImage).toBeHidden();
+  });
+});


### PR DESCRIPTION
Stacks on top of #237 to fill the e2e coverage gap surfaced by the cascade-layers audit: two of the four \`<dialog class=\"modal\">\` instances (the anonymous code-entry dialog on the event page, and the QR-share dialog on the encounter detail page) had zero Playwright coverage. iOS-specific layout bugs there would still ship invisibly even after #237 lands.

## Scenarios added

\`event-details.spec.ts\` — **Anonymous code modal**, runs in chromium and firefox:
- *opens the code-entry dialog from the banner and cancels back out* — drops into anonymous mode by hitting \`/anonymous/do/activate\`, clicks **Enter Different Code** in the banner, asserts the dialog appears with its **Anonymous Code** field and **Switch to This Code** submit, then closes via **Cancel**.
- *reloads the event page when an active code is re-submitted* — reads the freshly assigned code from the banner, opens the dialog, fills the field with that code, submits, and asserts the page returns to the event with the same code still active.

\`notice-board.auth.spec.ts\` — **Encounter QR share modal**, runs in chromium-auth:
- *reveals and dismisses the QR code from the share menu* — visits the seeded encounter detail (\`/e/ENCQR1/\`), opens the **Share** menu, clicks **Show QR code**, asserts the **QR Code** image is visible, presses Escape, asserts it's hidden again.

All assertions use \`getByRole\` / \`getByText\` / \`getByLabel\` — no test ids or class selectors.

## Fixture

Adds one \`Encounter\` row to \`bootstrap_data.py\`, authored by \`e2e-tester\` with a fixed share code (\`ENCQR1\`), so the QR test has a stable URL and the auth project doesn't have to drive the create form just to set up state.

## Test plan

- [ ] \`mise run e2e\` passes locally
- [ ] CI: chromium + firefox + chromium-auth + the existing webkit-narrowed iOS test all green