### PR TITLE
Handle duplicate import connection display names

### DIFF
--- a/src/ludamus/gates/web/django/multiverse/panel/views/connections.py
+++ b/src/ludamus/gates/web/django/multiverse/panel/views/connections.py
@@ -18,9 +18,16 @@ from ludamus.gates.web.django.multiverse.access import (
 from ludamus.gates.web.django.multiverse.panel.forms import ConnectionForm
 from ludamus.gates.web.django.multiverse.panel.views.base import sphere_panel_context
 from ludamus.pacts import NotFoundError, RedirectError
+from ludamus.pacts.multiverse import DuplicateConnectionDisplayNameError
 
 if TYPE_CHECKING:
     from django.http import HttpResponse
+
+
+def _add_duplicate_display_name_error(form: ConnectionForm) -> None:
+    form.add_error(
+        "display_name", _("A connection with this display name already exists.")
+    )
 
 
 def _connection_not_found() -> RedirectError:
@@ -76,9 +83,20 @@ class ConnectionCreatePageView(SphereAccessMixin, View):
 
         sphere_id = self.request.context.current_sphere_id
         plaintext = form.cleaned_data["secret"].encode("utf-8")
-        self.request.services.connections.create(
-            sphere_id, form.cleaned_data["display_name"], plaintext
-        )
+        try:
+            self.request.services.connections.create(
+                sphere_id, form.cleaned_data["display_name"], plaintext
+            )
+        except DuplicateConnectionDisplayNameError:
+            _add_duplicate_display_name_error(form)
+            return TemplateResponse(
+                self.request,
+                "multiverse/panel/connections/create.html",
+                {
+                    **sphere_panel_context(self.request, active_tab="connections"),
+                    "form": form,
+                },
+            )
         messages.success(self.request, _("Connection created successfully."))
         return redirect("multiverse:panel:connections")
 
@@ -126,13 +144,25 @@ class ConnectionEditPageView(SphereAccessMixin, View):
             )
 
         display_name = form.cleaned_data["display_name"]
-        if form.cleaned_data["replace_secret"]:
-            plaintext = form.cleaned_data["secret"].encode("utf-8")
-            self.request.services.connections.update(
-                sphere_id, pk, display_name, plaintext
+        try:
+            if form.cleaned_data["replace_secret"]:
+                plaintext = form.cleaned_data["secret"].encode("utf-8")
+                self.request.services.connections.update(
+                    sphere_id, pk, display_name, plaintext
+                )
+            else:
+                self.request.services.connections.update(sphere_id, pk, display_name)
+        except DuplicateConnectionDisplayNameError:
+            _add_duplicate_display_name_error(form)
+            return TemplateResponse(
+                self.request,
+                "multiverse/panel/connections/edit.html",
+                {
+                    **sphere_panel_context(self.request, active_tab="connections"),
+                    "form": form,
+                    "connection": connection,
+                },
             )
-        else:
-            self.request.services.connections.update(sphere_id, pk, display_name)
         messages.success(self.request, _("Connection updated successfully."))
         return redirect("multiverse:panel:connections")
 

--- a/src/ludamus/links/db/django/repositories.py
+++ b/src/ludamus/links/db/django/repositories.py
@@ -2632,7 +2632,7 @@ _SQLITE_CONNECTION_UNIQUE_DISPLAY_NAME_CONSTRAINT = (
 )
 
 
-def _is_connection_display_name_conflict(exc: IntegrityError) -> bool:
+def is_connection_display_name_conflict(exc: IntegrityError) -> bool:
     diag = getattr(exc.__cause__, "diag", None)
     if (
         getattr(diag, "constraint_name", None)
@@ -2671,7 +2671,7 @@ class ConnectionsRepository(ConnectionsRepositoryProtocol):
                 sphere_id=sphere_id, display_name=display_name
             )
         except IntegrityError as exc:
-            if _is_connection_display_name_conflict(exc):
+            if is_connection_display_name_conflict(exc):
                 raise DuplicateConnectionDisplayNameError from exc
             raise
         return ConnectionDTO.model_validate(connection)
@@ -2686,7 +2686,7 @@ class ConnectionsRepository(ConnectionsRepositoryProtocol):
         try:
             connection.save(update_fields=["display_name"])
         except IntegrityError as exc:
-            if _is_connection_display_name_conflict(exc):
+            if is_connection_display_name_conflict(exc):
                 raise DuplicateConnectionDisplayNameError from exc
             raise
         return ConnectionDTO.model_validate(connection)

--- a/src/ludamus/links/db/django/repositories.py
+++ b/src/ludamus/links/db/django/repositories.py
@@ -4,7 +4,7 @@ from datetime import UTC, datetime, timedelta
 from secrets import token_urlsafe
 from typing import TYPE_CHECKING, Literal, cast  # pylint: disable=unused-import
 
-from django.db import transaction
+from django.db import IntegrityError, transaction
 from django.db.models import Count, Max, Q
 from django.utils.text import slugify
 
@@ -128,7 +128,11 @@ from ludamus.pacts.chronology import (
     IntegrationImplementationId,
     IntegrationKind,
 )
-from ludamus.pacts.multiverse import ConnectionDTO, ConnectionsRepositoryProtocol
+from ludamus.pacts.multiverse import (
+    ConnectionDTO,
+    ConnectionsRepositoryProtocol,
+    DuplicateConnectionDisplayNameError,
+)
 
 if TYPE_CHECKING:
     from collections.abc import Iterable
@@ -2622,6 +2626,26 @@ class TrackRepository(TrackRepositoryProtocol):
         )
 
 
