### PR TITLE
feat(event): fuzzy search on event page filter

### DIFF
--- a/src/ludamus/templates/chronology/event.html
+++ b/src/ludamus/templates/chronology/event.html
@@ -1048,8 +1048,19 @@
                 select.addEventListener('change', filterSessions);
             });
 
+            // Fold diacritics and lowercase so "swiata" matches "Świata".
+            const COMBINING_MARKS = new RegExp('[\\u0300-\\u036f]', 'g');
+            function normalizeText(value) {
+                return (value || '')
+                    .toLowerCase()
+                    .normalize('NFD')
+                    .replace(COMBINING_MARKS, '');
+            }
+
             function filterSessions() {
-                const searchText = sessionFilter.value.toLowerCase();
+                const searchTokens = normalizeText(sessionFilter.value)
+                    .split(/\s+/)
+                    .filter(Boolean);
                 const statusValue = statusFilter.value;
                 const venueValue = venueFilter.value;
                 const minAgeValue = minAgeFilter.value;
@@ -1065,17 +1076,17 @@
                     }
                 });
 
-                let hiddenCount = 0;
-                let totalCount = 0;
                 sessionCards.forEach(card => {
-                    totalCount++;
                     let show = true;
 
-                    // Text filter (title or host)
-                    if (searchText) {
-                        const title = card.dataset.title;
-                        const host = card.dataset.host;
-                        show = show && (title.includes(searchText) || host.includes(searchText));
+                    // Fuzzy text filter: every token must appear somewhere in
+                    // the combined title + host, so "Bestie Świata Jakub"
+                    // matches a "Bestie Świata" session hosted by "Jakub".
+                    if (searchTokens.length) {
+                        const haystack = normalizeText(
+                            `${card.dataset.title} ${card.dataset.host}`
+                        );
+                        show = show && searchTokens.every(token => haystack.includes(token));
                     }
 
                     // Status filter
@@ -1149,23 +1160,6 @@
                         });
 
                         show = show && matchesAllFilters;
-                    }
-
-                    // Debug the final show/hide decision
-                    if (card.dataset.title === 'bestie nowego świata') {
-                        console.log('Final decision for Bestie:', {
-                            show,
-                            searchText,
-                            statusValue,
-                            hasActiveTagFilters: Object.keys(activeTagFilters).length > 0,
-                            activeTagFilters,
-                            minAgeValue,
-                            maxAgeValue
-                        });
-                    }
-
-                    if (!show) {
-                        hiddenCount++;
                     }
 
                     // Show/hide card container

--- a/src/ludamus/templates/chronology/event.html
+++ b/src/ludamus/templates/chronology/event.html
@@ -1051,13 +1051,24 @@
             });
 
             // Fold diacritics and lowercase so "swiata" matches "Świata".
-            // NFD splits accented letters into base + combining mark, but "ł"
-            // is a distinct letter with no decomposition, so map it explicitly.
+            // NFD splits accented letters into base + combining mark, but some
+            // letters (e.g. "ł", "ø", "ß") have no decomposition, so map those
+            // explicitly before stripping the combining marks.
             const COMBINING_MARKS = new RegExp('[\\u0300-\\u036f]', 'g');
+            const NON_DECOMPOSING_MAP = {
+                ł: 'l',
+                ø: 'o',
+                đ: 'd',
+                ħ: 'h',
+                ı: 'i',
+                œ: 'oe',
+                æ: 'ae',
+                ß: 'ss',
+            };
             function normalizeText(value) {
                 return (value || '')
                     .toLowerCase()
-                    .replace(/ł/g, 'l')
+                    .replace(/[łøđħıœæß]/g, (char) => NON_DECOMPOSING_MAP[char] || char)
                     .normalize('NFD')
                     .replace(COMBINING_MARKS, '');
             }

--- a/src/ludamus/templates/chronology/event.html
+++ b/src/ludamus/templates/chronology/event.html
@@ -267,10 +267,12 @@
                         <span class="absolute left-3.5 top-1/2 -translate-y-1/2 text-foreground-muted">
                             {% icon "magnifying-glass" class="w-5 h-5" variant="mini" %}
                         </span>
+                        {% translate "Filter by title or host..." as filter_placeholder %}
                         <input type="text"
                                class="filter-input w-full pl-11 pr-4 py-3 rounded-2xl border border-border text-sm font-medium bg-bg-secondary text-foreground placeholder:text-foreground-muted placeholder:font-normal transition-all duration-150"
                                id="session-filter"
-                               placeholder="{% translate "Filter by title or host..." %}"
+                               placeholder="{{ filter_placeholder }}"
+                               aria-label="{{ filter_placeholder }}"
                                autocomplete="off">
                     </div>
                     <div class="filters-popover-wrapper relative overflow-visible">
