### PR TITLE
feat(event): filter sessions by day and hour

### DIFF
--- a/src/ludamus/locale/pl/LC_MESSAGES/django.po
+++ b/src/ludamus/locale/pl/LC_MESSAGES/django.po
@@ -2407,6 +2407,22 @@ msgid "I am waiting"
 msgstr "Oczekuję"
 
 #: src/ludamus/templates/chronology/event.html
+msgid "Day"
+msgstr "Dzień"
+
+#: src/ludamus/templates/chronology/event.html
+msgid "All days"
+msgstr "Wszystkie dni"
+
+#: src/ludamus/templates/chronology/event.html
+msgid "Hour"
+msgstr "Godzina"
+
+#: src/ludamus/templates/chronology/event.html
+msgid "All hours"
+msgstr "Wszystkie godziny"
+
+#: src/ludamus/templates/chronology/event.html
 msgid "Venue"
 msgstr "Lokalizacja"
 

--- a/src/ludamus/templates/chronology/_session_card.html
+++ b/src/ludamus/templates/chronology/_session_card.html
@@ -5,7 +5,7 @@
     <div class="session-card relative block w-full h-full rounded-2xl bg-neutral-50 dark:bg-neutral-800 border border-border ring-offset-[.5px] hover:ring-1 hover:ring-neutral-200 dark:hover:ring-neutral-600 hover:[--pb-scale:1.01] duration-100 ring-offset-background {% if data.user_enrolled %}ring-2 ring-coral-400{% endif %}"
          data-title="{{ data.session.title|lower }}"
          data-session-id="{{ data.session.pk }}"
-         data-host="{{ data.session.display_name }}"
+         data-host="{{ data.session.display_name|lower }}"
          data-tags="{% for fv in data.field_values %}{% if fv.field_type == 'select' and fv.is_public %}{% for val in fv.value %}{{ val }}{% if not forloop.last %},{% endif %}{% endfor %}{% if not forloop.last %},{% endif %}{% endif %}{% endfor %}"
          data-tag-categories="{% for fv in data.field_values %}{% if fv.field_type == 'select' and fv.is_public %}{% for val in fv.value %}{{ fv.field_slug }}:{{ val }}{% if not forloop.last %};{% endif %}{% endfor %}{% if not forloop.last %};{% endif %}{% endif %}{% endfor %}"
          data-status="{% if ended %}ended{% elif data.is_ongoing %}in-progress{% elif not data.is_enrollment_available %}unavailable{% elif data.is_full %}full{% else %}available{% endif %}"

--- a/src/ludamus/templates/chronology/_session_card.html
+++ b/src/ludamus/templates/chronology/_session_card.html
@@ -9,15 +9,14 @@
          data-tags="{% for fv in data.field_values %}{% if fv.field_type == 'select' and fv.is_public %}{% for val in fv.value %}{{ val }}{% if not forloop.last %},{% endif %}{% endfor %}{% if not forloop.last %},{% endif %}{% endif %}{% endfor %}"
          data-tag-categories="{% for fv in data.field_values %}{% if fv.field_type == 'select' and fv.is_public %}{% for val in fv.value %}{{ fv.field_slug }}:{{ val }}{% if not forloop.last %};{% endif %}{% endfor %}{% if not forloop.last %};{% endif %}{% endif %}{% endfor %}"
          data-status="{% if ended %}ended{% elif data.is_ongoing %}in-progress{% elif not data.is_enrollment_available %}unavailable{% elif data.is_full %}full{% else %}available{% endif %}"
-         data-debug-ended="{{ ended|yesno:'true,false' }}"
-         data-debug-is-ongoing="{{ data.is_ongoing|yesno:'true,false' }}"
-         data-debug-enrollment-available="{{ data.is_enrollment_available|yesno:'true,false' }}"
-         data-debug-is-full="{{ data.is_full|yesno:'true,false' }}"
          data-user-enrolled="{% if data.user_enrolled %}true{% else %}false{% endif %}"
          data-user-waiting="{% if data.user_waiting %}true{% else %}false{% endif %}"
          data-min-age="{{ data.session.min_age }}"
          data-venue="{{ data.loc.venue.slug }}"
-         data-venue-name="{{ data.loc.venue.name }}">
+         data-venue-name="{{ data.loc.venue.name }}"
+         data-day="{{ data.agenda_item.start_time|date:'Y-m-d' }}"
+         data-day-label="{{ data.agenda_item.start_time|date:'l, j F' }}"
+         data-hour="{{ data.agenda_item.start_time|date:'H:i' }}">
         <div class="relative z-10 flex h-full flex-col px-5 pb-5">
             <a href="?session={{ data.session.pk }}"
                class="session-card-link absolute inset-0 z-10 rounded-2xl"

