### PR TITLE
set up portless for git worktrees

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -5,7 +5,7 @@ PYTHONPATH=src
 DJANGO_SETTINGS_MODULE=ludamus.edges.settings
 
 # Domains
-ALLOWED_HOSTS=.localhost
+ALLOWED_HOSTS=.localhost,127.0.0.1,localhost
 ROOT_DOMAIN=localhost:8000
 SESSION_COOKIE_DOMAIN=.localhost
 

--- a/Procfile.dev
+++ b/Procfile.dev
@@ -1,2 +1,2 @@
-django: django-admin runserver --insecure
+django: django-admin runserver --insecure 0.0.0.0:${PORT:-8000}
 vite: cd src/ludamus/client && npm run dev

--- a/mise.toml
+++ b/mise.toml
@@ -246,7 +246,7 @@ run = "lsof -ti :8000 | xargs kill -9 2>/dev/null; lsof -ti :5173 | xargs kill -
 
 [tasks.ts-check]
 description = "Type-check frontend TypeScript"
-run = "cd src/ludamus/client && npm typecheck"
+run = "cd src/ludamus/client && npm run typecheck"
 
 
 [tasks.npm]

--- a/scripts/dev
+++ b/scripts/dev
@@ -1,0 +1,103 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+port=""
+use_portless="1"
+use_lan="0"
+do_trust="0"
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    -p|--port)
+      shift
+      port="${1:-}"
+      if [ -z "$port" ]; then
+        echo "missing port after -p/--port" >&2
+        exit 2
+      fi
+      ;;
+    --lan)
+      use_lan="1"
+      ;;
+    --trust)
+      do_trust="1"
+      ;;
+    --portless)
+      use_portless="1"
+      ;;
+    --no-portless)
+      use_portless="0"
+      ;;
+    --)
+      shift
+      break
+      ;;
+    *)
+      echo "unknown arg: $1" >&2
+      exit 2
+      ;;
+  esac
+  shift
+done
+
+if [ -n "$port" ]; then
+  export PORTLESS_APP_PORT="$port"
+fi
+
+if [ "${PORT:-}" != "" ]; then
+  export PORTLESS_APP_PORT="${PORT}"
+fi
+
+if [ "${VITE_PORT:-}" = "" ]; then
+  export VITE_PORT="$(mise x -- python -c "import socket; s=socket.socket(); s.bind(('127.0.0.1',0)); print(s.getsockname()[1]); s.close()")"
+fi
+
+if [ "$use_portless" = "1" ]; then
+  if [ "$use_lan" = "1" ]; then
+    export PORTLESS_LAN=1
+    if [ "$do_trust" = "1" ]; then
+      sudo -E npx --prefix src/ludamus/client portless trust
+    fi
+
+    exec sudo -E npx --prefix src/ludamus/client portless run --force --name "$(basename "$PWD")" -- bash -lc '
+    if [ "${PORTLESS_URL:-}" = "" ]; then
+      echo "PORTLESS_URL missing" >&2
+      exit 1
+    fi
+
+    root_domain="${PORTLESS_URL#http://}"
+    root_domain="${root_domain#https://}"
+    root_domain="${root_domain%/}"
+
+    export ROOT_DOMAIN="$root_domain"
+    export ALLOWED_HOSTS=".localhost,127.0.0.1,localhost,.local"
+
+    mise x -- python -c "import os; os.environ.setdefault(\"DJANGO_SETTINGS_MODULE\",\"ludamus.edges.settings\"); import django; django.setup(); from django.contrib.sites.models import Site; root_domain=os.environ[\"ROOT_DOMAIN\"]; Site.objects.update_or_create(id=1, defaults={\"domain\": root_domain, \"name\": root_domain})" >/dev/null
+
+    exec honcho start -f Procfile.dev
+  '
+  fi
+
+  export PORTLESS_PORT=1355
+  export PORTLESS_TLD=localhost
+  export PORTLESS_LAN=0
+  export PORTLESS_HTTPS=0
+  exec npx --prefix src/ludamus/client portless run --force --name "$(basename "$PWD")" -- bash -lc '
+    if [ "${PORTLESS_URL:-}" = "" ]; then
+      echo "PORTLESS_URL missing" >&2
+      exit 1
+    fi
+
+    root_domain="${PORTLESS_URL#http://}"
+    root_domain="${root_domain#https://}"
+    root_domain="${root_domain%/}"
+
+    export ROOT_DOMAIN="$root_domain"
+    export ALLOWED_HOSTS=".localhost,127.0.0.1,localhost,.local"
+
+    exec honcho start -f Procfile.dev
+  '
+fi
+
+exec honcho start -f Procfile.dev

