### PR TITLE
Add desktop fold toggle to backoffice panel sidebar

### DIFF
--- a/src/ludamus/templates/panel/base.html
+++ b/src/ludamus/templates/panel/base.html
@@ -19,6 +19,15 @@
         {% vite_hmr_client %}
         <link rel="stylesheet" href="{% vite_asset_url 'src/index.css' %}">
         <script src="{% static 'vendor/htmx.min.js' %}?v={{ STATIC_VERSION }}"></script>
+        <script>
+            (function() {
+                try {
+                    if (localStorage.getItem("panel-sidebar-folded") === "1") {
+                        document.documentElement.setAttribute("data-folded", "");
+                    }
+                } catch (e) {}
+            })();
+        </script>
         <style>
             .sidebar-overlay {
                 transition: opacity 0.3s ease-in-out;
@@ -35,6 +44,62 @@
             .sidebar-scroll::-webkit-scrollbar {
                 display: none;
             }
+
+            .sidebar-fold-btn {
+                display: none;
+            }
+
+            @media (min-width: 1024px) {
+                .sidebar-fold-btn {
+                    display: inline-flex;
+                }
+
+                html[data-folded] #sidebar {
+                    width: 4rem;
+                }
+
+                html[data-folded] main.panel-main {
+                    margin-left: 4rem;
+                }
+
+                html[data-folded] #sidebar .sidebar-label,
+                html[data-folded] #sidebar .sidebar-fold-hide {
+                    display: none;
+                }
+
+                html[data-folded] #sidebar .sidebar-header {
+                    padding: 1rem 0.5rem;
+                    justify-content: center;
+                }
+
+                html[data-folded] #sidebar .sidebar-link {
+                    justify-content: center;
+                    padding-left: 0.5rem;
+                    padding-right: 0.5rem;
+                }
+
+                html[data-folded] #sidebar .sidebar-link svg {
+                    margin-right: 0;
+                }
+
+                html[data-folded] #sidebar .sidebar-section {
+                    padding-left: 0.5rem;
+                    padding-right: 0.5rem;
+                }
+
+                html[data-folded] #sidebar .sidebar-footer {
+                    padding-left: 0.5rem;
+                    padding-right: 0.5rem;
+                }
+
+                html[data-folded] #sidebar .sidebar-profile {
+                    justify-content: center;
+                }
+
+                html[data-folded] #sidebarFoldIcon {
+                    transform: rotate(180deg);
+                }
+            }
         </style>
         {% block extra_head %}
         {% endblock extra_head %}
@@ -50,13 +115,24 @@
             <aside id="sidebar"
                    class="sidebar-panel w-64 bg-neutral-900 text-white flex-shrink-0 fixed h-full z-50 -translate-x-full lg:translate-x-0 flex flex-col">
                 <div class="sidebar-scroll flex-1 overflow-y-auto min-h-0">
-                    <div class="p-6">
-                        <h1 class="text-2xl font-bold text-primary">{{ current_sphere.name }}</h1>
-                        <p class="text-neutral-400 text-sm">{% translate "Backoffice" %}</p>
+                    <div class="sidebar-header p-6 flex items-start justify-between gap-2">
+                        <div class="sidebar-fold-hide min-w-0">
+                            <h1 class="text-2xl font-bold text-primary break-words">{{ current_sphere.name }}</h1>
+                            <p class="text-neutral-400 text-sm">{% translate "Backoffice" %}</p>
+                        </div>
+                        {% translate "Toggle sidebar" as t_toggle_sidebar %}
+                        <button id="sidebarFoldBtn"
+                                type="button"
+                                class="sidebar-fold-btn items-center justify-center p-2 text-neutral-400 hover:text-white hover:bg-neutral-800 rounded-lg transition flex-shrink-0"
+                                title="{{ t_toggle_sidebar }}"
+                                aria-label="{{ t_toggle_sidebar }}"
+                                hx-on:click="var h=document.documentElement;var f=h.toggleAttribute('data-folded');try{localStorage.setItem('panel-sidebar-folded',f?'1':'0');}catch(e){}">
+                            <span id="sidebarFoldIcon" class="block transition-transform">{% icon "chevron-double-left" class="w-5 h-5" %}</span>
+                        </button>
                     </div>
                     <!-- Event Selector -->
                     {% if events %}
