### PR TITLE
Replace enrollment banner with compact status pill in event hero

### DIFF
--- a/src/ludamus/locale/pl/LC_MESSAGES/django.po
+++ b/src/ludamus/locale/pl/LC_MESSAGES/django.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-06-04 15:44+0200\n"
+"POT-Creation-Date: 2026-06-05 03:03+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -2153,6 +2153,10 @@ msgid "Proposals Open"
 msgstr "Zgłoszenia otwarte"
 
 #: src/ludamus/templates/chronology/event.html
+msgid "Enrollment Open"
+msgstr "Zapisy otwarte"
+
+#: src/ludamus/templates/chronology/event.html
 msgid "Session"
 msgid_plural "Sessions"
 msgstr[0] "Punkt programu"
@@ -2515,6 +2519,10 @@ msgid "Tags"
 msgstr "Tagi"
 
 #: src/ludamus/templates/chronology/event.html
+msgid "Could not open the editor. Please try again."
+msgstr "Nie udało się otworzyć edytora. Spróbuj ponownie."
+
+#: src/ludamus/templates/chronology/event.html
 msgid "Information"
 msgstr "Informacje"
 
@@ -2584,10 +2592,6 @@ msgstr "Zaloguj się aby się zapisać"
 #: src/ludamus/templates/chronology/event.html
 msgid "Back to Events"
 msgstr "Powrót do wydarzeń"
-
-#: src/ludamus/templates/chronology/event.html
-msgid "Could not open the editor. Please try again."
-msgstr "Nie udało się otworzyć edytora. Spróbuj ponownie."
 
 #: src/ludamus/templates/chronology/panel/integrations/_check_result.html
 msgid "Check passed."
@@ -3746,7 +3750,6 @@ msgid "Harmonogram"
 msgstr "Harmonogram"
 
 #: src/ludamus/templates/panel/base.html
-#: src/ludamus/templates/panel/base.html
 #: src/ludamus/templates/panel/print-materials.html
 msgid "Print Materials"
 msgstr "Materiały do druku"
@@ -4186,13 +4189,13 @@ msgstr ""
 "Nie ma jeszcze żadnych integracji. Dodaj jedną, aby to wydarzenie mogło "
 "komunikować się przez zewnętrzny system."
 
+#: src/ludamus/templates/panel/parts/_print-scope-control.html
+msgid "Venue / area…"
+msgstr "Lokalizacja / strefa…"
+
 #: src/ludamus/templates/panel/parts/print-controls.html
 msgid "Print timetable for a venue or area"
 msgstr "Drukuj harmonogram dla lokalizacji lub strefy"
-
-#: src/ludamus/templates/panel/parts/print-controls.html
-msgid "Venue / area…"
-msgstr "Lokalizacja / strefa…"
 
 #: src/ludamus/templates/panel/parts/print-controls.html
 msgid "Print door cards for a venue or area"

--- a/src/ludamus/templates/chronology/event.html
+++ b/src/ludamus/templates/chronology/event.html
@@ -49,35 +49,45 @@
         <div class="p-6 sm:p-8">
             <div class="flex flex-col lg:flex-row lg:items-start lg:justify-between gap-6">
                 <div class="flex-1">