--- a/src/ludamus/templates/chronology/event.html
+++ b/src/ludamus/templates/chronology/event.html
@@ -301,22 +301,6 @@
                                         <option value="my-waiting">{% translate "I am waiting" %}</option>
                                     </select>
                                 </div>
-                                <div id="day-filter-group" class="flex flex-col gap-1.5 hidden">
-                                    <label class="text-[0.625rem] font-bold uppercase tracking-widest text-foreground-muted"
-                                           for="day-filter">{% translate "Day" %}</label>
-                                    <select id="day-filter"
-                                            class="filter-input w-full py-2 px-3 rounded-xl border border-border text-[0.8125rem] font-medium bg-bg-secondary text-foreground transition-all duration-150">
-                                        <option value="">{% translate "All days" %}</option>
-                                    </select>
-                                </div>
-                                <div id="hour-filter-group" class="flex flex-col gap-1.5 hidden">
-                                    <label class="text-[0.625rem] font-bold uppercase tracking-widest text-foreground-muted"
-                                           for="hour-filter">{% translate "Hour" %}</label>
-                                    <select id="hour-filter"
-                                            class="filter-input w-full py-2 px-3 rounded-xl border border-border text-[0.8125rem] font-medium bg-bg-secondary text-foreground transition-all duration-150">
-                                        <option value="">{% translate "All hours" %}</option>
-                                    </select>
-                                </div>
                                 <div id="venue-filter-group" class="flex flex-col gap-1.5 hidden">
                                     <label class="text-[0.625rem] font-bold uppercase tracking-widest text-foreground-muted"
                                            for="venue-filter">{% translate "Venue" %}</label>
@@ -343,6 +327,24 @@
                                                placeholder="{% translate "Max" %}"
                                                min="0"
                                                max="99">
+                                    </div>
+                                </div>
+                                <div id="day-hour-filter-group" class="flex gap-3 grow hidden">
+                                    <div id="day-filter-group" class="flex flex-col gap-1.5 grow hidden">
+                                        <label class="text-[0.625rem] font-bold uppercase tracking-widest text-foreground-muted"
+                                               for="day-filter">{% translate "Day" %}</label>
+                                        <select id="day-filter"
+                                                class="filter-input w-full py-2 px-3 rounded-xl border border-border text-[0.8125rem] font-medium bg-bg-secondary text-foreground transition-all duration-150">
+                                            <option value="">{% translate "All days" %}</option>
+                                        </select>
+                                    </div>
+                                    <div id="hour-filter-group" class="flex flex-col gap-1.5 grow hidden">
+                                        <label class="text-[0.625rem] font-bold uppercase tracking-widest text-foreground-muted"
+                                               for="hour-filter">{% translate "Hour" %}</label>
+                                        <select id="hour-filter"
+                                                class="filter-input w-full py-2 px-3 rounded-xl border border-border text-[0.8125rem] font-medium bg-bg-secondary text-foreground transition-all duration-150">
+                                            <option value="">{% translate "All hours" %}</option>
+                                        </select>
                                     </div>
                                 </div>
                                 <div id="tag-filters" class="contents">
@@ -1048,6 +1050,10 @@
                 });
             if (hourSet.size > 1) {
                 document.getElementById('hour-filter-group').classList.remove('hidden');
+            }
+            // Reveal the shared Day/Hour row when either filter is in play.
+            if (dayMap.size > 1 || hourSet.size > 1) {
+                document.getElementById('day-hour-filter-group').classList.remove('hidden');
             }
 
             // Populate venue filter dropdown from session data

--- a/src/ludamus/templates/chronology/event.html
+++ b/src/ludamus/templates/chronology/event.html
@@ -301,6 +301,22 @@
                                         <option value="my-waiting">{% translate "I am waiting" %}</option>
                                     </select>
                                 </div>
