### PR TITLE
panel: hide "Required" for checkbox session fields

### DIFF
--- a/src/ludamus/templates/panel/cfp-edit.html
+++ b/src/ludamus/templates/panel/cfp-edit.html
@@ -265,6 +265,7 @@
                             {% for field in available_fields %}
                                 <div class="field-item flex items-center gap-3 py-2 px-3 bg-bg-tertiary rounded-lg"
                                      data-field-id="{{ field.pk }}"
+                                     data-field-type="{{ field.field_type }}"
                                      data-original-index="{{ forloop.counter0 }}">
                                     <span class="text-sm font-medium text-foreground-secondary flex-1">{{ field.name }}</span>
                                     <select name="field_{{ field.pk }}" class="field-select hidden">
@@ -272,12 +273,14 @@
                                                 {% if field.pk not in field_requirements %}selected{% endif %}>
                                             {% translate "Not included" %}
                                         </option>
-                                        <option value="required"
-                                                {% if field_requirements|get_item:field.pk is True %}selected{% endif %}>
-                                            {% translate "Required" %}
-                                        </option>
+                                        {% if field.field_type != "checkbox" %}
+                                            <option value="required"
+                                                    {% if field_requirements|get_item:field.pk is True %}selected{% endif %}>
+                                                {% translate "Required" %}
+                                            </option>
+                                        {% endif %}
                                         <option value="optional"
-                                                {% if field_requirements|get_item:field.pk is False %}selected{% endif %}>
+                                                {% if field_requirements|get_item:field.pk is False or field.field_type == "checkbox" and field_requirements|get_item:field.pk is True %}selected{% endif %}>
                                             {% translate "Optional" %}
                                         </option>
                                     </select>
@@ -589,6 +592,17 @@
                                     }
                                 });
                             }