-                    <!-- Status badge -->
-                    {% if event.is_live %}
-                        <div class="inline-flex items-center gap-2 px-3 py-1.5 bg-teal-100 text-teal-700 rounded-full text-sm font-medium mb-4">
-                            <span class="w-2 h-2 bg-teal-500 rounded-full live-dot"></span>
-                            {% translate "Happening now!" %}
+                    <!-- Status pills: capped at two, priority order
+                         live/completed > enrollment open > proposals open > upcoming -->
+                    {% with configs=event.get_active_enrollment_configs %}
+                        <div class="flex flex-wrap items-center gap-2 mb-4">
+                            {% if event.is_live %}
+                                <div class="inline-flex items-center gap-2 px-3 py-1.5 bg-teal-100 text-teal-700 rounded-full text-sm font-medium">
+                                    <span class="w-2 h-2 bg-teal-500 rounded-full live-dot"></span>
+                                    {% translate "Happening now!" %}
+                                </div>
+                            {% elif event.is_ended %}
+                                <div class="inline-flex items-center gap-2 px-3 py-1.5 bg-neutral-200 dark:bg-neutral-700/30 rounded-full text-sm font-medium text-foreground-secondary">
+                                    {% icon "check-circle" class="w-4 h-4" variant="mini" %}
+                                    {% translate "Completed" %}
+                                </div>
+                            {% endif %}
+                            {% if configs %}
+                                <div class="inline-flex items-center gap-2 px-3 py-1.5 bg-coral-100 dark:bg-coral-900/30 text-coral-700 dark:text-coral-400 rounded-full text-sm font-medium">
+                                    {% icon "user-plus" class="w-4 h-4" variant="mini" %}
+                                    {% translate "Enrollment Open" %}
+                                </div>
+                            {% endif %}
+                            {% if event.is_proposal_active %}
+                                {% if not event.is_live and not event.is_ended or not configs %}
+                                    <div class="inline-flex items-center gap-2 px-3 py-1.5 bg-amber-100 dark:bg-amber-900/10 text-amber-700 dark:text-amber-400 rounded-full text-sm font-medium">
+                                        {% icon "light-bulb" class="w-4 h-4" variant="mini" %}
+                                        {% translate "Proposals Open" %}
+                                    </div>
+                                {% endif %}
+                            {% endif %}
+                            {% if not event.is_live and not event.is_ended %}
+                                {% if not configs or not event.is_proposal_active %}
+                                    <div class="inline-flex items-center gap-2 px-3 py-1.5 bg-warm-200 dark:bg-warm-800/30 text-warm-700 dark:text-warm-400 rounded-full text-sm font-medium">
+                                        {% icon "clock" class="w-4 h-4" variant="mini" %}
+                                        {% translate "Upcoming" %}
+                                    </div>
+                                {% endif %}
+                            {% endif %}
                         </div>
-                    {% elif event.is_ended %}
-                        <div class="inline-flex items-center gap-2 px-3 py-1.5 bg-neutral-200 dark:bg-neutral-700/30 rounded-full text-sm font-medium mb-4 text-foreground-secondary">
-                            {% icon "check-circle" class="w-4 h-4" variant="mini" %}
-                            {% translate "Completed" %}
-                        </div>
-                    {% else %}
-                        <div class="inline-flex items-center gap-2 px-3 py-1.5 bg-warm-200 dark:bg-warm-800/30 text-warm-700 dark:text-warm-400 rounded-full text-sm font-medium mb-4">
-                            {% icon "clock" class="w-4 h-4" variant="mini" %}
-                            {% translate "Upcoming" %}
-                        </div>
-                    {% endif %}
-                    {% if event.is_proposal_active %}
-                        <div class="inline-flex items-center gap-2 px-3 py-1.5 bg-amber-100 dark:bg-amber-900/10 text-amber-700 dark:text-amber-400 rounded-full text-sm font-medium mb-4 ml-2">
-                            {% icon "light-bulb" class="w-4 h-4" variant="mini" %}
-                            {% translate "Proposals Open" %}
-                        </div>
-                    {% endif %}
-                    {% if event.get_active_enrollment_configs %}
-                        <div class="inline-flex items-center gap-2 px-3 py-1.5 bg-coral-100 dark:bg-coral-900/30 text-coral-700 dark:text-coral-400 rounded-full text-sm font-medium mb-4 ml-2">
-                            {% icon "user-plus" class="w-4 h-4" variant="mini" %}
-                            {% translate "Enrollment Open" %}
-                        </div>
-                    {% endif %}
+                    {% endwith %}
                     <h1 class="text-3xl sm:text-4xl font-bold mb-3 text-foreground">{{ event.name }}</h1>
                     {% if event.description %}
                         <p class="text-lg mb-6 max-w-2xl text-foreground-muted">{{ event.description }}</p>

--- a/src/ludamus/templates/chronology/event.html
+++ b/src/ludamus/templates/chronology/event.html
@@ -72,6 +72,12 @@
                             {% translate "Proposals Open" %}
                         </div>
                     {% endif %}