+                                <div id="day-filter-group" class="flex flex-col gap-1.5 hidden">
+                                    <label class="text-[0.625rem] font-bold uppercase tracking-widest text-foreground-muted"
+                                           for="day-filter">{% translate "Day" %}</label>
+                                    <select id="day-filter"
+                                            class="filter-input w-full py-2 px-3 rounded-xl border border-border text-[0.8125rem] font-medium bg-bg-secondary text-foreground transition-all duration-150">
+                                        <option value="">{% translate "All days" %}</option>
+                                    </select>
+                                </div>
+                                <div id="hour-filter-group" class="flex flex-col gap-1.5 hidden">
+                                    <label class="text-[0.625rem] font-bold uppercase tracking-widest text-foreground-muted"
+                                           for="hour-filter">{% translate "Hour" %}</label>
+                                    <select id="hour-filter"
+                                            class="filter-input w-full py-2 px-3 rounded-xl border border-border text-[0.8125rem] font-medium bg-bg-secondary text-foreground transition-all duration-150">
+                                        <option value="">{% translate "All hours" %}</option>
+                                    </select>
+                                </div>
                                 <div id="venue-filter-group" class="flex flex-col gap-1.5 hidden">
                                     <label class="text-[0.625rem] font-bold uppercase tracking-widest text-foreground-muted"
                                            for="venue-filter">{% translate "Venue" %}</label>
@@ -975,6 +991,8 @@
 
             const sessionFilter = document.getElementById('session-filter');
             const statusFilter = document.getElementById('status-filter');
+            const dayFilter = document.getElementById('day-filter');
+            const hourFilter = document.getElementById('hour-filter');
             const venueFilter = document.getElementById('venue-filter');
             const minAgeFilter = document.getElementById('min-age-filter');
             const maxAgeFilter = document.getElementById('max-age-filter');
@@ -989,6 +1007,47 @@
             const tagFilters = {};
             if (!filterChipsBar || !filterChipsInner) {
                 throw new Error('Missing filter chips bar');
+            }
+
+            // Populate day filter dropdown from session data. Only relevant for
+            // multi-day events, so reveal it once more than one day is present.
+            const dayMap = new Map(); // ISO date -> human-readable label
+            sessionCards.forEach(card => {
+                const day = card.dataset.day;
+                if (day && !dayMap.has(day)) {
+                    dayMap.set(day, card.dataset.dayLabel || day);
+                }
+            });
+            Array.from(dayMap.entries())
+                .sort((a, b) => a[0].localeCompare(b[0]))
+                .forEach(([value, label]) => {
+                    const option = document.createElement('option');
+                    option.value = value;
+                    option.textContent = label;
+                    dayFilter.appendChild(option);
+                });
+            if (dayMap.size > 1) {
+                document.getElementById('day-filter-group').classList.remove('hidden');
+            }
+
+            // Populate hour filter dropdown from session data. Reveal it once more
+            // than one start hour is present.
+            const hourSet = new Set();
+            sessionCards.forEach(card => {
+                if (card.dataset.hour) {
+                    hourSet.add(card.dataset.hour);
+                }
+            });
+            Array.from(hourSet)
+                .sort()
+                .forEach(hour => {
+                    const option = document.createElement('option');
+                    option.value = hour;
+                    option.textContent = hour;
+                    hourFilter.appendChild(option);
+                });
+            if (hourSet.size > 1) {
+                document.getElementById('hour-filter-group').classList.remove('hidden');
             }
 
             // Populate venue filter dropdown from session data
@@ -1051,6 +1110,8 @@
             function filterSessions() {
                 const searchText = sessionFilter.value.toLowerCase();
                 const statusValue = statusFilter.value;
+                const dayValue = dayFilter.value;
+                const hourValue = hourFilter.value;
                 const venueValue = venueFilter.value;
                 const minAgeValue = minAgeFilter.value;
                 const maxAgeValue = maxAgeFilter.value;
@@ -1065,10 +1126,7 @@
                     }
                 });
 
-                let hiddenCount = 0;
-                let totalCount = 0;
                 sessionCards.forEach(card => {
-                    totalCount++;
                     let show = true;
 
                     // Text filter (title or host)
@@ -1103,6 +1161,16 @@
                                 show = show && card.dataset.userWaiting === 'true';
                                 break;
                         }
+                    }
+
+                    // Day filter
+                    if (dayValue) {
+                        show = show && card.dataset.day === dayValue;
+                    }
+
+                    // Hour filter
+                    if (hourValue) {
+                        show = show && card.dataset.hour === hourValue;
                     }
 
                     // Venue filter
@@ -1151,23 +1219,6 @@
                         show = show && matchesAllFilters;
                     }
 