+_CONNECTION_UNIQUE_DISPLAY_NAME_CONSTRAINT = "connection_unique_display_name_per_sphere"
+_SQLITE_CONNECTION_UNIQUE_DISPLAY_NAME_CONSTRAINT = (
+    "UNIQUE constraint failed: connection.sphere_id, connection.display_name"
+)
+
+
+def _is_connection_display_name_conflict(exc: IntegrityError) -> bool:
+    diag = getattr(exc.__cause__, "diag", None)
+    if (
+        getattr(diag, "constraint_name", None)
+        == _CONNECTION_UNIQUE_DISPLAY_NAME_CONSTRAINT
+    ):
+        return True
+    message = str(exc)
+    return (
+        _CONNECTION_UNIQUE_DISPLAY_NAME_CONSTRAINT in message
+        or _SQLITE_CONNECTION_UNIQUE_DISPLAY_NAME_CONSTRAINT in message
+    )
+
+
 class ConnectionsRepository(ConnectionsRepositoryProtocol):
     @staticmethod
     def list_for_sphere(sphere_id: int) -> list[ConnectionDTO]:
@@ -2642,9 +2666,14 @@ class ConnectionsRepository(ConnectionsRepositoryProtocol):
 
     @staticmethod
     def create(sphere_id: int, display_name: str) -> ConnectionDTO:
-        connection = Connection.objects.create(
-            sphere_id=sphere_id, display_name=display_name
-        )
+        try:
+            connection = Connection.objects.create(
+                sphere_id=sphere_id, display_name=display_name
+            )
+        except IntegrityError as exc:
+            if _is_connection_display_name_conflict(exc):
+                raise DuplicateConnectionDisplayNameError from exc
+            raise
         return ConnectionDTO.model_validate(connection)
 
     @staticmethod
@@ -2654,7 +2683,12 @@ class ConnectionsRepository(ConnectionsRepositoryProtocol):
         except Connection.DoesNotExist as exc:
             raise NotFoundError from exc
         connection.display_name = display_name