-                        <div class="px-4 mb-6">
+                        <div class="sidebar-fold-hide px-4 mb-6">
                             <label class="text-xs text-neutral-500 uppercase tracking-wider">{% translate "Event" %}</label>
                             <div class="relative mt-1">
                                 <select id="eventSelector"
@@ -77,72 +153,93 @@
                             </div>
                         </div>
                     {% endif %}
-                    <nav class="px-4 space-y-1">
+                    <nav class="sidebar-section px-4 space-y-1">
                         {% block sidebar_nav %}
                             {% if current_event %}
+                                {% translate "Dashboard" as t_dashboard %}
                                 <a href="{% url 'panel:event-index' slug=current_event.slug %}"
-                                   class="flex items-center px-4 py-3 {% if active_nav == 'index' %}text-white bg-neutral-800{% else %}text-neutral-300 hover:bg-neutral-800{% endif %} rounded-lg transition">
-                                    {% icon "home" class="w-5 h-5 mr-3" %}
-                                    {% translate "Dashboard" %}
+                                   title="{{ t_dashboard }}"
+                                   class="sidebar-link flex items-center px-4 py-3 {% if active_nav == 'index' %}text-white bg-neutral-800{% else %}text-neutral-300 hover:bg-neutral-800{% endif %} rounded-lg transition">
+                                    {% icon "home" class="w-5 h-5 mr-3 flex-shrink-0" %}
+                                    <span class="sidebar-label">{{ t_dashboard }}</span>
                                 </a>
+                                {% translate "Call for Proposals" as t_cfp %}
                                 <a href="{% url 'panel:cfp' slug=current_event.slug %}"
-                                   class="flex items-center px-4 py-3 {% if active_nav == 'cfp' %}text-white bg-neutral-800{% else %}text-neutral-300 hover:bg-neutral-800{% endif %} rounded-lg transition">
-                                    {% icon "rectangle-stack" class="w-5 h-5 mr-3" %}
-                                    {% translate "Call for Proposals" %}
+                                   title="{{ t_cfp }}"
+                                   class="sidebar-link flex items-center px-4 py-3 {% if active_nav == 'cfp' %}text-white bg-neutral-800{% else %}text-neutral-300 hover:bg-neutral-800{% endif %} rounded-lg transition">
+                                    {% icon "rectangle-stack" class="w-5 h-5 mr-3 flex-shrink-0" %}
+                                    <span class="sidebar-label">{{ t_cfp }}</span>
                                 </a>
+                                {% translate "Proposals" as t_proposals %}
                                 <a href="{% url 'panel:proposals' slug=current_event.slug %}"
-                                   class="flex items-center px-4 py-3 {% if active_nav == 'proposals' %}text-white bg-neutral-800{% else %}text-neutral-300 hover:bg-neutral-800{% endif %} rounded-lg transition">
-                                    {% icon "document-text" class="w-5 h-5 mr-3" %}
-                                    {% translate "Proposals" %}
+                                   title="{{ t_proposals }}"
+                                   class="sidebar-link flex items-center px-4 py-3 {% if active_nav == 'proposals' %}text-white bg-neutral-800{% else %}text-neutral-300 hover:bg-neutral-800{% endif %} rounded-lg transition">
+                                    {% icon "document-text" class="w-5 h-5 mr-3 flex-shrink-0" %}
+                                    <span class="sidebar-label">{{ t_proposals }}</span>
                                 </a>
+                                {% translate "Facilitators" as t_facilitators %}
                                 <a href="{% url 'panel:facilitators' slug=current_event.slug %}"