--- a/src/ludamus/adapters/web/django/middlewares.py
+++ b/src/ludamus/adapters/web/django/middlewares.py
@@ -39,9 +39,15 @@ class RequestContextMiddleware:
         try:
             current_sphere = sphere_repository.read_by_domain(request.get_host())
         except NotFoundError:
-            url = f"{request.scheme}://{settings.ROOT_DOMAIN}{reverse('web:index')}"
-            messages.error(request, _("Sphere not found"))
-            return HttpResponseRedirect(url)
+            host = request.get_host().split(":", 1)[0]
+            if settings.ENV == "development" and (
+                host == "127.0.0.1" or host.endswith((".localhost", ".local"))
+            ):
+                current_sphere = root_sphere
+            else:
+                url = f"{request.scheme}://{settings.ROOT_DOMAIN}{reverse('web:index')}"
+                messages.error(request, _("Sphere not found"))
+                return HttpResponseRedirect(url)
 
         if hasattr(request, "user") and request.user.is_authenticated:
             request.context = AuthenticatedRequestContext(

--- a/src/ludamus/client/package-lock.json
+++ b/src/ludamus/client/package-lock.json
@@ -16,6 +16,7 @@
         "@tailwindcss/typography": "^0.5.19",
         "@tailwindcss/vite": "^4.2.4",
         "@types/body-scroll-lock": "^3.1.2",
+        "portless": "^0.12.0",
         "postcss-nested": "^7.0.2",
         "prettier": "^3.8.1",
         "prettier-plugin-tailwindcss": "^0.8.0",
@@ -1104,6 +1105,24 @@
       "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/portless": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/portless/-/portless-0.12.0.tgz",
+      "integrity": "sha512-zE8EYJ5xIEtKEBu1wnD+FavOE90/GNxRixF4Mu2hxMvDuVx1ftUbA6VbjbxI9sP9LUt0L26l6OiENGo4EFtLfw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "os": [
+        "darwin",
+        "linux",
+        "win32"
+      ],
+      "bin": {
+        "portless": "dist/cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      }
     },
     "node_modules/postcss": {
       "version": "8.5.11",

--- a/src/ludamus/client/package.json
+++ b/src/ludamus/client/package.json
@@ -17,17 +17,20 @@
     "@tailwindcss/typography": "^0.5.19",
     "@tailwindcss/vite": "^4.2.4",
     "@types/body-scroll-lock": "^3.1.2",
+    "portless": "^0.12.0",
     "postcss-nested": "^7.0.2",
     "prettier": "^3.8.1",
+    "prettier-plugin-tailwindcss": "^0.8.0",
     "tailwindcss": "^4.1.16",
     "typescript": "^5.9.3",
-    "vite": "^8.0.10",
-    "prettier-plugin-tailwindcss": "^0.8.0"
+    "vite": "^8.0.10"
   },
   "dependencies": {
     "body-scroll-lock": "^3.1.5"
   },
   "prettier": {
-    "plugins": ["prettier-plugin-tailwindcss"]
+    "plugins": [
+      "prettier-plugin-tailwindcss"
+    ]
   }
 }