@@ -1049,10 +1051,13 @@
             });
 
             // Fold diacritics and lowercase so "swiata" matches "Świata".
+            // NFD splits accented letters into base + combining mark, but "ł"
+            // is a distinct letter with no decomposition, so map it explicitly.
             const COMBINING_MARKS = new RegExp('[\\u0300-\\u036f]', 'g');
             function normalizeText(value) {
                 return (value || '')
                     .toLowerCase()
+                    .replace(/ł/g, 'l')
                     .normalize('NFD')
                     .replace(COMBINING_MARKS, '');
             }

--- a/tests/e2e/scripts/bootstrap_data.py
+++ b/tests/e2e/scripts/bootstrap_data.py
@@ -397,7 +397,7 @@ def main() -> None:
         fireside_space,
         title="Przygoda w Mieście Neonów",
         slug="neon-city-adventure",
-        presenter="Radek MG",
+        presenter="Radek Włodarczyk",
         description=(
             'Przygoda w stylu filmu "Jumanji". Na strychu znajdujecie grę '
             "komputerową z lat 90 o wojnach gangów w cyberpunkowym Mieście "

--- a/tests/e2e/tests/event-filters.spec.ts
+++ b/tests/e2e/tests/event-filters.spec.ts
@@ -21,3 +21,41 @@ test.describe('Event filter panel', () => {
     await context.close();
   });
 });
+
+test.describe('Event fuzzy search', () => {
+  const visibleCards = '.session-card-wrapper:visible .session-card';
+
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/chronology/event/autumn-open/');
+    await expect(page.locator(visibleCards)).toHaveCount(3);
+  });
+
+  test('matches multiple tokens across title and host, ignoring diacritics', async ({
+    page,
+  }) => {
+    // "Przygoda w Mieście Neonów" hosted by "Radek MG": tokens span the
+    // title (sans diacritics) and the host name.
+    await page.locator('#session-filter').fill('przygoda neonow radek');
+
+    const cards = page.locator(visibleCards);
+    await expect(cards).toHaveCount(1);
+    await expect(cards.first()).toContainText('Przygoda w Mieście Neonów');
+  });
+
+  test('matches a token from the title and a token from the host', async ({
+    page,
+  }) => {
+    await page.locator('#session-filter').fill('mega alex');
+
+    const cards = page.locator(visibleCards);
+    await expect(cards).toHaveCount(1);
+    await expect(cards.first()).toContainText('Mega Strategy Lab');
+  });
+
+  test('shows the empty state when nothing matches', async ({ page }) => {
+    await page.locator('#session-filter').fill('zzzznomatch');
+
+    await expect(page.locator(visibleCards)).toHaveCount(0);
+    await expect(page.locator('#filter-no-results')).toBeVisible();
+  });
+});

--- a/tests/e2e/tests/event-filters.spec.ts
+++ b/tests/e2e/tests/event-filters.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test } from '@playwright/test';
+import { expect, type Page, test } from '@playwright/test';
 
 const MOBILE_WIDTH = 375;
 