-                    // Debug the final show/hide decision
-                    if (card.dataset.title === 'bestie nowego świata') {
-                        console.log('Final decision for Bestie:', {
-                            show,
-                            searchText,
-                            statusValue,
-                            hasActiveTagFilters: Object.keys(activeTagFilters).length > 0,
-                            activeTagFilters,
-                            minAgeValue,
-                            maxAgeValue
-                        });
-                    }
-
-                    if (!show) {
-                        hiddenCount++;
-                    }
-
                     // Show/hide card container
                     const cardContainer = card.closest('.session-card-wrapper');
                     if (cardContainer) {
@@ -1193,6 +1244,8 @@
             function clearAllFilters() {
                 sessionFilter.value = '';
                 statusFilter.value = '';
+                dayFilter.value = '';
+                hourFilter.value = '';
                 venueFilter.value = '';
                 minAgeFilter.value = '';
                 maxAgeFilter.value = '';
@@ -1216,6 +1269,8 @@
 
             sessionFilter.addEventListener('input', filterSessions);
             statusFilter.addEventListener('change', filterSessions);
+            dayFilter.addEventListener('change', filterSessions);
+            hourFilter.addEventListener('change', filterSessions);
             venueFilter.addEventListener('change', filterSessions);
             minAgeFilter.addEventListener('input', filterSessions);
             maxAgeFilter.addEventListener('input', filterSessions);
@@ -1251,6 +1306,24 @@
                         label: statusFilter.options[statusFilter.selectedIndex].text,
                         clear() {
                             statusFilter.value = '';
+                            filterSessions();
+                        }
+                    });
+                }
+                if (dayFilter.value) {
+                    chips.push({
+                        label: dayFilter.options[dayFilter.selectedIndex].text,
+                        clear() {
+                            dayFilter.value = '';
+                            filterSessions();
+                        }
+                    });
+                }
+                if (hourFilter.value) {
+                    chips.push({
+                        label: hourFilter.options[hourFilter.selectedIndex].text,
+                        clear() {
+                            hourFilter.value = '';
                             filterSessions();
                         }
                     });

--- a/tests/e2e/scripts/bootstrap_data.py
+++ b/tests/e2e/scripts/bootstrap_data.py
@@ -328,7 +328,7 @@ def main() -> None:
             "Bring dice, meeples, and curiosity!"
         ),
         start_offset=timedelta(days=1),
-        duration_hours=4,
+        duration_hours=28,
         publication_offset=timedelta(days=2),
         enrollment_banner="Enrollment is open—grab a slot before we fill up!",
         allow_anonymous=True,
@@ -405,7 +405,8 @@ def main() -> None:
             "wirtualny świat, gdzie jako wybrane postaci zmierzycie się z "
             "okrutnym Bossem Akimurą i jego armią cyberninja."
         ),
-        start_offset=timedelta(hours=3),
+        # Scheduled on the event's second day so the day/hour filters appear.
+        start_offset=timedelta(days=1, hours=1),
         duration_hours=1,
     )
 

--- a/tests/e2e/scripts/bootstrap_data.py
+++ b/tests/e2e/scripts/bootstrap_data.py
@@ -328,6 +328,8 @@ def main() -> None:
             "Bring dice, meeples, and curiosity!"
         ),
         start_offset=timedelta(days=1),
+        # Span two days so the event encloses its day-2 session (below) and the
+        # day/hour filters have more than one day to work with.
         duration_hours=28,
         publication_offset=timedelta(days=2),
         enrollment_banner="Enrollment is open—grab a slot before we fill up!",

--- a/tests/e2e/tests/event-filters.spec.ts
+++ b/tests/e2e/tests/event-filters.spec.ts
@@ -34,8 +34,11 @@ test.describe('Event filter panel', () => {
     await expect(page.locator('#day-filter-group')).toBeVisible();
     await expect(page.locator('#hour-filter-group')).toBeVisible();
 
-    // The second day holds only the neon-city adventure.
-    await page.locator('#day-filter').selectOption({ index: 2 });
+    // Select the day holding the neon-city adventure by its value (read from the
+    // card itself), so the test doesn't depend on option order or the date.
+    const neonDay = await card('Przygoda w Mieście Neonów').getAttribute('data-day');
+    if (!neonDay) throw new Error('neon-city card is missing data-day');
+    await page.locator('#day-filter').selectOption(neonDay);
     await expect(card('Przygoda w Mieście Neonów')).toBeVisible();
     await expect(card('Mega Strategy Lab')).toBeHidden();
     await expect(card('Cozy Storytellers Circle')).toBeHidden();
@@ -46,5 +49,16 @@ test.describe('Event filter panel', () => {
     await expect(card('Cozy Storytellers Circle')).toBeVisible();
     await expect(card('Mega Strategy Lab')).toBeHidden();
     await expect(card('Przygoda w Mieście Neonów')).toBeHidden();
+  });
+
+  test('filters by host name case-insensitively', async ({ page }) => {
+    await page.goto('/chronology/event/autumn-open/');
+
+    const card = (title: string) => page.locator('.session-card', { hasText: title });
+
+    // "Alex Morgan" hosts Mega Strategy Lab; a lowercase query must still match.
+    await page.locator('#session-filter').fill('alex');
+    await expect(card('Mega Strategy Lab')).toBeVisible();
+    await expect(card('Cozy Storytellers Circle')).toBeHidden();
   });
 });

