### PR TITLE
Fix two Firefox e2e flakes in panel.spec.ts

### DIFF
--- a/tests/e2e/tests/panel.spec.ts
+++ b/tests/e2e/tests/panel.spec.ts
@@ -74,8 +74,11 @@ test.describe.configure({ mode: 'serial' });
 
 test.describe('Backoffice Panel', () => {
   test.beforeEach(async ({ page }) => {
-    // Log in via Django admin as the manager user
-    await page.goto('/admin/login/');
+    // Log in via Django admin as the manager user.
+    // Use domcontentloaded — the login form is interactable at DCL and
+    // Firefox occasionally never fires `load` for this page, hanging the
+    // default goto until the test timeout (CI run 25398374365).
+    await page.goto('/admin/login/', { waitUntil: 'domcontentloaded' });
     await page.getByLabel('Username:').fill('e2e-manager');
     await page.getByLabel('Password:').fill('e2e-manager-123');
     await page.getByRole('button', { name: /Log in/i }).click();
@@ -714,7 +717,10 @@ test.describe('Backoffice Panel', () => {
   });
 
   test('creates and manages a session field', async ({ page }, testInfo) => {
-    const fieldName = `Game System ${testInfo.project.name}`;
+    // Suffix with retry index so retries after a half-completed attempt do
+    // not collide with leftover rows and trip strict-mode locator matches.
+    const retrySuffix = testInfo.retry === 0 ? '' : `-r${testInfo.retry}`;
+    const fieldName = `Game System ${testInfo.project.name}${retrySuffix}`;
     await page.goto(
       '/panel/event/autumn-open/cfp/session-fields/',
     );


### PR DESCRIPTION
## Summary

Two flakes seen in CI run [25398374365](https://github.com/zagrajmy/ludamus/actions/runs/25398374365) on `main`:

1. **`beforeEach` login `goto` hangs on Firefox.** The Playwright trace shows all 8 resources for `/admin/login/` completing in under 150 ms, but Firefox's `load` event never fires, so `page.goto` (default `waitUntil: 'load'`) blocks until the 120 s test timeout. Switching to `waitUntil: 'domcontentloaded'` is sufficient — the form is interactable at DCL.

2. **`creates and manages a session field` strict-mode violation on retry.** `fieldName` is hard-coded as `Game System ${project.name}`. When a prior attempt half-completes (creates the field but fails before delete), the retry creates a second row with the same name and `getByRole('cell', { name: /Game System firefox/ })` resolves to two elements. Suffixing with `testInfo.retry` makes retries collision-free.

## Test plan

- [x] Trace from the failing CI run matches the diagnosis (artifact 6816071418, traces `b7c8…` for #1 and `19d3…` for #2).
- [x] CI run on this PR is green for chromium + firefox + webkit.
- [x] Spot-check: panel.spec.ts still logs in correctly on chromium locally.

## Notes

Did not touch `panel.spec.ts:570` (also flaky in the failing run) because it shares the same `beforeEach` and is fixed transitively by change #1. If it still flakes after this lands, treat it as a separate issue.