### PR TITLE
test: cover session field value upsert on re-save

### DIFF
--- a/tests/integration/web/panel/test_session_field_value_upsert.py
+++ b/tests/integration/web/panel/test_session_field_value_upsert.py
@@ -1,0 +1,42 @@
+from http import HTTPStatus
+
+from ludamus.adapters.db.django.models import SessionField, SessionFieldValue
+from tests.integration.web.panel.test_proposal_edit_page import (
+    TestProposalEditPageView,
+    _make_session,
+)
+
+
+class TestSessionFieldValueUpsertOnProposalEdit(TestProposalEditPageView):
+    def test_post_twice_updates_existing_session_field_values(
+        self, authenticated_client, active_user, sphere, event
+    ):
+        sphere.managers.add(active_user)
+        session = _make_session(event, sphere)
+        field = SessionField.objects.create(
+            event=event,
+            name="18+",
+            question="Is this session 18+?",
+            slug="adult",
+            field_type="checkbox",
+            order=0,
+        )
+        data = {
+            "title": "Updated",
+            "display_name": "Host",
+            "participants_limit": 5,
+            "min_age": 0,
+            "session_field_adult": "true",
+        }
+        url = self.get_url(event, session.pk)
+        first = authenticated_client.post(url, data=data)
+        assert first.status_code == HTTPStatus.FOUND
+        values = SessionFieldValue.objects.filter(session=session, field=field)
+        assert values.count() == 1
+
+        data["session_field_adult"] = "false"
+        response = authenticated_client.post(url, data=data)
+        assert response.status_code == HTTPStatus.FOUND, response.content[:500]
+        sfv = SessionFieldValue.objects.get(session=session, field=field)
+        assert sfv.value is False
+        assert values.count() == 1


### PR DESCRIPTION
Adds the integration regression test that #314 shipped without.

The 500 (`UNIQUE constraint failed` when re-saving session custom fields) was already fixed on `main` by #314 — `save_field_values` uses `bulk_create(update_conflicts=True, ...)`. This adds the missing test: post field values twice on proposal edit, assert the value updates in place with no duplicate row.

Supersedes #320 (Cursor's PR), which re-proposed the now-redundant production fix; this keeps only the test.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added integration test to verify session field value upsert behavior during proposal edits, ensuring that duplicate submissions correctly create and update records without duplication.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->