--- a/tests/e2e/tests/event-filters.spec.ts
+++ b/tests/e2e/tests/event-filters.spec.ts
@@ -20,4 +20,31 @@ test.describe('Event filter panel', () => {
 
     await context.close();
   });
+
+  test('filters sessions by day and hour on a multi-day event', async ({ page }) => {
+    await page.goto('/chronology/event/autumn-open/');
+
+    const card = (title: string) => page.locator('.session-card', { hasText: title });
+    await expect(page.locator('.session-card')).toHaveCount(3);
+
+    await page.locator('#filter-toggle').click();
+    await expect(page.locator('#filter-panel.is-open')).toBeVisible();
+
+    // Day and hour filters only surface for multi-day events.
+    await expect(page.locator('#day-filter-group')).toBeVisible();
+    await expect(page.locator('#hour-filter-group')).toBeVisible();
+
+    // The second day holds only the neon-city adventure.
+    await page.locator('#day-filter').selectOption({ index: 2 });
+    await expect(card('Przygoda w Mieście Neonów')).toBeVisible();
+    await expect(card('Mega Strategy Lab')).toBeHidden();
+    await expect(card('Cozy Storytellers Circle')).toBeHidden();
+
+    // Clearing the day and filtering by start hour narrows to the noon session.
+    await page.locator('#day-filter').selectOption('');
+    await page.locator('#hour-filter').selectOption('12:00');
+    await expect(card('Cozy Storytellers Circle')).toBeVisible();
+    await expect(card('Mega Strategy Lab')).toBeHidden();
+    await expect(card('Przygoda w Mieście Neonów')).toBeHidden();
+  });
 });

--- a/tests/integration/web/chronology/test_event_page.py
+++ b/tests/integration/web/chronology/test_event_page.py
@@ -4,6 +4,7 @@ from unittest.mock import ANY
 
 import pytest
 import responses
+from django.template.defaultfilters import date as date_filter
 from django.urls import reverse
 from django.utils import timezone
 
@@ -127,7 +128,9 @@ class TestEventPageView:
         content = response.content.decode()
         assert f'data-day="{local_start:%Y-%m-%d}"' in content
         assert f'data-hour="{local_start:%H:%M}"' in content
-        assert 'data-day-label="' in content
+        assert f'data-day-label="{date_filter(agenda_item.start_time, "l, j F")}"' in (
+            content
+        )
 
     def test_ok_superuser_proposal(
         self, authenticated_client, event, active_user, pending_session

--- a/tests/integration/web/chronology/test_event_page.py
+++ b/tests/integration/web/chronology/test_event_page.py
@@ -5,6 +5,7 @@ from unittest.mock import ANY
 import pytest
 import responses
 from django.urls import reverse
+from django.utils import timezone
 
 from ludamus.adapters.db.django.models import (
     DomainEnrollmentConfig,
@@ -68,6 +69,65 @@ class TestEventPageView:
             },
             template_name=["chronology/event.html"],
         )