+                    {% if event.get_active_enrollment_configs %}
+                        <div class="inline-flex items-center gap-2 px-3 py-1.5 bg-coral-100 dark:bg-coral-900/30 text-coral-700 dark:text-coral-400 rounded-full text-sm font-medium mb-4 ml-2">
+                            {% icon "user-plus" class="w-4 h-4" variant="mini" %}
+                            {% translate "Enrollment Open" %}
+                        </div>
+                    {% endif %}
                     <h1 class="text-3xl sm:text-4xl font-bold mb-3 text-foreground">{{ event.name }}</h1>
                     {% if event.description %}
                         <p class="text-lg mb-6 max-w-2xl text-foreground-muted">{{ event.description }}</p>
@@ -109,17 +115,6 @@
             </div>
         </div>
     </div>
-    <!-- Enrollment Banner -->
-    {% for enrollment_config in event.get_active_enrollment_configs %}
-        {% if enrollment_config.banner_text %}
-            <div class="alert alert-info mb-4" role="alert">
-                <div class="flex">
-                    <div class="shrink-0">{% icon "information-circle" class="w-5 h-5" %}</div>
-                    <div class="grow ml-3">{{ enrollment_config.banner_text|linebreaks }}</div>
-                </div>
-            </div>
-        {% endif %}
-    {% endfor %}
     <!-- Enrollment Passes Info (for authenticated users) -->
     {% if current_user and event.get_active_enrollment_configs and enrollment_requires_slots %}
         <div class="alert alert-success mb-4" role="alert">

--- a/tests/e2e/tests/event-details.spec.ts
+++ b/tests/e2e/tests/event-details.spec.ts
@@ -5,14 +5,12 @@ test.describe('Event detail page', () => {
     await page.goto('/chronology/event/autumn-open/');
   });
 
