### PR TITLE
Integrate fallow for frontend TypeScript analysis

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,23 @@ jobs:
       - run: mise install
       - run: mise run impeccable
 
+  frontend-analysis:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: jdx/mise-action@v2
+      - run: mise install
+      - name: Install frontend dependencies
+        run: npm ci
+        working-directory: src/ludamus/client
+      # Non-blocking: fallow surfaces dead code, duplication, and
+      # complexity hotspots as a report without failing the build.
+      - name: Analyze frontend TypeScript (fallow)
+        continue-on-error: true
+        run: mise run fallow
+
   test:
     runs-on: ubuntu-latest
     steps:

--- a/mise.toml
+++ b/mise.toml
@@ -261,6 +261,10 @@ run = "lsof -ti :8000 | xargs kill -9 2>/dev/null; lsof -ti :5173 | xargs kill -
 description = "Type-check frontend TypeScript"
 run = "cd src/ludamus/client && npm run typecheck"
 
+[tasks.fallow]
+description = "Analyze frontend TypeScript: dead code, duplication, complexity"
+run = "cd src/ludamus/client && npm run fallow"
+
 
 [tasks.npm]
 description = "Run npm in the frontend client directory"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -84,6 +84,8 @@ target-version = ['py314']
 
 [tool.codespell]
 skip = 'node_modules,tests/e2e,*.po,*.lock,package-lock.json,vendor,src/ludamus/gates/web/django/theme/static_src/package-lock.json,CLAUDE.md'
+# 'fallow' is the frontend analysis tool, not a misspelling of 'follow'
+ignore-words-list = 'fallow'
 
 # COVERAGE
 

--- a/src/ludamus/client/.fallowrc.json
+++ b/src/ludamus/client/.fallowrc.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "https://raw.githubusercontent.com/fallow-rs/fallow/main/schema.json",
+  "entry": [
+    "src/django-hmr.ts",
+    "src/encounter-form.ts",
+    "src/modal.ts",
+    "src/tabs.ts",
+    "src/timetable.ts",
+    "src/index.css"
+  ],
+  "ignoreDependencies": ["portless", "postcss-nested"]
+}

--- a/src/ludamus/client/package-lock.json
+++ b/src/ludamus/client/package-lock.json
@@ -15,6 +15,7 @@
         "@hasparus/tailwind": "1.1.8",
         "@tailwindcss/typography": "0.5.19",
         "@tailwindcss/vite": "4.2.4",
+        "fallow": "2.73.0",
         "portless": "0.13.0",
         "postcss-nested": "7.0.2",
         "prettier": "3.8.1",
@@ -57,6 +58,118 @@
       "dependencies": {
         "tslib": "^2.4.0"
       }