-                                   class="flex items-center px-4 py-3 {% if active_nav == 'facilitators' %}text-white bg-neutral-800{% else %}text-neutral-300 hover:bg-neutral-800{% endif %} rounded-lg transition">
-                                    {% icon "user-group" class="w-5 h-5 mr-3" %}
-                                    {% translate "Facilitators" %}
+                                   title="{{ t_facilitators }}"
+                                   class="sidebar-link flex items-center px-4 py-3 {% if active_nav == 'facilitators' %}text-white bg-neutral-800{% else %}text-neutral-300 hover:bg-neutral-800{% endif %} rounded-lg transition">
+                                    {% icon "user-group" class="w-5 h-5 mr-3 flex-shrink-0" %}
+                                    <span class="sidebar-label">{{ t_facilitators }}</span>
                                 </a>
+                                {% translate "Venues" as t_venues %}
                                 <a href="{% url 'panel:venues' slug=current_event.slug %}"
-                                   class="flex items-center px-4 py-3 {% if active_nav == 'venues' %}text-white bg-neutral-800{% else %}text-neutral-300 hover:bg-neutral-800{% endif %} rounded-lg transition">
-                                    {% icon "building-office-2" class="w-5 h-5 mr-3" %}
-                                    {% translate "Venues" %}
+                                   title="{{ t_venues }}"
+                                   class="sidebar-link flex items-center px-4 py-3 {% if active_nav == 'venues' %}text-white bg-neutral-800{% else %}text-neutral-300 hover:bg-neutral-800{% endif %} rounded-lg transition">
+                                    {% icon "building-office-2" class="w-5 h-5 mr-3 flex-shrink-0" %}
+                                    <span class="sidebar-label">{{ t_venues }}</span>
                                 </a>
+                                {% translate "Tracks" as t_tracks %}
                                 <a href="{% url 'panel:tracks' slug=current_event.slug %}"
-                                   class="flex items-center px-4 py-3 {% if active_nav == 'tracks' %}text-white bg-neutral-800{% else %}text-neutral-300 hover:bg-neutral-800{% endif %} rounded-lg transition">
-                                    {% icon "tag" class="w-5 h-5 mr-3" %}
-                                    {% translate "Tracks" %}
+                                   title="{{ t_tracks }}"
+                                   class="sidebar-link flex items-center px-4 py-3 {% if active_nav == 'tracks' %}text-white bg-neutral-800{% else %}text-neutral-300 hover:bg-neutral-800{% endif %} rounded-lg transition">
+                                    {% icon "tag" class="w-5 h-5 mr-3 flex-shrink-0" %}
+                                    <span class="sidebar-label">{{ t_tracks }}</span>
                                 </a>
+                                {% translate "Harmonogram" as t_timetable %}
                                 <a href="{% url 'panel:timetable' slug=current_event.slug %}"
-                                   class="flex items-center px-4 py-3 {% if active_nav == 'timetable' %}text-white bg-neutral-800{% else %}text-neutral-300 hover:bg-neutral-800{% endif %} rounded-lg transition">
-                                    {% icon "calendar-days" class="w-5 h-5 mr-3" %}
-                                    {% translate "Harmonogram" %}
+                                   title="{{ t_timetable }}"
+                                   class="sidebar-link flex items-center px-4 py-3 {% if active_nav == 'timetable' %}text-white bg-neutral-800{% else %}text-neutral-300 hover:bg-neutral-800{% endif %} rounded-lg transition">
+                                    {% icon "calendar-days" class="w-5 h-5 mr-3 flex-shrink-0" %}
+                                    <span class="sidebar-label">{{ t_timetable }}</span>
                                 </a>
+                                {% translate "Event Settings" as t_event_settings %}
                                 <a href="{% url 'panel:event-settings' slug=current_event.slug %}"
-                                   class="flex items-center px-4 py-3 {% if active_nav == 'settings' %}text-white bg-neutral-800{% else %}text-neutral-300 hover:bg-neutral-800{% endif %} rounded-lg transition">
-                                    {% icon "cog-6-tooth" class="w-5 h-5 mr-3" %}
-                                    {% translate "Event Settings" %}
+                                   title="{{ t_event_settings }}"
+                                   class="sidebar-link flex items-center px-4 py-3 {% if active_nav == 'settings' %}text-white bg-neutral-800{% else %}text-neutral-300 hover:bg-neutral-800{% endif %} rounded-lg transition">
+                                    {% icon "cog-6-tooth" class="w-5 h-5 mr-3 flex-shrink-0" %}
+                                    <span class="sidebar-label">{{ t_event_settings }}</span>
                                 </a>
                             {% endif %}
                             <div class="{% if current_event %}pt-4 mt-4 border-t border-neutral-800{% endif %}">
