### PR TITLE
Recover from 404s on event links with stray trailing junk

### DIFF
--- a/src/ludamus/adapters/web/django/error_views.py
+++ b/src/ludamus/adapters/web/django/error_views.py
@@ -38,8 +38,8 @@ def _event_slug(path: str) -> str | None:
 
 def _event_state(request: RootRequestProtocol, slug: str) -> str:
     try:
-        event = request.di.uow.events.read_by_slug(
-            slug, request.context.current_sphere_id
+        event = request.services.events.read_by_slug(
+            request.context.current_sphere_id, slug
         )
     except NotFoundError:
         return _EVENT_MISSING
@@ -55,7 +55,7 @@ def _recover_from_404(request: HttpRequest) -> HttpResponse | None:
     # request context middleware has resolved a sphere for this host.
     if request.method not in {"GET", "HEAD"}:
         return None
-    if not hasattr(request, "di") or not hasattr(request, "context"):
+    if not hasattr(request, "services") or not hasattr(request, "context"):
         return None
 
     cleaned = strip_trailing_junk(request.path)
@@ -77,13 +77,13 @@ def _recover_from_404(request: HttpRequest) -> HttpResponse | None:
             reverse(_EVENT_VIEW_NAME, kwargs={"slug": slug})
         )
 
-    # Renamed, deleted, or never existed, but the visitor reached the right
-    # sphere: drop them on the sphere home instead of a dead end.
-    if state == _EVENT_MISSING:
+    # Missing and unpublished events return the same response on purpose, so a
+    # 404 never reveals whether an unannounced event exists. The visitor
+    # reached the right sphere, so offer the sphere home rather than a dead end.
+    # (A clean URL to a public event renders normally and never reaches here.)
+    if state in {_EVENT_MISSING, _EVENT_UNPUBLISHED}:
         return HttpResponseRedirect(reverse("web:index"))
 
-    # Unpublished (keep it private, do not bounce its previewers) or a clean
-    # URL to a public event that 404'd for some other reason: keep the page.
     return None
 
 

--- a/src/ludamus/adapters/web/django/error_views.py
+++ b/src/ludamus/adapters/web/django/error_views.py
@@ -1,15 +1,104 @@
 import secrets
+from datetime import UTC, datetime
 from http import HTTPStatus
+from typing import TYPE_CHECKING, cast
 
-from django.http import HttpRequest  # noqa: TC002  # Django
+from django.contrib import messages
+from django.http import (  # Django
+    HttpRequest,
+    HttpResponse,
+    HttpResponsePermanentRedirect,
+    HttpResponseRedirect,
+)
 from django.template.response import TemplateResponse
+from django.urls import Resolver404, resolve, reverse
 from django.utils.translation import gettext as _
