### PR TITLE
Smooth local dev: poetry install in e2e:prep + document local login

### DIFF
--- a/docs/LOCAL_DEV.md
+++ b/docs/LOCAL_DEV.md
@@ -1,0 +1,36 @@
+# Local development
+
+```bash
+poetry install      # in a fresh worktree, populate the mise-managed .venv
+mise run start       # dev server on :8000 (Django + client watch)
+mise run bootstrap   # seed a local sphere, admin user, and demo event
+```
+
+## Logging in locally (auth0-simulator)
+
+Auth0 is the real identity provider, so local login goes through a bundled
+**auth0-simulator** instead of the production tenant. It is enabled only when
+`AUTH0_DOMAIN` is local-shaped — `localhost`, `*.localhost`, `*.local`, or
+`auth0.local*` — and TLS certs exist at `~/.portless` (symlinked into
+`~/.simulacrum/certs`). With those in place, `mise run start` runs the simulator
+on `:4400` and the normal login flow works against it.
+
+If `AUTH0_DOMAIN` points at a real tenant (the default in some `.env.local`
+files), the simulator stays idle and you cannot log in locally — switch
+`AUTH0_DOMAIN` to e.g. `auth0.localhost` for simulator-backed login.
+
+## Authenticated browser checks without a UI login (Playwright storageState)
+
+The e2e harness already wires an authenticated session, a seeded database, and
+the server — reuse it instead of hand-rolling cookies:
+
+```bash
+mise run e2e:prep    # migrate + seed + build client; writes tests/e2e/.auth-state.json
+```
+
+`tests/e2e/playwright.config.ts` starts the server itself (`webServer`, with
+`reuseExistingServer` off CI) and loads `tests/e2e/.auth-state.json`
+(`storageState`) — the `e2e-tester` session. Any Playwright script run under that
+config (or pointed at the same `storageState`) is logged in with no Auth0 round
+trip. Seeded logins: `e2e-tester` (member), `e2e-manager` (sphere manager),
+`e2e-superuser`.

--- a/mise.toml
+++ b/mise.toml
@@ -246,6 +246,7 @@ dir = "tests/e2e"
 [tasks."e2e:prep"]
 description = "Migrate, seed fixtures, and build client for e2e tests"
 run = """
+poetry install
 aube install
 mise run _e2e -- django-admin migrate --noinput
 mise run _e2e -- django-admin createcachetable


### PR DESCRIPTION
Two small DX fixes split out of the session-edit work (#314) so that PR stays a clean feature diff.

## `poetry install` in `e2e:prep`
A fresh CLI worktree gets its own mise-managed `.venv` (`_.python.venv` in mise.toml), which is empty until `poetry install` runs there. Without it, `mise run e2e:prep`'s bootstrap scripts fail with a cryptic `ModuleNotFoundError: No module named 'django'`. Running `poetry install` first makes the supported task work in any fresh worktree.

## `docs/LOCAL_DEV.md`
Laconic doc for two things that were tribal knowledge:
- **Local login** via the bundled `auth0-simulator` (enabled when `AUTH0_DOMAIN` is local-shaped + portless certs present; idle against a real tenant).
- **Authenticated browser checks** by reusing the e2e Playwright harness (`webServer` + `storageState` from `tests/e2e/.auth-state.json`) instead of hand-rolling cookies/server.

No code or behavior changes.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/zagrajmy/ludamus/pull/315" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive local development guide covering environment setup, development server initialization, local authentication configuration, and Playwright end-to-end testing.

* **Chores**
  * Updated development workflow to ensure dependency installation runs automatically during test environment preparation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->