-                                <p class="px-4 text-xs text-neutral-500 uppercase tracking-wider mb-2">{% translate "Sphere" %}</p>
+                                <p class="sidebar-fold-hide px-4 text-xs text-neutral-500 uppercase tracking-wider mb-2">{% translate "Sphere" %}</p>
+                                {% translate "Sphere settings" as t_sphere_settings %}
                                 <a href="{% url 'multiverse:panel:sphere-settings' %}"
-                                   class="flex items-center px-4 py-3 {% if active_nav == 'sphere-settings' %}text-white bg-neutral-800{% else %}text-neutral-300 hover:bg-neutral-800{% endif %} rounded-lg transition">
-                                    {% icon "cog-6-tooth" class="w-5 h-5 mr-3" %}
-                                    {% translate "Sphere settings" %}
+                                   title="{{ t_sphere_settings }}"
+                                   class="sidebar-link flex items-center px-4 py-3 {% if active_nav == 'sphere-settings' %}text-white bg-neutral-800{% else %}text-neutral-300 hover:bg-neutral-800{% endif %} rounded-lg transition">
+                                    {% icon "cog-6-tooth" class="w-5 h-5 mr-3 flex-shrink-0" %}
+                                    <span class="sidebar-label">{{ t_sphere_settings }}</span>
                                 </a>
                             </div>
                         {% endblock sidebar_nav %}
                     </nav>
                 </div>
-                <div class="flex-shrink-0 p-4 border-t border-neutral-800 bg-neutral-900">
+                <div class="sidebar-footer flex-shrink-0 p-4 border-t border-neutral-800 bg-neutral-900">
+                    {% translate "Back to website" as t_back_to_website %}
                     <a href="{% url 'web:index' %}"
-                       class="flex items-center px-4 py-2 mb-4 text-neutral-300 hover:text-white hover:bg-neutral-800 rounded-lg transition">
-                        {% icon "arrow-left" class="w-5 h-5 mr-3" %}
-                        {% translate "Back to website" %}
+                       title="{{ t_back_to_website }}"
+                       class="sidebar-link flex items-center px-4 py-2 mb-4 text-neutral-300 hover:text-white hover:bg-neutral-800 rounded-lg transition">
+                        {% icon "arrow-left" class="w-5 h-5 mr-3 flex-shrink-0" %}
+                        <span class="sidebar-label">{{ t_back_to_website }}</span>
                     </a>
-                    <div class="flex items-center">
+                    <div class="sidebar-profile flex items-center"
+                         title="{{ request.user.username }}">
                         <div class="w-10 h-10 rounded-full bg-primary flex items-center justify-center flex-shrink-0">
                             <span class="text-white font-medium">{{ request.user.username|first|upper|default:"?" }}</span>
                         </div>
-                        <div class="ml-3 min-w-0">
+                        <div class="sidebar-label ml-3 min-w-0">
                             <p class="text-sm font-medium truncate">{{ request.user.username }}</p>
                             <p class="text-xs text-neutral-400 truncate">{% translate "Organizer" %}</p>
                         </div>
@@ -150,7 +247,7 @@
                 </div>
             </aside>
             <!-- Main Content -->
-            <main class="flex-1 lg:ml-64">
+            <main class="panel-main flex-1 lg:ml-64">
                 <!-- Top Bar -->
                 <header class="bg-white border-b border-neutral-200 px-3 sm:px-4 lg:px-8 py-3 sm:py-4 sticky top-0 z-10">
                     <div class="flex flex-wrap items-center justify-between gap-x-4 gap-y-2">


### PR DESCRIPTION
Sidebar can collapse to icon-only (64px) on desktop to free horizontal space on views like the agenda builder. Toggle persists via localStorage and applies pre-paint to avoid flash. Mobile hamburger flow is untouched.