--- a/src/ludamus/client/vite.config.ts
+++ b/src/ludamus/client/vite.config.ts
@@ -34,7 +34,7 @@ export default defineConfig({
     strictPort: true,
     cors: {
       origin:
-        /^https?:\/\/(localhost|127\.0\.0\.1|[a-z0-9-]+\.(localhost|local))(:\d+)?$/,
+        /^https?:\/\/(localhost|127\.0\.0\.1|([a-z0-9-]+\.)+(localhost|local))(:\d+)?$/,
     },
   },
   build: {

--- a/src/ludamus/client/vite.config.ts
+++ b/src/ludamus/client/vite.config.ts
@@ -30,10 +30,11 @@ export default defineConfig({
   plugins: [djangoTemplateReload(), tailwindcss()],
   server: {
     host: "0.0.0.0",
-    port: 5173,
+    port: Number(process.env.VITE_PORT ?? 5173),
     strictPort: true,
     cors: {
-      origin: /^https?:\/\/(localhost|127\.0\.0\.1)(:\d+)?$/,
+      origin:
+        /^https?:\/\/(localhost|127\.0\.0\.1|[a-z0-9-]+\.(localhost|local))(:\d+)?$/,
     },
   },
   build: {

--- a/src/ludamus/edges/settings.py
+++ b/src/ludamus/edges/settings.py
@@ -22,6 +22,7 @@ env = environ.Env(
     ALLOWED_HOSTS=(list, ["localhost"]),
     ROOT_DOMAIN=(str, ""),
     SESSION_COOKIE_DOMAIN=(str, None),
+    VITE_PORT=(int, 5173),
     # Auth0
     AUTH0_CLIENT_ID=(str, ""),
     AUTH0_CLIENT_SECRET=(str, ""),
@@ -427,7 +428,7 @@ DJANGO_VITE = {
     "default": {
         "dev_mode": ENV == "development" or ROOT_DOMAIN == "testserver",
         "dev_server_host": "localhost",
-        "dev_server_port": int(env("VITE_PORT") or 5173),
+        "dev_server_port": env("VITE_PORT"),
         "static_url_prefix": "vite",
         "manifest_path": BASE_DIR / "static" / "vite" / "manifest.json",
     }

--- a/src/ludamus/edges/settings.py
+++ b/src/ludamus/edges/settings.py
@@ -66,6 +66,11 @@ DEBUG = env("DEBUG")
 
 # Parse comma-separated allowed hosts for production
 ALLOWED_HOSTS: list[str] = env("ALLOWED_HOSTS")
+
+# Append localhost and its subdomains for development
+if ENV == "development":
+    ALLOWED_HOSTS.extend([".localhost", ".local", "localhost", "127.0.0.1"])
+
 SESSION_COOKIE_DOMAIN = env("SESSION_COOKIE_DOMAIN") or None
 
 # Application definition
@@ -422,7 +427,7 @@ DJANGO_VITE = {
     "default": {
         "dev_mode": ENV == "development" or ROOT_DOMAIN == "testserver",
         "dev_server_host": "localhost",
-        "dev_server_port": 5173,
+        "dev_server_port": int(env("VITE_PORT") or 5173),
         "static_url_prefix": "vite",
         "manifest_path": BASE_DIR / "static" / "vite" / "manifest.json",
     }

--- a/tasks.toml
+++ b/tasks.toml
@@ -8,11 +8,11 @@ run = "django-admin"
 
 [start]
 description = "Start Django dev server with frontend watch"
-run = "honcho start -f Procfile.dev"
+run = "./scripts/dev"
 
 [dev]
 description = "Start Django dev server with frontend watch"
-run = "honcho start -f Procfile.dev"
+run = "./scripts/dev"
 
 [build-frontend]
 description = "Build frontend assets (CSS + JS)"

--- a/tests/integration/web/test_middlewares.py
+++ b/tests/integration/web/test_middlewares.py
@@ -62,7 +62,9 @@ class TestRequestContextMiddleware:
         host, get_response_mock, middleware, rf, settings
     ):
         settings.ENV = "development"
-        settings.ALLOWED_HOSTS.extend([".localhost", ".local", "localhost", "127.0.0.1"])
+        settings.ALLOWED_HOSTS.extend(
+            [".localhost", ".local", "localhost", "127.0.0.1"]
+        )
         request = rf.get("/")
         request.META["HTTP_HOST"] = host
         request.di = DependencyInjector()

--- a/tests/integration/web/test_middlewares.py
+++ b/tests/integration/web/test_middlewares.py
@@ -50,6 +50,36 @@ class TestRequestContextMiddleware:
 
     @pytest.mark.django_db
     @staticmethod
+    @pytest.mark.parametrize(
+        "host",
+        (
+            "127.0.0.1:1355",
+            "filters-bar.skip-steps.localhost:1355",
+            "filters-bar.skip-steps.local:1355",
+        ),
+    )
+    def test_unknown_local_host_uses_root_sphere_in_development(
+        host, get_response_mock, middleware, rf, settings
+    ):
+        settings.ENV = "development"
+        settings.ALLOWED_HOSTS.extend([".localhost", ".local", "localhost", "127.0.0.1"])
+        request = rf.get("/")
+        request.META["HTTP_HOST"] = host
+        request.di = DependencyInjector()
+        root_sphere = Sphere.objects.get(site__domain=settings.ROOT_DOMAIN)
+
+        middleware(request)
+
+        assert request.context == RequestContext(
+            current_site_id=root_sphere.site.id,
+            current_sphere_id=root_sphere.id,
+            root_site_id=root_sphere.site.id,
+            root_sphere_id=root_sphere.id,
+        )
+        get_response_mock.assert_called_once_with(request)
+
+    @pytest.mark.django_db
+    @staticmethod
     def test_site_does_not_exist_redirects(
         middleware, get_response_mock, rf, settings, sphere
     ):


### PR DESCRIPTION
I did some bash shenanigans to set up dynamic ports and readable aliasing for https://github.com/vercel-labs/portless, so now if you launch `mise dev` from a separate clone or a worktree it won't conflict with your.

With `USE_POSTGRES=false` you even get separate DBs so it's totally separate.