### PR TITLE
Document tessera reusable components on /design/

### DIFF
--- a/src/ludamus/adapters/web/django/design_fixtures.py
+++ b/src/ludamus/adapters/web/django/design_fixtures.py
@@ -2,6 +2,7 @@
 
 from datetime import UTC, datetime, timedelta
 
+from django import forms
 from django.contrib.staticfiles.storage import staticfiles_storage
 
 from ludamus.gates.web.django.entities import UserInfo
@@ -78,6 +79,28 @@ def _mock_field_values() -> list[SessionFieldValueDTO]:
             value=["horror", "violence"],
         ),
     ]
+
+
+def mock_user() -> UserInfo:
+    return _mock_user("Alex Designer", pk=1, slug="alex-designer", username="alex")
+
+
+class _MockTesseraForm(forms.Form):
+    name = forms.CharField(label="Name", max_length=64, required=True)
+    email = forms.EmailField(label="Email", required=False)
+    bio = forms.CharField(
+        label="Bio", widget=forms.Textarea(attrs={"rows": 3}), required=False
+    )
+    color = forms.ChoiceField(
+        label="Color",
+        choices=[("", "Pick one…"), ("r", "Red"), ("g", "Green"), ("b", "Blue")],
+        required=False,
+    )
+    subscribe = forms.BooleanField(label="Subscribe to updates", required=False)
+
+
+def mock_form() -> forms.Form:
+    return _MockTesseraForm()
 
 
 def mock_event_info() -> EventInfo:

--- a/src/ludamus/adapters/web/django/views.py
+++ b/src/ludamus/adapters/web/django/views.py
@@ -78,7 +78,13 @@ from ludamus.pacts import (
     VenueDTO,
 )
 