+
+from ludamus.mills.url_recovery import strip_trailing_junk
+from ludamus.pacts import NotFoundError
+
+if TYPE_CHECKING:
+    from ludamus.pacts import RootRequestProtocol
+
+_EVENT_VIEW_NAME = "web:chronology:event"
+
+_EVENT_MISSING = "missing"
+_EVENT_UNPUBLISHED = "unpublished"
+_EVENT_PUBLISHED = "published"
+
+
+def _event_slug(path: str) -> str | None:
+    try:
+        match = resolve(path)
+    except Resolver404:
+        return None
+    if match.view_name == _EVENT_VIEW_NAME:
+        return match.kwargs.get("slug")
+    return None
+
+
+def _event_state(request: RootRequestProtocol, slug: str) -> str:
+    try:
+        event = request.di.uow.events.read_by_slug(
+            slug, request.context.current_sphere_id
+        )
+    except NotFoundError:
+        return _EVENT_MISSING
+    published = (
+        event.publication_time is not None
+        and event.publication_time <= datetime.now(tz=UTC)
+    )
+    return _EVENT_PUBLISHED if published else _EVENT_UNPUBLISHED
+
+
+def _recover_from_404(request: HttpRequest) -> HttpResponse | None:
+    # Only safe, idempotent navigations are recovered, and only once the
+    # request context middleware has resolved a sphere for this host.
+    if request.method not in {"GET", "HEAD"}:
+        return None
+    if not hasattr(request, "di") or not hasattr(request, "context"):
+        return None
+
+    cleaned = strip_trailing_junk(request.path)
+    # A cleaned path that resolves to an event means the original link had
+    # stray trailing characters (a dot, a closing paren, an emoji that a
+    # chat/social autolinker swallowed). Otherwise fall back to the slug of
+    # the clean-but-unresolved event URL that originally 404'd.
+    slug_from_cleaned = _event_slug(cleaned) if cleaned is not None else None
+    if (slug := slug_from_cleaned or _event_slug(request.path)) is None:
+        return None
+
+    root_request = cast("RootRequestProtocol", request)
+    state = _event_state(root_request, slug)
+
+    # A junk link to a real, public event: send them on to the clean,
+    # canonical event URL with a permanent redirect.
+    if slug_from_cleaned is not None and state == _EVENT_PUBLISHED:
+        return HttpResponsePermanentRedirect(
+            reverse(_EVENT_VIEW_NAME, kwargs={"slug": slug})
+        )
+
+    # Renamed, deleted, or never existed, but the visitor reached the right
+    # sphere: drop them on the sphere home instead of a dead end.
+    if state == _EVENT_MISSING:
+        messages.info(
+            request,
+            _("We couldn't find that event, so here's everything happening here."),
+        )
+        return HttpResponseRedirect(reverse("web:index"))
+
+    # Unpublished (keep it private, do not bounce its previewers) or a clean
+    # URL to a public event that 404'd for some other reason: keep the page.
+    return None
 
 
 def custom_404(
     request: HttpRequest, exception: Exception | None  # noqa: ARG001
-) -> TemplateResponse:
-    messages = [
+) -> HttpResponse:
+    if (recovered := _recover_from_404(request)) is not None:
+        return recovered
+
+    error_messages = [
         # D&D/Fantasy themed
         {
             "title": _("Critical Failure!"),
@@ -119,7 +208,7 @@ def custom_404(
         },
     ]
 
-    selected = messages[secrets.randbelow(len(messages))]
+    selected = error_messages[secrets.randbelow(len(error_messages))]
     context = {
         "error_code": HTTPStatus.NOT_FOUND,
         "title": selected["title"],
@@ -134,7 +223,7 @@ def custom_404(
 
 
 def custom_500(request: HttpRequest) -> TemplateResponse:
-    messages = [
+    error_messages = [
         # D&D/Fantasy themed
         {
             "title": _("Total Server Kill!"),
@@ -239,7 +328,7 @@ def custom_500(request: HttpRequest) -> TemplateResponse:
         },
     ]
 
-    selected = messages[secrets.randbelow(len(messages))]
+    selected = error_messages[secrets.randbelow(len(error_messages))]
     context = {
         "error_code": HTTPStatus.INTERNAL_SERVER_ERROR,
         "title": selected["title"],

--- a/src/ludamus/adapters/web/django/error_views.py
+++ b/src/ludamus/adapters/web/django/error_views.py
@@ -3,7 +3,6 @@ from datetime import UTC, datetime
 from http import HTTPStatus
 from typing import TYPE_CHECKING, cast
 
-from django.contrib import messages
 from django.http import (  # Django
     HttpRequest,
     HttpResponse,
@@ -81,10 +80,6 @@ def _recover_from_404(request: HttpRequest) -> HttpResponse | None:
     # Renamed, deleted, or never existed, but the visitor reached the right
     # sphere: drop them on the sphere home instead of a dead end.
     if state == _EVENT_MISSING:
-        messages.info(
-            request,
-            _("We couldn't find that event, so here's everything happening here."),
-        )
         return HttpResponseRedirect(reverse("web:index"))
 
     # Unpublished (keep it private, do not bounce its previewers) or a clean

--- a/src/ludamus/locale/pl/LC_MESSAGES/django.po
+++ b/src/ludamus/locale/pl/LC_MESSAGES/django.po
@@ -644,6 +644,10 @@ msgstr "W tej przestrzeni i w tym czasie jest już zaplanowany punkt programu."
 msgid "Sphere not found"
 msgstr "Sfera nie została znaleziona."
 
+#: src/ludamus/adapters/web/django/error_views.py
+msgid "We couldn't find that event, so here's everything happening here."
+msgstr "Nie znaleźliśmy tego wydarzenia — oto wszystko, co się tutaj dzieje."
+
 #: src/ludamus/adapters/web/django/views.py
 msgid "Please complete your profile."
 msgstr "Proszę uzupełnić profil."

--- a/src/ludamus/locale/pl/LC_MESSAGES/django.po
+++ b/src/ludamus/locale/pl/LC_MESSAGES/django.po
@@ -644,10 +644,6 @@ msgstr "W tej przestrzeni i w tym czasie jest już zaplanowany punkt programu."
 msgid "Sphere not found"
 msgstr "Sfera nie została znaleziona."
 
-#: src/ludamus/adapters/web/django/error_views.py
-msgid "We couldn't find that event, so here's everything happening here."
-msgstr "Nie znaleźliśmy tego wydarzenia — oto wszystko, co się tutaj dzieje."
-
 #: src/ludamus/adapters/web/django/views.py
 msgid "Please complete your profile."
 msgstr "Proszę uzupełnić profil."

--- a/src/ludamus/mills/multiverse.py
+++ b/src/ludamus/mills/multiverse.py
@@ -84,6 +84,9 @@ class EventsService:
             sphere_id, include_unpublished=include_unpublished
         )
 
+    def read_by_slug(self, sphere_id: int, slug: str) -> EventDTO:
+        return self._events.read_by_slug(slug, sphere_id)
+
 
 class SpherePanelService:
     """Read-side context loader for the multiverse sphere panel."""

--- a/src/ludamus/mills/url_recovery.py
+++ b/src/ludamus/mills/url_recovery.py
@@ -22,6 +22,6 @@ def strip_trailing_junk(path: str) -> str | None:
     kept = segments[:-1]
     if cleaned:
         kept.append(cleaned)
-    result = "/" + "/".join(kept) + "/"
+    result = "/" + "/".join(kept) + "/" if kept else "/"
 
     return result if result != path else None

--- a/src/ludamus/mills/url_recovery.py
+++ b/src/ludamus/mills/url_recovery.py
@@ -1,0 +1,27 @@
+import re
+
+# Characters Django's default SlugField accepts. A run of anything else at the
+# end of a path segment is junk: a stray dot from the end of a sentence, a
+# closing paren, or an emoji that a chat/social autolinker greedily swallowed
+# into the URL when a user pasted a link.
+_TRAILING_JUNK = re.compile(r"[^A-Za-z0-9_-]+$")
+
+
+# Trim trailing junk off the final segment of a path. Returns the cleaned,
+# slash-normalised path, or None when there is nothing to recover (the final
+# segment is already clean, or there is no slug-bearing segment). A segment
+# that is entirely junk is dropped back to its parent.
+def strip_trailing_junk(path: str) -> str | None:
+    if not (segments := [segment for segment in path.split("/") if segment]):
+        return None
+
+    last = segments[-1]
+    if (cleaned := _TRAILING_JUNK.sub("", last)) == last:
+        return None
+
+    kept = segments[:-1]
+    if cleaned:
+        kept.append(cleaned)
+    result = "/" + "/".join(kept) + "/"
+
+    return result if result != path else None

--- a/src/ludamus/pacts/multiverse.py
+++ b/src/ludamus/pacts/multiverse.py
@@ -71,6 +71,7 @@ class EventsServiceProtocol(Protocol):
     def list_for_sphere(
         self, sphere_id: int, *, include_unpublished: bool
     ) -> list[EventListItemDTO]: ...
+    def read_by_slug(self, sphere_id: int, slug: str) -> EventDTO: ...
 
 
 class SpherePanelServiceProtocol(Protocol):

--- a/src/ludamus/templates/components/navbar.html
+++ b/src/ludamus/templates/components/navbar.html
@@ -19,24 +19,13 @@
                     </span>
                 </a>
                 {% if current_sphere.enabled_pages|length > 1 %}
-                    {% with ns=request.resolver_match.namespace %}
-                        <div class="group hoverboard flex items-center gap-0.5">
-                            {% if "events" in current_sphere.enabled_pages %}
-                                <a href="{% url 'web:events' %}"
-                                   aria-current="{% if 'notice-board' not in ns %}page{% endif %}"
-                                   class="font-medium px-3 py-1.5 text-sm rounded-lg transition-colors text-foreground-secondary hover:text-foreground aria-[current=page]:text-foreground group-hover:not-hover:text-foreground-secondary! before:-inset-1 relative block before:absolute group-[:not(:hover)]:aria-[current=page]:[anchor-name:--a]">
-                                    {% translate "Events" %}
-                                </a>
-                            {% endif %}
-                            {% if "encounters" in current_sphere.enabled_pages %}
-                                <a aria-current="{% if 'notice-board' in ns %}page{% endif %}"
-                                   href="{% url 'web:notice-board:index' %}"
-                                   class="font-medium px-3 py-1.5 text-sm rounded-lg transition-colors text-foreground-secondary hover:text-foreground aria-[current=page]:text-foreground group-hover:not-hover:text-foreground-secondary! before:-inset-1 relative block before:absolute group-[:not(:hover)]:aria-[current=page]:[anchor-name:--a]">
-                                    {% translate "Encounters" %}
-                                </a>
-                            {% endif %}
-                        </div>
-                    {% endwith %}
+                    {% if request.resolver_match %}
+                        {% with ns=request.resolver_match.namespace %}
+                            {% include "components/navbar_pages.html" %}
+                        {% endwith %}
+                    {% else %}
+                        {% include "components/navbar_pages.html" with ns="" %}
+                    {% endif %}
                 {% endif %}
             </div>
             <div class="flex items-center">

--- a/src/ludamus/templates/components/navbar_pages.html
+++ b/src/ludamus/templates/components/navbar_pages.html
@@ -1,0 +1,17 @@
+{% load i18n %}
+<div class="group hoverboard flex items-center gap-0.5">
+    {% if "events" in current_sphere.enabled_pages %}
+        <a href="{% url 'web:events' %}"
+           aria-current="{% if 'notice-board' not in ns %}page{% endif %}"
+           class="font-medium px-3 py-1.5 text-sm rounded-lg transition-colors text-foreground-secondary hover:text-foreground aria-[current=page]:text-foreground group-hover:not-hover:text-foreground-secondary! before:-inset-1 relative block before:absolute group-[:not(:hover)]:aria-[current=page]:[anchor-name:--a]">
+            {% translate "Events" %}
+        </a>
+    {% endif %}
+    {% if "encounters" in current_sphere.enabled_pages %}
+        <a aria-current="{% if 'notice-board' in ns %}page{% endif %}"
+           href="{% url 'web:notice-board:index' %}"
+           class="font-medium px-3 py-1.5 text-sm rounded-lg transition-colors text-foreground-secondary hover:text-foreground aria-[current=page]:text-foreground group-hover:not-hover:text-foreground-secondary! before:-inset-1 relative block before:absolute group-[:not(:hover)]:aria-[current=page]:[anchor-name:--a]">
+            {% translate "Encounters" %}
+        </a>
+    {% endif %}
+</div>

--- a/tests/integration/web/chronology/test_event_page.py
+++ b/tests/integration/web/chronology/test_event_page.py
@@ -46,7 +46,7 @@ from tests.integration.conftest import (
     SessionFactory,
     UserFactory,
 )
-from tests.integration.utils import assert_response, assert_response_404
+from tests.integration.utils import assert_response
 
 PNG_BYTES = (
     b"\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDR\x00\x00\x00\x01"
@@ -2160,21 +2160,25 @@ class TestEventPageView:
             template_name=["chronology/event.html"],
         )
 
-    def test_unpublished_event_returns_404_for_anonymous(self, client, sphere):
+    # Unpublished events are not 404s but redirects to the sphere home: the 404
+    # fallback routes missing and unpublished events identically so a response
+    # never reveals whether an unannounced event exists. See
+    # TestSemantic404Recovery in tests/integration/web/test_error_views.py.
+    def test_unpublished_event_redirects_anonymous_to_home(self, client, sphere):
         event = EventFactory(sphere=sphere, publication_time=None)
 
         response = client.get(self._get_url(event.slug))
 
-        assert_response_404(response)
+        assert_response(response, HTTPStatus.FOUND, url=reverse("web:index"))
 
-    def test_unpublished_event_returns_404_for_regular_user(
+    def test_unpublished_event_redirects_regular_user_to_home(
         self, authenticated_client, sphere
     ):
         event = EventFactory(sphere=sphere, publication_time=None)
 
         response = authenticated_client.get(self._get_url(event.slug))
 
-        assert_response_404(response)
+        assert_response(response, HTTPStatus.FOUND, url=reverse("web:index"))
 
     def test_unpublished_event_visible_for_manager(
         self, authenticated_client, active_user, sphere

--- a/tests/integration/web/test_error_views.py
+++ b/tests/integration/web/test_error_views.py
@@ -1,8 +1,14 @@
 from http import HTTPStatus
 
 import pytest
+from django.contrib import messages
+from django.urls import reverse
 
 from ludamus.adapters.web.django.error_views import custom_404, custom_500
+from tests.integration.conftest import EventFactory
+from tests.integration.utils import assert_response, assert_response_404
+
+_FALLBACK_MESSAGE = "We couldn't find that event, so here's everything happening here."
 
 
 @pytest.mark.django_db
@@ -116,6 +122,73 @@ class TestCustom500:
         assert context["subtitle"]
         assert isinstance(context["icon"], str)
         assert context["icon"]
+
+
+@pytest.mark.django_db
+class TestSemantic404Recovery:
+    @staticmethod
+    def _event_url(slug: str) -> str:
+        return reverse("web:chronology:event", kwargs={"slug": slug})
+
+    def test_trailing_dot_redirects_to_canonical_event(self, client, event):
+        response = client.get(f"{self._event_url(event.slug)}.")
+
+        assert_response(
+            response, HTTPStatus.MOVED_PERMANENTLY, url=self._event_url(event.slug)
+        )
+
+    def test_trailing_emoji_redirects_to_canonical_event(self, client, event):
+        response = client.get(f"{self._event_url(event.slug)}\U0001f600")
+
+        assert_response(
+            response, HTTPStatus.MOVED_PERMANENTLY, url=self._event_url(event.slug)
+        )
+
+    def test_missing_event_falls_back_to_sphere_home(self, client):
+        response = client.get(self._event_url("no-such-event"))
+
+        assert_response(
+            response,
+            HTTPStatus.FOUND,
+            url=reverse("web:index"),
+            messages=[(messages.INFO, _FALLBACK_MESSAGE)],
+        )
+
+    def test_junk_link_to_missing_event_falls_back_to_sphere_home(self, client):
+        response = client.get(f"{self._event_url('ghost')}.")
+
+        assert_response(
+            response,
+            HTTPStatus.FOUND,
+            url=reverse("web:index"),
+            messages=[(messages.INFO, _FALLBACK_MESSAGE)],
+        )
+
+    def test_unpublished_event_with_junk_keeps_themed_404(self, client, sphere):
+        # A real-but-unpublished event must not be revealed (nor its visitors
+        # bounced) by the fallback, even when the link carries trailing junk.
+        unpublished = EventFactory(sphere=sphere, publication_time=None)
+        junk_url = f"{self._event_url(unpublished.slug)[:-1]}./"
+
+        response = client.get(junk_url)
+
+        assert_response_404(response)
+
+    def test_non_event_path_keeps_themed_404(self, client):
+        # A resolvable, non-event path that 404s (a missing flatpage) must not
+        # be swept up by the event fallback.
+        response = client.get("/page/no-such-flatpage/")
+
+        assert_response_404(response)
+
+    @staticmethod
+    def test_non_get_request_falls_through_to_themed_404(rf):
+        # Only safe, idempotent navigations are recovered; a 404'd POST keeps
+        # the themed page rather than being redirected.
+        response = custom_404(rf.post("/chronology/event/ghost./"), None)
+
+        assert response.status_code == HTTPStatus.NOT_FOUND
+        assert response.template_name == "404_dynamic.html"
 
 
 @pytest.mark.django_db

--- a/tests/integration/web/test_error_views.py
+++ b/tests/integration/web/test_error_views.py
@@ -1,14 +1,11 @@
 from http import HTTPStatus
 
 import pytest
-from django.contrib import messages
 from django.urls import reverse
 
 from ludamus.adapters.web.django.error_views import custom_404, custom_500
 from tests.integration.conftest import EventFactory
 from tests.integration.utils import assert_response, assert_response_404
-
-_FALLBACK_MESSAGE = "We couldn't find that event, so here's everything happening here."
 
 
 @pytest.mark.django_db
@@ -147,22 +144,12 @@ class TestSemantic404Recovery:
     def test_missing_event_falls_back_to_sphere_home(self, client):
         response = client.get(self._event_url("no-such-event"))
 
-        assert_response(
-            response,
-            HTTPStatus.FOUND,
-            url=reverse("web:index"),
-            messages=[(messages.INFO, _FALLBACK_MESSAGE)],
-        )
+        assert_response(response, HTTPStatus.FOUND, url=reverse("web:index"))
 
     def test_junk_link_to_missing_event_falls_back_to_sphere_home(self, client):
         response = client.get(f"{self._event_url('ghost')}.")
 
-        assert_response(
-            response,
-            HTTPStatus.FOUND,
-            url=reverse("web:index"),
-            messages=[(messages.INFO, _FALLBACK_MESSAGE)],
-        )
+        assert_response(response, HTTPStatus.FOUND, url=reverse("web:index"))
 
     def test_unpublished_event_with_junk_keeps_themed_404(self, client, sphere):
         # A real-but-unpublished event must not be revealed (nor its visitors
@@ -178,6 +165,13 @@ class TestSemantic404Recovery:
         # A resolvable, non-event path that 404s (a missing flatpage) must not
         # be swept up by the event fallback.
         response = client.get("/page/no-such-flatpage/")
+
+        assert_response_404(response)
+
+    def test_fully_unresolvable_path_renders_themed_404(self, client):
+        # No URL pattern matches, so request.resolver_match is None; the themed
+        # 404 (and its navbar) must still render.
+        response = client.get("/totally/unknown/place/")
 
         assert_response_404(response)
 

--- a/tests/integration/web/test_error_views.py
+++ b/tests/integration/web/test_error_views.py
@@ -151,15 +151,15 @@ class TestSemantic404Recovery:
 
         assert_response(response, HTTPStatus.FOUND, url=reverse("web:index"))
 
-    def test_unpublished_event_with_junk_keeps_themed_404(self, client, sphere):
-        # A real-but-unpublished event must not be revealed (nor its visitors
-        # bounced) by the fallback, even when the link carries trailing junk.
+    def test_unpublished_event_redirects_like_a_missing_one(self, client, sphere):
+        # Crucial: an unpublished event must produce the SAME response as a
+        # missing one (302 to home), so a 404 never betrays whether an
+        # unannounced event with this slug exists.
         unpublished = EventFactory(sphere=sphere, publication_time=None)
-        junk_url = f"{self._event_url(unpublished.slug)[:-1]}./"
 
-        response = client.get(junk_url)
+        response = client.get(self._event_url(unpublished.slug))
 
-        assert_response_404(response)
+        assert_response(response, HTTPStatus.FOUND, url=reverse("web:index"))
 
     def test_non_event_path_keeps_themed_404(self, client):
         # A resolvable, non-event path that 404s (a missing flatpage) must not

--- a/tests/integration/web/test_error_views.py
+++ b/tests/integration/web/test_error_views.py
@@ -184,6 +184,14 @@ class TestSemantic404Recovery:
         assert response.status_code == HTTPStatus.NOT_FOUND
         assert response.template_name == "404_dynamic.html"
 
+    def test_head_request_is_recovered_like_get(self, client):
+        # HEAD is a safe, idempotent navigation, so it is recovered exactly
+        # like GET (302 to the sphere home) rather than dropped like POST.
+        url = self._event_url("no-such-event")
+
+        assert_response(client.get(url), HTTPStatus.FOUND, url=reverse("web:index"))
+        assert_response(client.head(url), HTTPStatus.FOUND, url=reverse("web:index"))
+
 
 @pytest.mark.django_db
 class TestErrorViewsIntegration:

--- a/tests/unit/test_url_recovery.py
+++ b/tests/unit/test_url_recovery.py
@@ -1,0 +1,47 @@
+import pytest
+
+from ludamus.mills.url_recovery import strip_trailing_junk
+
+
+@pytest.mark.parametrize(
+    ("path", "expected"),
+    (
+        # Trailing punctuation a chat autolinker swallowed into the URL.
+        ("/chronology/event/summer-con.", "/chronology/event/summer-con/"),
+        ("/chronology/event/summer-con/.", "/chronology/event/summer-con/"),
+        ("/chronology/event/summer-con).", "/chronology/event/summer-con/"),
+        ("/chronology/event/summer-con/).", "/chronology/event/summer-con/"),
+        # A trailing emoji, with or without its own path segment.
+        ("/chronology/event/summer-con\U0001f600", "/chronology/event/summer-con/"),
+        ("/chronology/event/summer-con/\U0001f600", "/chronology/event/summer-con/"),
+        ("/chronology/event/summer-con/\U0001f600/", "/chronology/event/summer-con/"),
+        # Junk on a slug also strips back to the clean slug.
+        ("/chronology/event/summer-con!!!", "/chronology/event/summer-con/"),
+    ),
+)
+def test_strips_trailing_junk(path: str, expected: str) -> None:
+    assert strip_trailing_junk(path) == expected
+
+
+@pytest.mark.parametrize(
+    "path",
+    (
+        "/chronology/event/summer-con/",
+        "/chronology/event/summer-con",
+        "/events/",
+        "/",
+        "",
+    ),
+)
+def test_clean_paths_yield_no_recovery(path: str) -> None:
+    assert strip_trailing_junk(path) is None
+
+
+def test_keeps_underscores_and_hyphens() -> None:
+    assert strip_trailing_junk("/chronology/event/a_b-c/") is None
+
+
+def test_segment_that_is_only_junk_is_dropped_to_parent() -> None:
+    assert strip_trailing_junk("/chronology/event/summer-con/!!!") == (
+        "/chronology/event/summer-con/"
+    )

--- a/tests/unit/test_url_recovery.py
+++ b/tests/unit/test_url_recovery.py
@@ -45,3 +45,8 @@ def test_segment_that_is_only_junk_is_dropped_to_parent() -> None:
     assert strip_trailing_junk("/chronology/event/summer-con/!!!") == (
         "/chronology/event/summer-con/"
     )
+
+
+@pytest.mark.parametrize("path", ("/.", "/!!!/", "/\U0001f600"))
+def test_all_junk_path_normalises_to_root(path: str) -> None:
+    assert strip_trailing_junk(path) == "/"


### PR DESCRIPTION
## Why

People keep sharing event links that pick up a stray **dot** or **emoji** at the very end — a chat/social autolinker greedily swallows the trailing character into the URL. The result is a perfectly good event link that 404s. This is a [well-documented phenomenon](https://www.redblobgames.com/blog/2026-02-12-urls-with-trailing-punctuation/) (autolinkers grabbing trailing punctuation); the emoji variant is [its own messy class of bug](https://github.com/RocketChat/Rocket.Chat/issues/15882) because trailing emoji carry variant-selectors / ZWJ sequences.

Rather than dead-ending on the themed 404, this teaches the 404 handler to **resolve to the closest non-404 page**.

## Screenshots

| Before | After |
| --- | --- |
| A link with a trailing emoji dead-ends on the themed 404. | The same link lands on the real event page (301). |

_A non-existent event now lands on the events list (302, silently — no banner)._ Images attached in the session; drag them in here.

## What it does

When a request 404s, before rendering the themed page the handler tries, in order:

1. **Strip trailing junk → 301.** Trim any trailing characters that aren't valid in a slug off the final path segment. If the cleaned URL points at a real, **published** event, permanently redirect to the canonical event URL. Because it strips by *slug charset* (not a fixed punctuation list), it handles `…/my-event.`, `…/my-event)`, **and** `…/my-event😀` / `…/my-event/😀` uniformly.
2. **Walk up the hierarchy → 302.** If the event isn't publicly viewable — missing *or* unpublished — but the visitor reached the right **sphere**, send them to the sphere home **silently** (no flash message).
3. **Otherwise** → the existing themed 404, unchanged.

`301` for normalisation (stable, cacheable); `302` for the semantic walk-up (it's a guess, don't poison caches).

### Privacy: no existence oracle

Missing and unpublished events return the **same** response (302 → sphere home). This is deliberate: event slugs are derived from names and are guessable before launch, so if a missing event redirected while an unpublished one 404'd, probing `/chronology/event/<guess>/` would reveal whether an unannounced event exists. Routing both to the sphere home keeps them indistinguishable. (Caught in review — thanks.) Managers still see unpublished events normally (200). This changes the prior "unpublished ⇒ 404" behaviour to "unpublished ⇒ redirect to home", which the unpublished-event event-page tests now assert.

### Other scoping

- **Only event URLs are touched.** A random 404 (`/page/whatever/`, a typo'd profile URL) still gets the themed page — no blanket "redirect everything to home".
- **Only `GET`/`HEAD`** are recovered.

### Bonus: themed 404 hardening

Fixed a pre-existing fragility where the shared **navbar** assumed `request.resolver_match` was set. On a *fully unresolvable* URL it's `None`, so the themed 404 couldn't render its nav (Django silently swallows it in prod; our strict template-variable test checker trips on it). Guarded the namespace lookup and extracted the page links into `components/navbar_pages.html` so both branches share one markup source.

## Prior art (research)

- **redblobgames – "URLs with trailing punctuation"**: same problem/cause; their nginx/Caddy fix strips trailing `[;:,.)]` but **explicitly doesn't handle emoji** — the gap this fills.
- **[Cal.com #10483](https://github.com/calcom/cal.com/issues/10483) "Forward broken booking links to user profile"**: literally this idea. Still open/unimplemented — a real, unmet want.
- The usual alternative is a **redirect/permalink table** (Django's `contrib.redirects`, Discourse permalinks, WordPress plugins). This approach is **stateless** — no mapping table to maintain.

## Design / layering

Per GLIMPSE:
- **`mills/url_recovery.py`** — pure `strip_trailing_junk(path)` (charset-based, no IO). Unit-tested.
- **`adapters/web/django/error_views.py`** — wiring in the 404 handler. Reads the event via **`request.services.events.read_by_slug`** (new service method on `EventsService` / `EventsServiceProtocol`), not the legacy `request.di.uow` surface.

## Tests

- **Unit** (`tests/unit/test_url_recovery.py`): trailing dot / paren / emoji (with and without its own segment) / multi-junk; clean paths and root yield no recovery; all-junk → `/`.
- **Integration** (`tests/integration/web/test_error_views.py`): trailing dot **and** emoji on a real event → 301 to canonical; missing event → 302 home; junk link to a missing event → 302; **unpublished event → 302 home (same as missing — no oracle)**; resolvable non-event 404 (missing flatpage) → themed 404; **fully unresolvable URL → themed 404 renders** (navbar fix); non-GET → themed 404.
- Updated `test_event_page.py` unpublished-event tests to assert the redirect.

Full `mise run check` is green (ruff, mypy, pylint 10/10, import-linter, djlint, vulture, ast-grep, impeccable); full suite: 1774 passed, 3 skipped.

## Open question for review

- Should the walk-up also cover **sessions** (currently int-id URLs that already redirect to home on miss)? Left out for now.

> Draft — behaviour is verified by integration tests and the attached live screenshots.

https://claude.ai/code/session_01SdU1o8vZFC7vETjKL1gwxM

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Intelligent 404 recovery that normalizes URLs with trailing punctuation/special characters and redirects to canonical event pages or the site home when appropriate.
  * Navbar pages moved into a reusable component for clearer navigation rendering.

* **Bug Fixes**
  * Unpublished events redirect users to the home page instead of exposing error pages.

* **Tests**
  * New unit and integration tests covering URL recovery and revised unpublished-event behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->