+                            // Checkbox fields can't be required — show a static "Optional" badge
+                            // so the chosen row isn't visually empty next to its neighbours.
+                            chosenList.querySelectorAll('.field-item[data-field-type="checkbox"]').forEach(item => {
+                                if (!item.querySelector('.optional-label')) {
+                                    const label = document.createElement('span');
+                                    label.className = 'optional-label text-xs px-2 py-1 rounded border border-border bg-bg-tertiary text-foreground-muted';
+                                    label.textContent = i18n.optional;
+                                    const controls = item.querySelector('.field-controls');
+                                    if (controls) controls.insertBefore(label, controls.firstChild);
+                                }
+                            });
                         }
 
                         function updateDisabledStates() {

--- a/src/ludamus/templates/panel/cfp-edit.html
+++ b/src/ludamus/templates/panel/cfp-edit.html
@@ -280,9 +280,10 @@
                                             </option>
                                         {% endif %}
                                         <option value="optional"
-                                                {% if field.field_type == "checkbox" %}{% if field.pk in field_requirements %}selected{% endif %}{% else %}{% if field_requirements|get_item:field.pk is False %}selected{% endif %}{% endif %}>
-                                            {% translate "Optional" %}
-                                        </option>
+                                                {% if field.field_type == "checkbox" %}{% if field.pk in field_requirements %}selected{% endif %}
+                                                {% else %}
+                                                {% if field_requirements|get_item:field.pk is False %}selected{% endif %}
+                                                {% endif %}>{% translate "Optional" %}</option>
                                     </select>
                                 </div>
                             {% endfor %}
@@ -324,9 +325,10 @@
                                             </option>
                                         {% endif %}
                                         <option value="optional"
-                                                {% if field.field_type == "checkbox" %}{% if field.pk in session_field_requirements %}selected{% endif %}{% else %}{% if session_field_requirements|get_item:field.pk is False %}selected{% endif %}{% endif %}>
-                                            {% translate "Optional" %}
-                                        </option>
+                                                {% if field.field_type == "checkbox" %}{% if field.pk in session_field_requirements %}selected{% endif %}
+                                                {% else %}
+                                                {% if session_field_requirements|get_item:field.pk is False %}selected{% endif %}
+                                                {% endif %}>{% translate "Optional" %}</option>
                                     </select>
                                 </div>
                             {% endfor %}

--- a/src/ludamus/templates/panel/cfp-edit.html
+++ b/src/ludamus/templates/panel/cfp-edit.html
@@ -280,7 +280,7 @@
                                             </option>
                                         {% endif %}
                                         <option value="optional"
-                                                {% if field_requirements|get_item:field.pk is False or field.field_type == "checkbox" and field_requirements|get_item:field.pk is True %}selected{% endif %}>
+                                                {% if field.field_type == "checkbox" %}{% if field.pk in field_requirements %}selected{% endif %}{% else %}{% if field_requirements|get_item:field.pk is False %}selected{% endif %}{% endif %}>
                                             {% translate "Optional" %}
                                         </option>
                                     </select>
@@ -324,7 +324,7 @@
                                             </option>
                                         {% endif %}
                                         <option value="optional"
-                                                {% if session_field_requirements|get_item:field.pk is False or field.field_type == "checkbox" and session_field_requirements|get_item:field.pk is True %}selected{% endif %}>
+                                                {% if field.field_type == "checkbox" %}{% if field.pk in session_field_requirements %}selected{% endif %}{% else %}{% if session_field_requirements|get_item:field.pk is False %}selected{% endif %}{% endif %}>
                                             {% translate "Optional" %}
                                         </option>
                                     </select>
@@ -639,7 +639,7 @@
                                 const item = addBtn.closest('.field-item');
                                 const select = item.querySelector('.field-select');
                                 const isCheckboxField = item.dataset.fieldType === 'checkbox';
-                                select.value = hasReqOpt && isCheckboxField ? 'optional' : 'required';
+                                select.value = isCheckboxField ? 'optional' : 'required';
                                 rebuildControls(item, true);
                                 distributeItems();
                                 syncOrder();

--- a/src/ludamus/templates/panel/cfp-edit.html
+++ b/src/ludamus/templates/panel/cfp-edit.html
@@ -306,6 +306,7 @@
                             {% for field in available_session_fields %}
                                 <div class="field-item flex items-center gap-3 py-2 px-3 bg-bg-tertiary rounded-lg"
                                      data-field-id="{{ field.pk }}"
+                                     data-field-type="{{ field.field_type }}"
                                      data-original-index="{{ forloop.counter0 }}">
                                     <span class="text-sm font-medium text-foreground-secondary flex-1">{{ field.name }}</span>
                                     <select name="session_field_{{ field.pk }}" class="field-select hidden">
@@ -313,12 +314,14 @@
                                                 {% if field.pk not in session_field_requirements %}selected{% endif %}>
                                             {% translate "Not included" %}
                                         </option>
-                                        <option value="required"
-                                                {% if session_field_requirements|get_item:field.pk is True %}selected{% endif %}>
-                                            {% translate "Required" %}
-                                        </option>
+                                        {% if field.field_type != "checkbox" %}
+                                            <option value="required"
+                                                    {% if session_field_requirements|get_item:field.pk is True %}selected{% endif %}>
+                                                {% translate "Required" %}
+                                            </option>
+                                        {% endif %}
                                         <option value="optional"
-                                                {% if session_field_requirements|get_item:field.pk is False %}selected{% endif %}>
+                                                {% if session_field_requirements|get_item:field.pk is False or field.field_type == "checkbox" and session_field_requirements|get_item:field.pk is True %}selected{% endif %}>
                                             {% translate "Optional" %}
                                         </option>
                                     </select>
@@ -433,9 +436,10 @@
                             controls.className = 'field-controls flex items-center gap-1';
                             const select = item.querySelector('.field-select');
                             const isChosen = select.value !== 'none';
+                            const itemHasReqOpt = hasReqOpt && item.dataset.fieldType !== 'checkbox';
 
                             if (isChosen) {
-                                if (hasReqOpt) {
+                                if (itemHasReqOpt) {
                                     const toggleBtn = document.createElement('button');
                                     toggleBtn.type = 'button';
                                     toggleBtn.className = 'toggle-req text-xs px-2 py-1 rounded border transition';
@@ -526,9 +530,10 @@
 
                             const controls = document.createElement('div');
                             controls.className = 'field-controls flex items-center gap-1';
+                            const itemHasReqOpt = hasReqOpt && item.dataset.fieldType !== 'checkbox';
 
                             if (isChosen) {
-                                if (hasReqOpt) {
+                                if (itemHasReqOpt) {
                                     const toggleBtn = document.createElement('button');
                                     toggleBtn.type = 'button';
                                     toggleBtn.className = 'toggle-req text-xs px-2 py-1 rounded border transition';
@@ -619,7 +624,8 @@
                             if (addBtn) {
                                 const item = addBtn.closest('.field-item');
                                 const select = item.querySelector('.field-select');
-                                select.value = 'required';
+                                const isCheckboxField = item.dataset.fieldType === 'checkbox';
+                                select.value = hasReqOpt && isCheckboxField ? 'optional' : 'required';
                                 rebuildControls(item, true);
                                 distributeItems();
                                 syncOrder();

--- a/src/ludamus/templates/panel/personal-data-field-create.html
+++ b/src/ludamus/templates/panel/personal-data-field-create.html
@@ -146,9 +146,19 @@
                             const optionsContainer = document.getElementById('options-container');
                             const maxLengthContainer = document.getElementById('max-length-container');
 
+                            const categorySelects = document.querySelectorAll('select[name^="category_"]');
+
                             function toggleOptions() {
+                                const isCheckbox = fieldType.value === 'checkbox';
                                 optionsContainer.classList.toggle('hidden', fieldType.value !== 'select');
-                                maxLengthContainer.classList.toggle('hidden', fieldType.value === 'checkbox');
+                                maxLengthContainer.classList.toggle('hidden', isCheckbox);
+                                categorySelects.forEach(sel => {
+                                    const required = sel.querySelector('option[value="required"]');
+                                    if (!required) return;
+                                    required.hidden = isCheckbox;
+                                    required.disabled = isCheckbox;
+                                    if (isCheckbox && sel.value === 'required') sel.value = 'optional';
+                                });
                             }
                             fieldType.addEventListener('change', toggleOptions);
                             toggleOptions();

--- a/src/ludamus/templates/panel/personal-data-field-edit.html
+++ b/src/ludamus/templates/panel/personal-data-field-edit.html
@@ -137,12 +137,14 @@
                                             {% if category.pk not in required_category_pks and category.pk not in optional_category_pks %}selected{% endif %}>
                                         {% translate "Not included" %}
                                     </option>
-                                    <option value="required"
-                                            {% if category.pk in required_category_pks %}selected{% endif %}>
-                                        {% translate "Required" %}
-                                    </option>
+                                    {% if field.field_type != "checkbox" %}
+                                        <option value="required"
+                                                {% if category.pk in required_category_pks %}selected{% endif %}>
+                                            {% translate "Required" %}
+                                        </option>
+                                    {% endif %}
                                     <option value="optional"
-                                            {% if category.pk in optional_category_pks %}selected{% endif %}>
+                                            {% if category.pk in optional_category_pks or field.field_type == "checkbox" and category.pk in required_category_pks %}selected{% endif %}>
                                         {% translate "Optional" %}
                                     </option>
                                 </select>

--- a/src/ludamus/templates/panel/personal-data-field-edit.html
+++ b/src/ludamus/templates/panel/personal-data-field-edit.html
@@ -144,9 +144,10 @@
                                         </option>
                                     {% endif %}
                                     <option value="optional"
-                                            {% if field.field_type == "checkbox" %}{% if category.pk in optional_category_pks or category.pk in required_category_pks %}selected{% endif %}{% else %}{% if category.pk in optional_category_pks %}selected{% endif %}{% endif %}>
-                                        {% translate "Optional" %}
-                                    </option>
+                                            {% if field.field_type == "checkbox" %}{% if category.pk in optional_category_pks or category.pk in required_category_pks %}selected{% endif %}
+                                            {% else %}
+                                            {% if category.pk in optional_category_pks %}selected{% endif %}
+                                            {% endif %}>{% translate "Optional" %}</option>
                                 </select>
                             </label>
                         {% endfor %}

--- a/src/ludamus/templates/panel/personal-data-field-edit.html
+++ b/src/ludamus/templates/panel/personal-data-field-edit.html
@@ -144,7 +144,7 @@
                                         </option>
                                     {% endif %}
                                     <option value="optional"
-                                            {% if category.pk in optional_category_pks or field.field_type == "checkbox" and category.pk in required_category_pks %}selected{% endif %}>
+                                            {% if field.field_type == "checkbox" %}{% if category.pk in optional_category_pks or category.pk in required_category_pks %}selected{% endif %}{% else %}{% if category.pk in optional_category_pks %}selected{% endif %}{% endif %}>
                                         {% translate "Optional" %}
                                     </option>
                                 </select>

--- a/src/ludamus/templates/panel/session-field-create.html
+++ b/src/ludamus/templates/panel/session-field-create.html
@@ -164,9 +164,19 @@
                             const optionsContainer = document.getElementById('options-container');
                             const maxLengthContainer = document.getElementById('max-length-container');
 
+                            const categorySelects = document.querySelectorAll('select[name^="category_"]');
+
                             function toggleOptions() {
+                                const isCheckbox = fieldType.value === 'checkbox';
                                 optionsContainer.classList.toggle('hidden', fieldType.value !== 'select');
-                                maxLengthContainer.classList.toggle('hidden', fieldType.value === 'checkbox');
+                                maxLengthContainer.classList.toggle('hidden', isCheckbox);
+                                categorySelects.forEach(sel => {
+                                    const required = sel.querySelector('option[value="required"]');
+                                    if (!required) return;
+                                    required.hidden = isCheckbox;
+                                    required.disabled = isCheckbox;
+                                    if (isCheckbox && sel.value === 'required') sel.value = 'optional';
+                                });
                             }
                             fieldType.addEventListener('change', toggleOptions);
                             toggleOptions();

--- a/src/ludamus/templates/panel/session-field-edit.html
+++ b/src/ludamus/templates/panel/session-field-edit.html
@@ -155,12 +155,14 @@
                                             {% if category.pk not in required_category_pks and category.pk not in optional_category_pks %}selected{% endif %}>
                                         {% translate "Not included" %}
                                     </option>
-                                    <option value="required"
-                                            {% if category.pk in required_category_pks %}selected{% endif %}>
-                                        {% translate "Required" %}
-                                    </option>
+                                    {% if field.field_type != "checkbox" %}
+                                        <option value="required"
+                                                {% if category.pk in required_category_pks %}selected{% endif %}>
+                                            {% translate "Required" %}
+                                        </option>
+                                    {% endif %}
                                     <option value="optional"
-                                            {% if category.pk in optional_category_pks %}selected{% endif %}>
+                                            {% if category.pk in optional_category_pks or field.field_type == "checkbox" and category.pk in required_category_pks %}selected{% endif %}>
                                         {% translate "Optional" %}
                                     </option>
                                 </select>

--- a/src/ludamus/templates/panel/session-field-edit.html
+++ b/src/ludamus/templates/panel/session-field-edit.html
@@ -162,9 +162,10 @@
                                         </option>
                                     {% endif %}
                                     <option value="optional"
-                                            {% if field.field_type == "checkbox" %}{% if category.pk in optional_category_pks or category.pk in required_category_pks %}selected{% endif %}{% else %}{% if category.pk in optional_category_pks %}selected{% endif %}{% endif %}>
-                                        {% translate "Optional" %}
-                                    </option>
+                                            {% if field.field_type == "checkbox" %}{% if category.pk in optional_category_pks or category.pk in required_category_pks %}selected{% endif %}
+                                            {% else %}
+                                            {% if category.pk in optional_category_pks %}selected{% endif %}
+                                            {% endif %}>{% translate "Optional" %}</option>
                                 </select>
                             </label>
                         {% endfor %}

--- a/src/ludamus/templates/panel/session-field-edit.html
+++ b/src/ludamus/templates/panel/session-field-edit.html
@@ -162,7 +162,7 @@
                                         </option>
                                     {% endif %}
                                     <option value="optional"
-                                            {% if category.pk in optional_category_pks or field.field_type == "checkbox" and category.pk in required_category_pks %}selected{% endif %}>
+                                            {% if field.field_type == "checkbox" %}{% if category.pk in optional_category_pks or category.pk in required_category_pks %}selected{% endif %}{% else %}{% if category.pk in optional_category_pks %}selected{% endif %}{% endif %}>
                                         {% translate "Optional" %}
                                     </option>
                                 </select>

--- a/tests/e2e/tests/panel.spec.ts
+++ b/tests/e2e/tests/panel.spec.ts
@@ -1218,6 +1218,12 @@ test.describe('Backoffice Panel', () => {
           ),
         ).toBeVisible();
 
+        /* NOTE: the panel UI hides "Required" for checkbox fields because
+           the proposer-side form builder (chronology/forms.py — BooleanField
+           for checkbox) ignores `is_required` anyway. The regression test
+           below needs a checkbox stored as required to exercise that
+           defensive coercion, so we re-inject the option to craft a
+           tampered POST that the server-side parser still accepts. */
         await page.goto(
           '/panel/event/autumn-open/cfp/session-fields/create/',
         );

--- a/tests/e2e/tests/panel.spec.ts
+++ b/tests/e2e/tests/panel.spec.ts
@@ -781,6 +781,25 @@ test.describe('Backoffice Panel', () => {
     ).toBeVisible();
   });
 
+  test('session field create form hides "Required" for checkbox fields', async ({
+    page,
+  }) => {
+    await page.goto(
+      '/panel/event/autumn-open/cfp/session-fields/create/',
+    );
+    const requiredOption = page
+      .locator('select[name^="category_"]')
+      .first()
+      .locator('option[value="required"]');
+    const isHidden = () => requiredOption.evaluate((opt: HTMLOptionElement) => opt.hidden);
+
+    await page.locator('#id_field_type').selectOption('text');
+    expect(await isHidden()).toBe(false);
+
+    await page.locator('#id_field_type').selectOption('checkbox');
+    expect(await isHidden()).toBe(true);
+  });
+
   // --- Step 8: Time Slots ---
 
   test('shows time slots page', async ({ page }) => {

--- a/tests/e2e/tests/panel.spec.ts
+++ b/tests/e2e/tests/panel.spec.ts
@@ -46,13 +46,16 @@ async function expectRequiredOption(
   select: Locator,
   expected: { hidden: boolean; disabled: boolean },
 ) {
-  const state = await select
-    .locator('option[value="required"]')
-    .evaluate((opt: HTMLOptionElement) => ({
-      hidden: opt.hidden,
-      disabled: opt.disabled,
-    }));
-  expect(state).toEqual(expected);
+  await expect
+    .poll(() =>
+      select
+        .locator('option[value="required"]')
+        .evaluate((opt: HTMLOptionElement) => ({
+          hidden: opt.hidden,
+          disabled: opt.disabled,
+        })),
+    )
+    .toEqual(expected);
 }
 
 function proposalCategoryOption(page: Page, name: string) {

--- a/tests/e2e/tests/panel.spec.ts
+++ b/tests/e2e/tests/panel.spec.ts
@@ -1199,7 +1199,6 @@ test.describe('Backoffice Panel', () => {
           ),
         ).toBeVisible();
 
-        // Field 4: Beginner Friendly (checkbox, optional)
         await page.goto(
           '/panel/event/autumn-open/cfp/session-fields/create/',
         );
@@ -1213,7 +1212,13 @@ test.describe('Backoffice Panel', () => {
           .locator('#id_field_type')
           .selectOption('checkbox');
         await sessionTypeRequirementSelect(page, proposalCategoryName)
-          .selectOption('required');
+          .evaluate((sel: HTMLSelectElement) => {
+            const opt = document.createElement('option');
+            opt.value = 'required';
+            opt.textContent = 'Required';
+            sel.appendChild(opt);
+            sel.value = 'required';
+          });
         await page
           .getByRole('button', { name: 'Create' })
           .click();
@@ -1300,6 +1305,21 @@ test.describe('Backoffice Panel', () => {
         await expect(
           page.locator('.duration-item', { hasText: '2h' }),
         ).toBeVisible();
+
+        await page
+          .locator('#session-fields-list .field-item', {
+            hasText: beginnerName,
+          })
+          .locator('.field-select')
+          .evaluate((sel: HTMLSelectElement) => {
+            if (!sel.querySelector('option[value="required"]')) {
+              const opt = document.createElement('option');
+              opt.value = 'required';
+              opt.textContent = 'Required';
+              sel.appendChild(opt);
+            }
+            sel.value = 'required';
+          });
 
         // Save
         await page

--- a/tests/e2e/tests/panel.spec.ts
+++ b/tests/e2e/tests/panel.spec.ts
@@ -1,7 +1,7 @@
 import fs from 'node:fs';
 import path from 'node:path';
 
-import { expect, test, type Page } from '@playwright/test';
+import { expect, test, type Locator, type Page } from '@playwright/test';
 
 /** Build an HH:MM string by adding minutes to a base hour:minute. */
 function timeHHMM(
@@ -36,6 +36,23 @@ function slugify(value: string): string {
 
 function sessionTypeRequirementSelect(page: Page, name: string) {
   return page.getByRole('combobox', { name, exact: true }).last();
+}
+
+function firstCategoryRequirementSelect(page: Page) {
+  return page.locator('select[name^="category_"]').first();
+}
+
+async function expectRequiredOption(
+  select: Locator,
+  expected: { hidden: boolean; disabled: boolean },
+) {
+  const state = await select
+    .locator('option[value="required"]')
+    .evaluate((opt: HTMLOptionElement) => ({
+      hidden: opt.hidden,
+      disabled: opt.disabled,
+    }));
+  expect(state).toEqual(expected);
 }
 
 function proposalCategoryOption(page: Page, name: string) {
@@ -781,23 +798,109 @@ test.describe('Backoffice Panel', () => {
     ).toBeVisible();
   });
 
-  test('session field create form hides "Required" for checkbox fields', async ({
+  test('field create forms hide "Required" for checkbox fields', async ({
     page,
   }) => {
+    for (const path of [
+      '/panel/event/autumn-open/cfp/personal-data/create/',
+      '/panel/event/autumn-open/cfp/session-fields/create/',
+    ]) {
+      await page.goto(path);
+
+      const requirementSelect = firstCategoryRequirementSelect(page);
+      await page.locator('#id_field_type').selectOption('text');
+      await requirementSelect.selectOption('required');
+      await expectRequiredOption(requirementSelect, {
+        hidden: false,
+        disabled: false,
+      });
+      await expect(requirementSelect).toHaveValue('required');
+
+      await page.locator('#id_field_type').selectOption('checkbox');
+      await expectRequiredOption(requirementSelect, {
+        hidden: true,
+        disabled: true,
+      });
+      await expect(requirementSelect).toHaveValue('optional');
+    }
+  });
+
+  test('cfp picker shows checkbox fields as optional only', async ({
+    page,
+  }, testInfo) => {
+    const retrySuffix = testInfo.retry === 0 ? '' : `-r${testInfo.retry}`;
+    const nameSuffix = `${testInfo.project.name}${retrySuffix}`;
+    const hostFieldName = `Host Consent ${nameSuffix}`;
+    const sessionFieldName = `Session Consent ${nameSuffix}`;
+
+    await page.goto(
+      '/panel/event/autumn-open/cfp/personal-data/create/',
+    );
+    await page.locator('#id_name').fill(hostFieldName);
+    await page
+      .locator('#id_question')
+      .fill('May we contact this host?');
+    await page.locator('#id_field_type').selectOption('checkbox');
+    await page.getByRole('button', { name: 'Create' }).click();
+    await expect(
+      page.getByText(
+        'Personal data field created successfully.',
+      ),
+    ).toBeVisible();
+
     await page.goto(
       '/panel/event/autumn-open/cfp/session-fields/create/',
     );
-    const requiredOption = page
-      .locator('select[name^="category_"]')
-      .first()
-      .locator('option[value="required"]');
-    const isHidden = () => requiredOption.evaluate((opt: HTMLOptionElement) => opt.hidden);
-
-    await page.locator('#id_field_type').selectOption('text');
-    expect(await isHidden()).toBe(false);
-
+    await page.locator('#id_name').fill(sessionFieldName);
+    await page
+      .locator('#id_question')
+      .fill('Does this session need consent?');
     await page.locator('#id_field_type').selectOption('checkbox');
-    expect(await isHidden()).toBe(true);
+    await page.getByRole('button', { name: 'Create' }).click();
+    await expect(
+      page.getByText('Session field created successfully.'),
+    ).toBeVisible();
+
+    await page.goto('/panel/event/autumn-open/cfp/rpg-proposals/');
+
+    const assertOptionalOnly = async (group: string, fieldName: string) => {
+      await page
+        .locator(`${group} .avail-list .field-item`, { hasText: fieldName })
+        .locator('.add-field')
+        .click();
+
+      const chosen = page.locator(`${group} .chosen-list .field-item`, {
+        hasText: fieldName,
+      });
+      await expect(chosen.locator('.field-select')).toHaveValue('optional');
+      await expect(chosen.locator('.toggle-req')).toHaveCount(0);
+      await expect(chosen.locator('.optional-label')).toHaveText('Optional');
+    };
+
+    await assertOptionalOnly('#host-fields-list', hostFieldName);
+    await assertOptionalOnly('#session-fields-list', sessionFieldName);
+
+    page.once('dialog', (dialog) => dialog.accept());
+    await page.goto('/panel/event/autumn-open/cfp/personal-data/');
+    await page
+      .getByRole('row', { name: new RegExp(hostFieldName) })
+      .getByRole('button', { name: /Delete/i })
+      .click();
+    await expect(
+      page.getByText(
+        'Personal data field deleted successfully.',
+      ),
+    ).toBeVisible();
+
+    page.once('dialog', (dialog) => dialog.accept());
+    await page.goto('/panel/event/autumn-open/cfp/session-fields/');
+    await page
+      .getByRole('row', { name: new RegExp(sessionFieldName) })
+      .getByRole('button', { name: /Delete/i })
+      .click();
+    await expect(
+      page.getByText('Session field deleted successfully.'),
+    ).toBeVisible();
   });
 
   // --- Step 8: Time Slots ---


### PR DESCRIPTION
## Summary
- The proposer-side form builder already coerces `required → False` for checkbox fields (`forms.BooleanField(required=False)` in `src/ludamus/gates/web/django/chronology/forms.py:46-48`, locked in by a7139a27), so showing "Required" in the panel is misleading — event managers can pick it but it has no effect.
- Drop the option from:
  - per-category dropdowns on `session-field-create.html` (JS-toggled when field type switches to checkbox) and `session-field-edit.html` (template conditional on `field.field_type`)
  - per-field requirement select on `cfp-edit.html`, including the toggle-req button rebuild and the add-field default
- The regression test from #310 needs a checkbox field with a required category requirement, which the UI now forbids — inject the option client-side in the two setup steps so the crafted POST still exercises the form builder's defensive coercion.

## Test plan
- [x] `mise run e2e` — chromium passes including the regression test; only failures are pre-existing (1 chromium 120s timeout on `panel:915`, 13 firefox missing-binary)
- [ ] Manually verify the dropdown in session-field-create + session-field-edit hides "Required" when checkbox is the field type, and that cfp-edit shows no toggle button for previously-included checkbox fields
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/zagrajmy/ludamus/pull/311" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Hide and disable the "Required" option for checkbox fields across creation and editing UIs.
  * Default added checkbox fields to "Optional" and display a static "Optional" badge to avoid empty rows.
  * Preserve optional status and correctly sync order/requirements when fields are added via the picker.

* **Tests**
  * Added end-to-end tests verifying checkbox requirement controls and related form flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->