+    },
+    "node_modules/@fallow-cli/darwin-arm64": {
+      "version": "2.73.0",
+      "resolved": "https://registry.npmjs.org/@fallow-cli/darwin-arm64/-/darwin-arm64-2.73.0.tgz",
+      "integrity": "sha512-4mo+35ufU3H5HpyYi/UT12EvRJA7ibglIaWTDqjc6TkZoz7fXYKh9PT+KcBBZyMbFC1kvAxJsfJP1J4zKXr5xQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@fallow-cli/darwin-x64": {
+      "version": "2.73.0",
+      "resolved": "https://registry.npmjs.org/@fallow-cli/darwin-x64/-/darwin-x64-2.73.0.tgz",
+      "integrity": "sha512-bgob14wLLRXTXI+/XMT7OhVIZV1aBw0lvlXJwl/+t8MOUftlG68VoZVRkpzDypWc/dPxsa5J72kUv/5b1F/jXg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@fallow-cli/linux-arm64-gnu": {
+      "version": "2.73.0",
+      "resolved": "https://registry.npmjs.org/@fallow-cli/linux-arm64-gnu/-/linux-arm64-gnu-2.73.0.tgz",
+      "integrity": "sha512-7q058FGiv92VCMikoaNkcJOlhuUeYbu/dvzAyjwBYCt2FBadPdkafz29IRZN2McfLXmCdizV6531TPh2H8Z/XA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@fallow-cli/linux-arm64-musl": {
+      "version": "2.73.0",
+      "resolved": "https://registry.npmjs.org/@fallow-cli/linux-arm64-musl/-/linux-arm64-musl-2.73.0.tgz",
+      "integrity": "sha512-rykM9ClOZ7cSUvox0Qesq3Vh4XTdHdgVDqgEo+njs1vJsj9IMINZhENsR7/9PKIEbH5rH/3BsOQ6wwkXwi7Z/w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@fallow-cli/linux-x64-gnu": {
+      "version": "2.73.0",
+      "resolved": "https://registry.npmjs.org/@fallow-cli/linux-x64-gnu/-/linux-x64-gnu-2.73.0.tgz",
+      "integrity": "sha512-BOk8LUgb97giUB5gUbH2PDV68EV/KlIKmNe+UyYeb8qsQkuIbwnYIxYQ1SmvagcCJdjkzGnJI4JXswvDB96MJg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@fallow-cli/linux-x64-musl": {
+      "version": "2.73.0",
+      "resolved": "https://registry.npmjs.org/@fallow-cli/linux-x64-musl/-/linux-x64-musl-2.73.0.tgz",
+      "integrity": "sha512-zaHIF7rdNGj7gRJ49EG64nmuco1N074Na1DiOBn/bWg1YZxGlQlJL5d0cq1Kb+EoQ0sTwa+Ya4g4/mQ0Wdb+nA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@fallow-cli/win32-arm64-msvc": {
+      "version": "2.73.0",
+      "resolved": "https://registry.npmjs.org/@fallow-cli/win32-arm64-msvc/-/win32-arm64-msvc-2.73.0.tgz",
+      "integrity": "sha512-IlWjJiSPY8j0n7jUEMNaEEdygwI4F2gzulAQmIcTlemZgdzAQCDuI3i8ylePcCc2+1YfD5IwdoQIS+WRkUulBw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@fallow-cli/win32-x64-msvc": {
+      "version": "2.73.0",
+      "resolved": "https://registry.npmjs.org/@fallow-cli/win32-x64-msvc/-/win32-x64-msvc-2.73.0.tgz",
+      "integrity": "sha512-pceEJAFpqmlp4gL+ANyhnNLFGtaHCydEaJCUFZ3TL885RWP2nvOIe4TbbdIGRJwAnw0aa6jtM8QKK0DNCSQlxQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
     },
     "node_modules/@fluejs/noscroll": {
       "version": "1.0.0",
@@ -1030,6 +1143,35 @@
       },
       "engines": {
         "node": ">=10.13.0"
+      }
+    },
+    "node_modules/fallow": {
+      "version": "2.73.0",
+      "resolved": "https://registry.npmjs.org/fallow/-/fallow-2.73.0.tgz",
+      "integrity": "sha512-4qyUIGWhPvmeOnS6tNwB+WyVB92ImVWYEF6wiJT6Khn53SxIBi0+IxTsUT2NVjFR6mL4xRwL2vvpUe/OzvMYcw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "detect-libc": "2.1.2"
+      },
+      "bin": {
+        "fallow": "bin/fallow",
+        "fallow-lsp": "bin/fallow-lsp",
+        "fallow-mcp": "bin/fallow-mcp"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "optionalDependencies": {
+        "@fallow-cli/darwin-arm64": "2.73.0",
+        "@fallow-cli/darwin-x64": "2.73.0",
+        "@fallow-cli/linux-arm64-gnu": "2.73.0",
+        "@fallow-cli/linux-arm64-musl": "2.73.0",
+        "@fallow-cli/linux-x64-gnu": "2.73.0",
+        "@fallow-cli/linux-x64-musl": "2.73.0",
+        "@fallow-cli/win32-arm64-msvc": "2.73.0",
+        "@fallow-cli/win32-x64-msvc": "2.73.0"
       }
     },
     "node_modules/fsevents": {

--- a/src/ludamus/client/package.json
+++ b/src/ludamus/client/package.json
@@ -7,6 +7,7 @@
     "build": "tsc --noEmit && vite build",
     "dev": "vite",
     "typecheck": "tsc --noEmit",
+    "fallow": "fallow",
     "format": "prettier --write src"
   },
   "keywords": [],
@@ -16,6 +17,7 @@
     "@hasparus/tailwind": "1.1.8",
     "@tailwindcss/typography": "0.5.19",
     "@tailwindcss/vite": "4.2.4",
+    "fallow": "2.73.0",
     "portless": "0.13.0",
     "postcss-nested": "7.0.2",
     "prettier": "3.8.1",


### PR DESCRIPTION
## Summary

- Adds [fallow](https://github.com/fallow-rs/fallow), a Rust-native codebase analyzer, to surface dead code, duplication, and complexity hotspots in the Vite client (`src/ludamus/client`).
- `.fallowrc.json` declares the six Vite rollup inputs as entry points so dead-file detection is accurate, and whitelists `portless` / `postcss-nested` (used via CLI and PostCSS config, not imports).
- New `mise run fallow` task and a **non-blocking** CI job that reports findings without failing the build.

## Findings

Run against `src/ludamus/client` before tuning, fallow flagged 11/12 files as "dead" — a false positive, because its Vite plugin auto-detected only 1 of the 6 rollup inputs declared in `vite.config.ts`. The `.fallowrc.json` `entry` list fixes that.

With the config in place:

- **Dead code:** clean (0 / 12 files)
- **Duplication:** none
- **Maintainability:** 77.9 -> 94.6 ("good")
- **Complexity:** 12 functions over the default thresholds — surfaced as a non-blocking report; no code changes made here.

## Notes

- Pinned to fallow `2.73.0`: the latest `2.76.0` is younger than the `.npmrc` `min-release-age=7` gate.
- The CI `frontend-analysis` job uses `continue-on-error`, so fallow never blocks merges.

## Test plan

- [ ] `mise run fallow` runs locally and prints the dead-code / duplication / complexity report
- [ ] CI `frontend-analysis` job runs and is non-blocking

https://claude.ai/code/session_01FUcBdQiehDtiURHG41NhCT

---
_Generated by [Claude Code](https://claude.ai/code/session_01FUcBdQiehDtiURHG41NhCT)_
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/zagrajmy/ludamus/pull/287" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->