-        connection.save(update_fields=["display_name"])
+        try:
+            connection.save(update_fields=["display_name"])
+        except IntegrityError as exc:
+            if _is_connection_display_name_conflict(exc):
+                raise DuplicateConnectionDisplayNameError from exc
+            raise
         return ConnectionDTO.model_validate(connection)
 
     @staticmethod
@@ -2667,7 +2701,6 @@ class ConnectionsRepository(ConnectionsRepositoryProtocol):
 
     @staticmethod
     def read_secret(sphere_id: int, pk: int) -> bytes:
-        # Returns the encrypted blob. Decryption is the encryptor's job.
         try:
             connection = Connection.objects.only("secret").get(
                 pk=pk, sphere_id=sphere_id

--- a/src/ludamus/pacts/multiverse.py
+++ b/src/ludamus/pacts/multiverse.py
@@ -13,6 +13,10 @@ if TYPE_CHECKING:
     from ludamus.pacts.legacy import EventDTO
 
 
+class DuplicateConnectionDisplayNameError(Exception):
+    pass
+
+
 class ConnectionDTO(BaseModel):
     model_config = ConfigDict(from_attributes=True)
 

--- a/tests/integration/links/test_connection_repository.py
+++ b/tests/integration/links/test_connection_repository.py
@@ -6,6 +6,7 @@ import-execution slice.
 """
 
 import pytest
+from django.db import IntegrityError
 
 from ludamus.adapters.db.django.models import Connection
 from ludamus.links.db.django.repositories import ConnectionsRepository
@@ -97,3 +98,27 @@ class TestConnectionsRepositorySecretSurface:
             assert (
                 name in allowed
             ), f"Unexpected secret accessor on repo surface: {name}"
+
+
+class TestConnectionsRepositoryReraisesUnrelatedIntegrityError:
+    def test_create_reraises_non_duplicate_integrity_error(self, sphere, monkeypatch):
+        def raise_unrelated(*_args, **_kwargs):
+            raise IntegrityError("FOREIGN KEY constraint failed")
+
+        monkeypatch.setattr(Connection.objects, "create", raise_unrelated)
+
+        with pytest.raises(IntegrityError):
+            ConnectionsRepository.create(sphere_id=sphere.pk, display_name="Konto")
+
+    def test_update_reraises_non_duplicate_integrity_error(self, sphere, monkeypatch):
+        connection = Connection.objects.create(sphere=sphere, display_name="Konto")
+
+        def raise_unrelated(*_args, **_kwargs):
+            raise IntegrityError("FOREIGN KEY constraint failed")
+
+        monkeypatch.setattr(Connection, "save", raise_unrelated)
+
+        with pytest.raises(IntegrityError):
+            ConnectionsRepository.update(
+                sphere_id=sphere.pk, pk=connection.pk, display_name="Inne"
+            )

--- a/tests/integration/web/multiverse/test_connections.py
+++ b/tests/integration/web/multiverse/test_connections.py
@@ -198,6 +198,29 @@ class TestConnectionCreatePageView:
         assert stored
         assert b"abc" not in stored
 
+    def test_post_create_rejects_duplicate_display_name(
+        self, authenticated_client, active_user, sphere
+    ):
+        sphere.managers.add(active_user)
+        Connection.objects.create(sphere=sphere, display_name="Konto")
+
+        response = authenticated_client.post(
+            self.url, data={"display_name": "Konto", "secret": '{"client": "abc"}'}
+        )
+
+        assert response.context["form"].errors["display_name"] == [
+            "A connection with this display name already exists."
+        ]
+        assert_response(
+            response,
+            HTTPStatus.OK,
+            template_name="multiverse/panel/connections/create.html",
+            context_data={**CONNECTIONS_PANEL_CONTEXT, "form": ANY},
+        )
+        assert (
+            Connection.objects.filter(sphere=sphere, display_name="Konto").count() == 1
+        )
+
 
 class TestConnectionEditPageView:
     """Tests for /multiverse/panel/connections/<pk>/edit/ page."""
@@ -278,6 +301,33 @@ class TestConnectionEditPageView:
         )
         connection.refresh_from_db()
         assert connection.display_name == "New Name"
+
+    def test_post_rejects_duplicate_display_name(
+        self, authenticated_client, active_user, sphere
+    ):
+        sphere.managers.add(active_user)
+        connection = Connection.objects.create(sphere=sphere, display_name="Original")
+        Connection.objects.create(sphere=sphere, display_name="Taken")
+
+        response = authenticated_client.post(
+            self.get_url(connection), data={"display_name": "Taken"}
+        )
+
+        assert response.context["form"].errors["display_name"] == [
+            "A connection with this display name already exists."
+        ]
+        assert_response(
+            response,
+            HTTPStatus.OK,
+            template_name="multiverse/panel/connections/edit.html",
+            context_data={
+                **CONNECTIONS_PANEL_CONTEXT,
+                "form": ANY,
+                "connection": ConnectionDTO.model_validate(connection),
+            },
+        )
+        connection.refresh_from_db()
+        assert connection.display_name == "Original"
 
     def test_post_rerenders_form_on_invalid_data(
         self, authenticated_client, active_user, sphere

--- a/tests/unit/links/db/django/test_repositories.py
+++ b/tests/unit/links/db/django/test_repositories.py
@@ -1,0 +1,32 @@
+from types import SimpleNamespace
+
+from django.db import IntegrityError
+
+from ludamus.links.db.django.repositories import is_connection_display_name_conflict
+
+
+class _FakePostgresError(Exception):
+    def __init__(self, constraint_name: str) -> None:
+        super().__init__("duplicate key value violates unique constraint")
+        self.diag = SimpleNamespace(constraint_name=constraint_name)
+
+
+def test_detects_postgres_constraint_name():
+    exc = IntegrityError("duplicate key value violates unique constraint")
+    exc.__cause__ = _FakePostgresError("connection_unique_display_name_per_sphere")
+
+    assert is_connection_display_name_conflict(exc) is True
+
+
+def test_detects_sqlite_constraint_message():
+    exc = IntegrityError(
+        "UNIQUE constraint failed: connection.sphere_id, connection.display_name"
+    )
+
+    assert is_connection_display_name_conflict(exc) is True
+
+
+def test_ignores_unrelated_integrity_error():
+    exc = IntegrityError("FOREIGN KEY constraint failed")
+
+    assert is_connection_display_name_conflict(exc) is False


### PR DESCRIPTION
## Bug and impact
Sphere managers could create or edit an import connection with a display name already used in the same sphere. The DB unique constraint `connection_unique_display_name_per_sphere` raised an `IntegrityError` that no layer translated, so a normal panel action returned a **500**.

## Fix
- Translate the specific duplicate display-name integrity violation into a domain `DuplicateConnectionDisplayNameError` in `ConnectionsRepository.create`/`update` (Postgres `constraint_name` with a SQLite message fallback).
- Catch it in the create and edit views, rendering the error on the `display_name` form field.
- Add create/edit regression coverage.

The error propagates cleanly through `ConnectionsService`'s `atomic()` boundary, so the service layer needs no change.

## Relation to #271
Supersedes #271. That PR fixed the same bug but was built on the pre-encryption connection slice (`service` field, credential checks) that `main` has since removed — it no longer rebased. This is the same fix reapplied to the current encrypted-secret connection model.

## Validation
- `mise run check` — ruff/pylint/vulture/ast-grep/impeccable all clean (10.00/10)
- `mise run test` — connection + repository + integration suites green
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/zagrajmy/ludamus/pull/313" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Connections now enforce unique display names per sphere during create and edit; submitting a duplicate shows a localized "Display name" validation error, re-renders the form, and prevents saving or creating duplicates.

* **Tests**
  * Added unit and integration tests covering duplicate-name rejection across backends and ensuring unrelated database errors are still propagated.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->