-  test('shows event information and enrollment banner', async ({ page }) => {
+  test('shows event information and enrollment status pill', async ({ page }) => {
     await expect(page.getByRole('heading', { name: 'Autumn Open Playtest' })).toBeVisible();
     await expect(page.getByText('Upcoming')).toBeVisible();
 
-    const banner = page.getByRole('alert').filter({
-      hasText: 'Enrollment is open—grab a slot before we fill up!',
-    });
-    await expect(banner).toBeVisible();
+    // Enrollment status is a compact pill in the hero, not a full-width banner.
+    await expect(page.getByText('Enrollment Open')).toBeVisible();
   });
 
   test('renders session cards with locations and opens detail modal', async ({ page }) => {

--- a/tests/e2e/tests/event-details.spec.ts
+++ b/tests/e2e/tests/event-details.spec.ts
@@ -7,10 +7,13 @@ test.describe('Event detail page', () => {
 
   test('shows event information and enrollment status pill', async ({ page }) => {
     await expect(page.getByRole('heading', { name: 'Autumn Open Playtest' })).toBeVisible();
-    await expect(page.getByText('Upcoming')).toBeVisible();
 
+    // Status pills are capped at two. This event has enrollment and proposals
+    // open, so those win and the lower-priority "Upcoming" pill is dropped.
     // Enrollment status is a compact pill in the hero, not a full-width banner.
     await expect(page.getByText('Enrollment Open')).toBeVisible();
+    await expect(page.getByText('Proposals Open')).toBeVisible();
+    await expect(page.getByText('Upcoming')).toHaveCount(0);
   });
 
   test('renders session cards with locations and opens detail modal', async ({ page }) => {

--- a/tests/integration/utils.py
+++ b/tests/integration/utils.py
@@ -23,6 +23,8 @@ def assert_response(
     status_code: HTTPStatus,
     *,
     messages: Iterable[tuple[int, str]] = (),
+    contains: str | Iterable[str] = (),
+    not_contains: str | Iterable[str] = (),
     **response_fields: Any,
 ) -> None:
     assert response.status_code == status_code, response.status_code
@@ -31,6 +33,15 @@ def assert_response(
     default_fields = {"context_data": None, "template_name": None, "url": None}
     for key, value in (default_fields | response_fields).items():
         assert getattr(response, key, None) == value
+
+    needles = [contains] if isinstance(contains, str) else list(contains)
+    absent = [not_contains] if isinstance(not_contains, str) else list(not_contains)
+    if needles or absent:
+        content = response.content.decode()
+        for needle in needles:
+            assert needle in content, needle
+        for needle in absent:
+            assert needle not in content, needle
 
 
 def assert_response_404(

--- a/tests/integration/utils.py
+++ b/tests/integration/utils.py
@@ -36,6 +36,8 @@ def assert_response(
 
     needles = [contains] if isinstance(contains, str) else list(contains)
     absent = [not_contains] if isinstance(not_contains, str) else list(not_contains)
+    assert "" not in needles, "empty substring is not a meaningful content check"
+    assert "" not in absent, "empty substring is not a meaningful content check"
     if needles or absent:
         content = response.content.decode()
         for needle in needles:

--- a/tests/integration/web/chronology/test_event_page.py
+++ b/tests/integration/web/chronology/test_event_page.py
@@ -120,6 +120,68 @@ class TestEventPageView:
             not_contains="Upcoming",
         )
 
+    def test_status_pill_live_event_shows_happening_now(self, client, event):
+        now = timezone.now()
+        event.start_time = now - timedelta(hours=1)
+        event.end_time = now + timedelta(hours=1)
+        event.save()
+
+        response = client.get(self._get_url(event.slug))
+
+        assert_response(
+            response,
+            HTTPStatus.OK,
+            context_data={
+                "current_hour_data": {},
+                "ended_hour_data": {},
+                "enrollment_requires_slots": False,
+                "event": event,
+                "filterable_tag_categories": [],
+                "future_unavailable_hour_data": {},
+                "hour_data": {},
+                "object": event,
+                "sessions": [],
+                "user_enrollment_config": None,
+                "total_enrolled": 0,
+                "user_enrolled_sessions": [],
+                "view": ANY,
+            },
+            template_name=["chronology/event.html"],
+            contains="Happening now!",
+            not_contains="Upcoming",
+        )
+
+    def test_status_pill_ended_event_shows_completed(self, client, event):
+        now = timezone.now()
+        event.start_time = now - timedelta(hours=2)
+        event.end_time = now - timedelta(hours=1)
+        event.save()
+
+        response = client.get(self._get_url(event.slug))
+
+        assert_response(
+            response,
+            HTTPStatus.OK,
+            context_data={
+                "current_hour_data": {},
+                "ended_hour_data": {},
+                "enrollment_requires_slots": False,
+                "event": event,
+                "filterable_tag_categories": [],
+                "future_unavailable_hour_data": {},
+                "hour_data": {},
+                "object": event,
+                "sessions": [],
+                "user_enrollment_config": None,
+                "total_enrolled": 0,
+                "user_enrolled_sessions": [],
+                "view": ANY,
+            },
+            template_name=["chronology/event.html"],
+            contains="Completed",
+            not_contains="Upcoming",
+        )
+
     def test_ok_session_card_exposes_day_and_hour_data_attributes(
         self, active_user, agenda_item, client, event
     ):

--- a/tests/integration/web/chronology/test_event_page.py
+++ b/tests/integration/web/chronology/test_event_page.py
@@ -85,6 +85,7 @@ class TestEventPageView:
             },
             template_name=["chronology/event.html"],
         )
+        assert "Enrollment Open" not in response.content.decode()
 
     def test_ok_session_card_exposes_day_and_hour_data_attributes(
         self, active_user, agenda_item, client, event
@@ -1089,6 +1090,7 @@ class TestEventPageView:
             },
             template_name=["chronology/event.html"],
         )
+        assert "Enrollment Open" in response.content.decode()
 
     @responses.activate
     def test_ok_current_session_get_user_config_from_api(

--- a/tests/integration/web/chronology/test_event_page.py
+++ b/tests/integration/web/chronology/test_event_page.py
@@ -84,13 +84,12 @@ class TestEventPageView:
                 "view": ANY,
             },
             template_name=["chronology/event.html"],
+            contains="Upcoming",
+            not_contains="Enrollment Open",
         )
-        assert "Enrollment Open" not in response.content.decode()
-        assert "Upcoming" in response.content.decode()
 
-    def test_status_pills_capped_at_two_drops_upcoming(
-        self, client, enrollment_config, event
-    ):
+    @pytest.mark.usefixtures("enrollment_config")
+    def test_status_pills_capped_at_two_drops_upcoming(self, client, event):
         now = timezone.now()
         event.proposal_start_time = now - timedelta(days=1)
         event.proposal_end_time = now + timedelta(days=1)
@@ -117,11 +116,9 @@ class TestEventPageView:
                 "view": ANY,
             },
             template_name=["chronology/event.html"],
+            contains=["Enrollment Open", "Proposals Open"],
+            not_contains="Upcoming",
         )
-        content = response.content.decode()
-        assert "Enrollment Open" in content
-        assert "Proposals Open" in content
-        assert "Upcoming" not in content
 
     def test_ok_session_card_exposes_day_and_hour_data_attributes(
         self, active_user, agenda_item, client, event
@@ -1125,8 +1122,8 @@ class TestEventPageView:
                 "view": ANY,
             },
             template_name=["chronology/event.html"],
+            contains="Enrollment Open",
         )
-        assert "Enrollment Open" in response.content.decode()
 
     @responses.activate
     def test_ok_current_session_get_user_config_from_api(

--- a/tests/integration/web/chronology/test_event_page.py
+++ b/tests/integration/web/chronology/test_event_page.py
@@ -1,5 +1,5 @@
 import re
-from datetime import UTC
+from datetime import UTC, timedelta
 from http import HTTPStatus
 from unittest.mock import ANY
 
@@ -86,6 +86,42 @@ class TestEventPageView:
             template_name=["chronology/event.html"],
         )
         assert "Enrollment Open" not in response.content.decode()
+        assert "Upcoming" in response.content.decode()
+
+    def test_status_pills_capped_at_two_drops_upcoming(
+        self, client, enrollment_config, event
+    ):
+        now = timezone.now()
+        event.proposal_start_time = now - timedelta(days=1)
+        event.proposal_end_time = now + timedelta(days=1)
+        event.save()
+
+        response = client.get(self._get_url(event.slug))
+
+        assert_response(
+            response,
+            HTTPStatus.OK,
+            context_data={
+                "current_hour_data": {},
+                "ended_hour_data": {},
+                "enrollment_requires_slots": False,
+                "event": event,
+                "filterable_tag_categories": [],
+                "future_unavailable_hour_data": {},
+                "hour_data": {},
+                "object": event,
+                "sessions": [],
+                "user_enrollment_config": None,
+                "total_enrolled": 0,
+                "user_enrolled_sessions": [],
+                "view": ANY,
+            },
+            template_name=["chronology/event.html"],
+        )
+        content = response.content.decode()
+        assert "Enrollment Open" in content
+        assert "Proposals Open" in content
+        assert "Upcoming" not in content
 
     def test_ok_session_card_exposes_day_and_hour_data_attributes(
         self, active_user, agenda_item, client, event


### PR DESCRIPTION
## Summary

Replaces the full-width enrollment banner with a compact status pill displayed in the event hero section, improving visual hierarchy and reducing redundant information on the event details page.

## Changes

- **UI refactor**: Moved enrollment status indicator from a dismissible alert banner to a compact inline pill (similar to "Proposals Open" and "Upcoming" badges) in the event hero
- **Template updates**: 
  - Added "Enrollment Open" pill in `event.html` hero section when `event.get_active_enrollment_configs` is active
  - Removed the full-width enrollment banner loop that displayed `enrollment_config.banner_text`
- **Polish translations**: Added translation for "Enrollment Open" → "Zapisy otwarte" and reorganized translation entries
- **Test updates**:
  - Updated e2e test to verify the compact pill appears instead of the full banner
  - Added integration test assertions to verify "Enrollment Open" text presence/absence based on enrollment config state

## Implementation Details

The enrollment status is now displayed as a coral-colored pill with an icon in the hero section, consistent with other event status indicators. The full-width banner with custom banner text has been removed entirely. This reduces visual clutter while maintaining clear communication of enrollment availability.

The change assumes enrollment banner text is no longer needed; if custom banner messaging is required in the future, it would need to be handled through a different mechanism.

https://claude.ai/code/session_01LVEzGnXCTYehsC4MMj8dit

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an "Enrollment Open" compact status pill on event pages when enrollment is active.

* **Improvements**
  * Replaced full-width enrollment banner with a single-row, space-efficient status-pills display (capped at two).
  * Response assertion helper can now check for presence/absence of specific page text.

* **Localization**
  * Updated Polish translations and translation metadata; added a few translated strings.

* **Tests**
  * Updated integration and end-to-end tests to expect the compact status pill and adjusted assertions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->