@@ -23,39 +23,58 @@ test.describe('Event filter panel', () => {
 });
 
 test.describe('Event fuzzy search', () => {
-  const visibleCards = '.session-card-wrapper:visible .session-card';
+  // Each session card exposes an accessible link "Open details for <title>",
+  // so we can assert on cards by role + name rather than CSS classes.
+  const card = (page: Page, title: string) =>
+    page.getByRole('link', { name: `Open details for ${title}` });
+
+  const searchBox = (page: Page) =>
+    page.getByRole('textbox', { name: 'Filter by title or host...' });
+
+  const MEGA = 'Mega Strategy Lab';
+  const COZY = 'Cozy Storytellers Circle';
+  const NEON = 'Przygoda w Mieście Neonów';
 
   test.beforeEach(async ({ page }) => {
     await page.goto('/chronology/event/autumn-open/');
-    await expect(page.locator(visibleCards)).toHaveCount(3);
+    await expect(card(page, NEON)).toBeVisible();
+    await expect(card(page, MEGA)).toBeVisible();
   });
 
   test('matches multiple tokens across title and host, ignoring diacritics', async ({
     page,
   }) => {
-    // "Przygoda w Mieście Neonów" hosted by "Radek MG": tokens span the
+    // "Przygoda w Mieście Neonów" hosted by "Radek Włodarczyk": tokens span the
     // title (sans diacritics) and the host name.
-    await page.locator('#session-filter').fill('przygoda neonow radek');
+    await searchBox(page).fill('przygoda neonow radek');
 
-    const cards = page.locator(visibleCards);
-    await expect(cards).toHaveCount(1);
-    await expect(cards.first()).toContainText('Przygoda w Mieście Neonów');
+    await expect(card(page, NEON)).toBeVisible();
+    await expect(card(page, MEGA)).toBeHidden();
+    await expect(card(page, COZY)).toBeHidden();
+  });
+
+  test('folds the Polish "ł", which NFD leaves intact', async ({ page }) => {
+    // Host "Radek Włodarczyk": "ł" has no NFD decomposition, so the
+    // stroke-less query "wlodarczyk" only matches with the explicit fold.
+    await searchBox(page).fill('wlodarczyk');
+
+    await expect(card(page, NEON)).toBeVisible();
+    await expect(card(page, MEGA)).toBeHidden();
   });
 
   test('matches a token from the title and a token from the host', async ({
     page,
   }) => {
-    await page.locator('#session-filter').fill('mega alex');
+    await searchBox(page).fill('mega alex');
 
-    const cards = page.locator(visibleCards);
-    await expect(cards).toHaveCount(1);
-    await expect(cards.first()).toContainText('Mega Strategy Lab');
+    await expect(card(page, MEGA)).toBeVisible();
+    await expect(card(page, NEON)).toBeHidden();
   });
 
   test('shows the empty state when nothing matches', async ({ page }) => {
-    await page.locator('#session-filter').fill('zzzznomatch');
+    await searchBox(page).fill('zzzznomatch');
 
-    await expect(page.locator(visibleCards)).toHaveCount(0);
-    await expect(page.locator('#filter-no-results')).toBeVisible();
+    await expect(card(page, MEGA)).toBeHidden();
+    await expect(page.getByText('No sessions match your filters')).toBeVisible();
   });
 });


### PR DESCRIPTION
Closes #317

## The problem

The event page's session filter only matched when your whole query was a substring of *either* the title or the host. So typing `Bestie Świata Jakub` returned nothing, even when there was a "Bestie Świata" session run by "Jakub". The words you typed were split across the two fields. And since `data-host` was rendered without lowercasing while the query was lowercased, host matches quietly broke for any capitalised name.

## What changed

Matching is now token-based and diacritic-insensitive. The query gets split on whitespace, and every token has to turn up somewhere in the combined title + host. Both sides are lowercased and stripped of diacritics, so `swiata` finds `Świata`.

There's one Unicode wrinkle. `NFD` normalization handles almost every Polish letter by splitting it into a base letter plus a combining mark, but a few letters have no decomposition at all: `ł` above all, plus `ø đ ħ ı œ æ ß`. The stroke on `ł` isn't a combining mark, it's a separate letter, so the usual trick walks right past it. Those get mapped by hand before the combining marks are stripped, which is why `wlodarczyk` now matches `Włodarczyk`.

So `Bestie Świata Jakub` (or `bestie swiata jakub`) narrows down to the right session, which is what the issue asked for.

I cleaned up the same function while I was in there. There was a `console.log` hard-coded to one session's title and two counters that got incremented but never read, so those are gone. I also gave the search input an `aria-label`, so it has a real accessible name instead of relying on the placeholder.

## Tests

New Playwright coverage in `tests/e2e/tests/event-filters.spec.ts`, run against the seeded `autumn-open` event. It has "Przygoda w Mieście Neonów" hosted by "Radek Włodarczyk", which makes a good real case:

- a multi-token match spanning title and host with the diacritics dropped (`przygoda neonow radek`)
- the `ł` case on its own: `wlodarczyk` against `Radek Włodarczyk`. NFD alone leaves these unmatched, and the test fails without the explicit fold, so it guards the fix instead of just decorating it.
- one token from the title and one from the host (`mega alex`)
- the empty state when nothing matches

The cards and the search box are found by role and accessible name (`getByRole`) rather than CSS classes, so the tests survive a class rename. I ran the suite locally on Chromium, all five green, and `djlint` is clean on the template.

---
_Generated by [Claude Code](https://claude.ai/code/session_016dUqUsYBFH7R3QB5rQ2yMa)_


---

<a href="https://app.devin.ai/review/zagrajmy/ludamus/pull/318" rel="nofollow noreferrer noopener" target="_blank">
  
    
    `&lt;img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review"&gt;`
  
</a>



## Summary by CodeRabbit

* **Bug Fixes**
  * Improved session filtering with multi-token fuzzy matching across titles and hosts, ignoring diacritics (including explicit folding for certain characters)
  * Search placeholder and aria-label now use the same translated text for consistent accessibility

* **Tests**
  * Added end-to-end tests validating fuzzy search behavior, mixed-token matches, and empty-state handling
  * Updated seeded test data to include a presenter name with diacritics to exercise matching behavior