-from .design_fixtures import mock_event_info, mock_session_data, mock_session_data_ended
+from .design_fixtures import (
+    mock_event_info,
+    mock_form,
+    mock_session_data,
+    mock_session_data_ended,
+    mock_user,
+)
 from .forms import (
     ConnectedUserForm,
     UserForm,
@@ -440,6 +446,8 @@ class DesignPageView(TemplateView):
         context["design_event"] = mock_event_info()
         context["design_session_data"] = mock_session_data()
         context["design_session_data_ended"] = mock_session_data_ended()
+        context["design_user"] = mock_user()
+        context["design_form"] = mock_form()
         context["design_radio_options"] = [
             ("a", "Radio A", True, "design-radio-a"),
             ("b", "Radio B", False, "design-radio-b"),

--- a/src/ludamus/templates/design.html
+++ b/src/ludamus/templates/design.html
@@ -39,6 +39,53 @@
             </div>
         </div>
         <div class="relative bg-background pt-12 px-8 pb-8 min-h-48 flex items-center justify-center">
+            <code class="absolute top-3 left-3 text-xs text-foreground-muted">{% templatetag openblock %} icon {% templatetag closeblock %}</code>
+            <div class="flex flex-wrap items-center justify-center gap-3 text-foreground">
+                {% icon "calendar" class="w-4 h-4" %}
+                {% icon "calendar" class="w-5 h-5" %}
+                {% icon "calendar" class="w-6 h-6" %}
+                {% icon "calendar" variant="solid" class="w-5 h-5" %}
+                {% icon "calendar" variant="mini" class="w-5 h-5" %}
+                {% icon "calendar" variant="micro" class="w-4 h-4" %}
+            </div>
+        </div>
+        <div class="relative bg-background pt-12 px-8 pb-8 min-h-48 flex items-center justify-center">
+            <code class="absolute top-3 left-3 text-xs text-foreground-muted">.card</code>
+            <div class="card w-full max-w-xs">
+                <div class="card-header">
+                    <h3 class="font-semibold text-foreground">Card title</h3>
+                </div>
+                <div class="card-body">
+                    <p class="text-sm text-foreground-secondary">Contained section, used in panel pages.</p>
+                </div>
+            </div>
+        </div>
+        <div class="relative bg-background pt-12 px-8 pb-8 min-h-48 flex items-center justify-center sm:col-span-2 lg:col-span-3">
+            <code class="absolute top-3 left-3 text-xs text-foreground-muted">.alert</code>
+            <div class="w-full max-w-2xl flex flex-col gap-2">
+                <div class="alert alert-success flex items-start">
+                    {% icon "check-circle" class="w-5 h-5 mr-3 flex-shrink-0" %}
+                    <span>Saved successfully.</span>
+                </div>
+                <div class="alert alert-warning flex items-start">
+                    {% icon "exclamation-triangle" class="w-5 h-5 mr-3 flex-shrink-0" %}
+                    <span>Heads up — this action is permanent.</span>
+                </div>
+                <div class="alert alert-error flex items-start">
+                    {% icon "x-circle" class="w-5 h-5 mr-3 flex-shrink-0" %}
+                    <span>Something went wrong.</span>
+                </div>
+                <div class="alert alert-info flex items-start">
+                    {% icon "information-circle" class="w-5 h-5 mr-3 flex-shrink-0" %}
+                    <span>For your information.</span>
+                </div>
+                <div class="alert alert-default flex items-start">
+                    {% icon "information-circle" class="w-5 h-5 mr-3 flex-shrink-0" %}
+                    <span>Neutral notice.</span>
+                </div>
+            </div>
+        </div>
+        <div class="relative bg-background pt-12 px-8 pb-8 min-h-48 flex items-center justify-center">
             <code class="absolute top-3 left-3 text-xs text-foreground-muted">text-field.html</code>
             <div class="w-full max-w-xs">
                 {% include "components/text-field.html" with id="t-text" name="t-text" placeholder="Placeholder" required=False value="" only %}
@@ -68,12 +115,36 @@
             <code class="absolute top-3 left-3 text-xs text-foreground-muted">choice-group.html</code>
             {% include "components/choice-group.html" with input_type="radio" name="t-radio" options=design_radio_options only %}
         </div>
+        <div class="relative bg-background pt-12 px-8 pb-8 min-h-48 flex items-center justify-center sm:col-span-2">
+            <code class="absolute top-3 left-3 text-xs text-foreground-muted">file-dropzone.html</code>
+            <div class="w-full max-w-md">
+                {% include "components/file-dropzone.html" with id="t-file" name="t-file" required=False accept="image/*" has_errors=False initial_url="" initial_name="" dropzone_state="empty" only %}
+            </div>
+        </div>
         <div class="relative bg-background pt-12 px-8 pb-8 min-h-48 flex items-center justify-center">
             <code class="absolute top-3 left-3 text-xs text-foreground-muted">{% templatetag openblock %} tabs {% templatetag closeblock %}</code>
             {% tabs %}
             {% tab "a" icon="user" href="#" active=True %}One{% end_tab %}
             {% tab "b" icon="users" href="#" %}Two{% end_tab %}
         {% end_tabs %}
+    </div>
+    <div class="relative bg-background pt-12 px-8 pb-8 min-h-48 flex items-center justify-center">
+        <code class="absolute top-3 left-3 text-xs text-foreground-muted">visibility-*</code>
+        <div class="w-full flex flex-col gap-3 text-sm">
+            <div class="flex items-center gap-2">
+                <span class="text-foreground-muted text-xs">badge:</span>
+                {% include "components/visibility-badge.html" with is_public=True %}
+                {% include "components/visibility-badge.html" with is_public=False %}
+            </div>
+            <div class="flex items-center gap-2">
+                <span class="text-foreground-muted text-xs">icon:</span>
+                {% include "components/visibility-icon.html" with is_public=True %}
+                {% include "components/visibility-icon.html" with is_public=False %}
+            </div>
+            {% include "components/visibility-header.html" with is_public=True is_first=True %}
+            {% include "components/visibility-header.html" with is_public=False %}
+            {% include "components/visibility-legend.html" %}
+        </div>
     </div>
     <div class="relative bg-background pt-12 px-8 pb-8 min-h-48 flex items-center justify-center sm:col-span-2 lg:col-span-3">
         <code class="absolute top-3 left-3 text-xs text-foreground-muted">event_card.html</code>

--- a/src/ludamus/templates/design.html
+++ b/src/ludamus/templates/design.html
@@ -50,6 +50,15 @@
             </div>
         </div>
         <div class="relative bg-background pt-12 px-8 pb-8 min-h-48 flex items-center justify-center">
+            <code class="absolute top-3 left-3 text-xs text-foreground-muted">avatar.html</code>
+            <div class="flex items-end justify-center gap-3">
+                {% include "components/avatar.html" with user=design_user size="size-6" %}
+                {% include "components/avatar.html" with user=design_user %}
+                {% include "components/avatar.html" with user=design_user size="size-12" %}
+                {% include "components/avatar.html" with user=design_user size="size-16" %}
+            </div>
+        </div>
+        <div class="relative bg-background pt-12 px-8 pb-8 min-h-48 flex items-center justify-center">
             <code class="absolute top-3 left-3 text-xs text-foreground-muted">.card</code>
             <div class="card w-full max-w-xs">
                 <div class="card-header">
@@ -120,6 +129,10 @@
             <div class="w-full max-w-md">
                 {% include "components/file-dropzone.html" with id="t-file" name="t-file" required=False accept="image/*" has_errors=False initial_url="" initial_name="" dropzone_state="empty" only %}
             </div>
+        </div>
+        <div class="relative bg-background pt-12 px-8 pb-8 min-h-48 flex items-center justify-center sm:col-span-2 lg:col-span-3">
+            <code class="absolute top-3 left-3 text-xs text-foreground-muted">{% templatetag openblock %} tessera_form {% templatetag closeblock %}</code>
+            <div class="w-full max-w-xl">{% tessera_form design_form %}</div>
         </div>
         <div class="relative bg-background pt-12 px-8 pb-8 min-h-48 flex items-center justify-center">
             <code class="absolute top-3 left-3 text-xs text-foreground-muted">{% templatetag openblock %} tabs {% templatetag closeblock %}</code>

--- a/tests/integration/web/test_design_page.py
+++ b/tests/integration/web/test_design_page.py
@@ -264,6 +264,8 @@ class TestDesignPageView:
                 "design_event": _expected_event_info(),
                 "design_session_data": _expected_session_data(),
                 "design_session_data_ended": _expected_session_data_ended(),
+                "design_user": _make_presenter(),
+                "design_form": ANY,
                 "design_radio_options": [
                     ("a", "Radio A", True, "design-radio-a"),
                     ("b", "Radio B", False, "design-radio-b"),


### PR DESCRIPTION
## Summary

Adds tiles to the Tessera design page for reusable components that were missing from the showcase. Filtered to design-system primitives, skipping page-chrome / domain widgets (login_button, theme_switcher, encounter_card) and decorative CSS (gradient-border, live-dot, blob).

**New tiles:**
- `.alert` — all 5 variants (success/warning/error/info/default)
- `.card` — header + body
- `{% icon %}` — sizes + heroicon variants (outline/solid/mini/micro)
- `avatar.html` — 4 sizes
- `file-dropzone.html` — empty state
- `visibility-*` — badge / icon / header / legend in both is_public states
- `tessera_form` — full form macro rendering (text, email, textarea, select, checkbox)

Two new context fixtures: `mock_user()` and `mock_form()` (a tiny `_MockTesseraForm`). Integration test asserts `design_user` exactly and `design_form` via `ANY` (form, per project rule).

## Screenshot (after)

![/design/ on tessera-docs](https://files.catbox.moe/2xlcho.png)

## Test plan

- [x] `mise run check` clean (black, ruff, codespell, mypy, djlint, pylint, vulture, ast-grep, impeccable, contracts)
- [x] Full integration suite (`mise run _pytest tests/integration/web/`) — 1142 passed
- [x] Visual: `/design/` renders all new tiles correctly in dev
- [ ] e2e smoke (`tests/e2e/tests/design.spec.ts`) — title + first button assertions still hold