+
+    def test_ok_session_card_exposes_day_and_hour_data_attributes(
+        self, active_user, agenda_item, client, event
+    ):
+        """Cards expose day/hour data attributes powering client-side filters."""
+        session = agenda_item.session
+
+        response = client.get(self._get_url(event.slug))
+
+        session_data = SessionData(
+            agenda_item=AgendaItemDTO.model_validate(agenda_item),
+            effective_participants_limit=10,
+            enrolled_count=0,
+            full_participant_info="0/10",
+            has_any_enrollments=False,
+            is_enrollment_available=False,
+            is_full=False,
+            is_ongoing=False,
+            presenter=UserInfo.from_user_dto(
+                UserDTO.model_validate(active_user), gravatar_url=gravatar_url
+            ),
+            session_participations=[],
+            session=SessionDTO.model_validate(session),
+            should_show_as_inactive=False,
+            loc=LocationData(
+                space=SpaceDTO.model_validate(agenda_item.space),
+                area=AreaDTO.model_validate(agenda_item.space.area),
+                venue=VenueDTO.model_validate(agenda_item.space.area.venue),
+            ),
+            user_enrolled=False,
+            user_waiting=False,
+        )
+        assert_response(
+            response,
+            HTTPStatus.OK,
+            context_data={
+                "current_hour_data": {},
+                "ended_hour_data": {},
+                "enrollment_requires_slots": False,
+                "event": event,
+                "filterable_tag_categories": [],
+                "future_unavailable_hour_data": {
+                    agenda_item.start_time: [session_data]
+                },
+                "hour_data": {agenda_item.start_time: [session_data]},
+                "object": event,
+                "sessions": [session_data],
+                "user_enrollment_config": None,
+                "total_enrolled": 0,
+                "user_enrolled_sessions": [],
+                "view": ANY,
+            },
+            template_name=["chronology/event.html"],
+        )
+        local_start = timezone.localtime(agenda_item.start_time)
+        content = response.content.decode()
+        assert f'data-day="{local_start:%Y-%m-%d}"' in content
+        assert f'data-hour="{local_start:%H:%M}"' in content
+        assert 'data-day-label="' in content
 
     def test_ok_superuser_proposal(
         self, authenticated_client, event, active_user, pending_session


### PR DESCRIPTION
## What & why

On a multi-day event the session list renders every time slot in one long
chronological column, with no way to jump to a specific **day** or **start
hour**. This adds two client-side filters — **Day** and **Hour** — to the
existing session filter panel.

The implementation mirrors the existing data-driven **Venue** filter:

- Each select is populated from the session cards and **only revealed when
  more than one distinct value is present**. So single-day events are
  unaffected (no Day filter), and the Hour filter only shows when sessions
  start at more than one time.
- Both filters AND together with the existing ones, add removable chips,
  participate in *Clear all*, and feed the "no results" state.

Filter order is **Status · Age range · Day · Hour**, with Day and Hour sharing
one row. No view/DTO/service changes — the data already flows through
`agenda_item.start_time`; cards just expose it as `data-day` /
`data-day-label` / `data-hour`.

## Screenshots

### Filter panel — desktop

| Before | After |
| --- | --- |
| `&lt;img src="https://x0.at/-NRN.png" width="420"&gt;` | `&lt;img src="https://x0.at/VnKH.png" width="420"&gt;` |

### Filter panel — mobile (iPhone 14 Pro)

| Before | After |
| --- | --- |
| `&lt;img src="https://x0.at/y5Ga.png" width="300"&gt;` | `&lt;img src="https://x0.at/D1FS.png" width="300"&gt;` |

The panel stays within the mobile viewport (no horizontal overflow — guarded
by the existing `event-filters.spec.ts` overflow test), and Day/Hour wrap to
share one row.

### Filtering in action

Day filter set to the event's second day — the list narrows to that day's
session and a removable chip appears:

`&lt;img src="https://x0.at/Ti9e.png" width="720"&gt;`

## Surgical cleanup (same files)

Removed dead debug code that was sitting in the touched template/script:
`data-debug-*` card attributes, a `console.log` keyed on a hard-coded
session title, and unused `hiddenCount` / `totalCount` counters. Also fixed a
pre-existing bug surfaced in review: the "title or host" search was
case-sensitive on host (`data-host` is now lowercased like `data-title`).

## Tests

- **integration** (`test_event_page.py`): asserts a scheduled card renders the
  `data-day` / `data-day-label` / `data-hour` attributes (localtime) that drive
  the filters.
- **e2e** (`event-filters.spec.ts`): the `autumn-open` seed now spans two days;
  new Playwright tests drive the Day and Hour filters (selecting the day by the
  value read off the card, so it's robust to ordering/date) and verify
  case-insensitive host search.

Locally green: `tests/integration/web/chronology` (231 passed), full chromium
Playwright suite (77 passed), `djlint` / `ruff` / `black` / `tsc` clean.

Polish translations for *Day / Hour / All days / All hours* added to
`django.po` so the new labels match the rest of the (translated) filter UI.

> Screenshots are hosted on x0.at — catbox blocked this CI environment's egress
> IP (HTTP 412) and 0x0.st has uploads disabled, so x0.at was the working
> durable host.

https://claude.ai/code/session_01BBZxPV1uF61PSCr21i1c8s