### PR TITLE
Add SessionStart hook for Claude Code on the web

### DIFF
--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -6,6 +6,10 @@ if [ "${CLAUDE_CODE_REMOTE:-}" != "true" ]; then
   exit 0
 fi
 
+# Run setup in the background so the session starts immediately — Claude
+# usually reads files and talks before it needs the toolchain.
+echo '{"async": true, "asyncTimeout": 600000}'
+
 cd "$CLAUDE_PROJECT_DIR"
 
 export PATH="$HOME/.local/bin:$PATH"

--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -1,23 +1,16 @@
 #!/bin/bash
 set -euo pipefail
 
-# Only run in Claude Code on the web (remote) environments.
 if [ "${CLAUDE_CODE_REMOTE:-}" != "true" ]; then
   exit 0
 fi
 
-# Run setup in the background so the session starts immediately — Claude
-# usually reads files and talks before it needs the toolchain.
 echo '{"async": true, "asyncTimeout": 600000}'
 
 cd "$CLAUDE_PROJECT_DIR"
 
 export PATH="$HOME/.local/bin:$PATH"
 
-# mise manages Python, Node, Poetry, ast-grep, aube, markdownlint.
 mise trust
 mise install
-
-# Idempotent dev setup: poetry + aube deps, .env.local, migrations,
-# vendored static, demo data.
 mise run bootstrap

--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -14,6 +14,6 @@ export PATH="$HOME/.local/bin:$PATH"
 mise trust
 mise install
 
-# Python deps into the mise-managed .venv, then frontend/workspace deps.
-mise exec -- poetry install
-mise exec -- aube install
+# Idempotent dev setup: poetry + aube deps, .env.local, migrations,
+# vendored static, demo data.
+mise run bootstrap

--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+set -euo pipefail
+
+# Only run in Claude Code on the web (remote) environments.
+if [ "${CLAUDE_CODE_REMOTE:-}" != "true" ]; then
+  exit 0
+fi
+
+cd "$CLAUDE_PROJECT_DIR"
+
+export PATH="$HOME/.local/bin:$PATH"
+
+# mise manages Python, Node, Poetry, ast-grep, aube, markdownlint.
+mise trust
+mise install
+
+# Python deps into the mise-managed .venv, then frontend/workspace deps.
+mise exec -- poetry install
+mise exec -- aube install

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,14 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/session-start.sh"
+          }
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

Adds a `SessionStart` hook so remote Claude Code on the web sessions start with the toolchain and a provisioned dev environment, so tests and linters work without manual setup.

Here's why it's needed: the environment init script runs before the repo is cloned, so `mise trust && mise install && mise run bootstrap` had no working directory to run in. A `SessionStart` hook runs after the clone, with `$CLAUDE_PROJECT_DIR` set, so it can `cd` into the repo and set it up.

### What the hook does

```bash
mise trust
mise install
mise run bootstrap
```

`mise install` provisions Python, Node, Poetry, ast-grep, aube, and markdownlint. `mise run bootstrap` is the repo's existing idempotent setup task: it installs the poetry and aube deps, generates `.env.local`, runs migrations, downloads vendored static, and seeds demo data.

The hook only runs in remote (web) sessions, guarded by `CLAUDE_CODE_REMOTE`, and runs in async mode so the session starts right away while setup finishes in the background.

### Files

- `.claude/hooks/session-start.sh`: the hook script.
- `.claude/settings.json`: registers the hook under `hooks.SessionStart`.

## Validation

I ran the hook end-to-end with `CLAUDE_CODE_REMOTE=true` and it exited 0: tools installed, migrations applied, vendored static downloaded, demo data seeded.

- Hook execution: `mise trust && mise install && mise run bootstrap` succeeds (exit 0).
- Linter: `mise run ruff` and `mise run black-check` pass (373 files unchanged).
- Tests: `mise run _pytest -- tests/unit` passes (308 tests).

## Async startup

The hook emits the async marker, so setup runs in the background and the session starts immediately. Claude usually reads files and talks before it needs the toolchain, so most of the setup cost stays hidden. The tradeoff: a command that depends on the toolchain could fire before bootstrap finishes. If that turns into a problem, dropping the async marker makes startup synchronous again.

Once this merges to `main`, future remote sessions will use the hook.

https://claude.ai/code/session_01VpwhW9t12jtrpaC2smg3VP

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added a gated session-start hook registered in settings that initializes the development environment for remote sessions: enforces strict error handling, adjusts PATH, emits an async startup status, and runs trust/install/bootstrap steps to ensure dependencies and developer tooling are prepared on session startup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->