### PR TITLE
fix(flaky): AnonymousUserFactory slug collision via faker.word()

### DIFF
--- a/tests/integration/factories.py
+++ b/tests/integration/factories.py
@@ -1,12 +1,9 @@
 import factory
 from django.contrib.auth.hashers import make_password
 from factory.django import DjangoModelFactory
-from faker import Faker
 
 from ludamus.adapters.db.django.models import User
 from ludamus.pacts import UserType
-
-faker = Faker()
 
 
 class CompleteUserFactory(DjangoModelFactory):
@@ -26,6 +23,6 @@ class AnonymousUserFactory(DjangoModelFactory):
 
     is_active = False
     password = factory.LazyFunction(lambda: make_password(None))
-    slug = factory.LazyFunction(lambda: f"code_{faker.word()}")
+    slug = factory.Sequence(lambda n: f"code_{n}")
     user_type = UserType.ANONYMOUS
     username = factory.Faker("uuid4")


### PR DESCRIPTION
## Root-cause analysis

`AnonymousUserFactory` was generating user slugs with:

```python
slug = factory.LazyFunction(lambda: f"code_{faker.word()}")
```

`faker.word()` draws from a vocabulary of ~200 common English words. The birthday problem means that any test creating two anonymous users in the same transaction has a ~0.5% chance of a slug collision, which raises:

```
django.db.utils.IntegrityError: UNIQUE constraint failed: user.slug
```

The test `test_post_session_full` creates exactly two users in sequence (`filler_user` + `user`), hitting this reliably enough to appear in CI once per ~200 runs.

**Observed failure:** run [#1143](https://github.com/zagrajmy/ludamus/actions/runs/26840767514) on SHA `9ef0d835` (2026-06-02), job `test`, step "Run mise run test -- --cov".

## Fix

Replace the random `LazyFunction` with a `Sequence`, which is guaranteed unique within the test session:

```python
# before
slug = factory.LazyFunction(lambda: f"code_{faker.word()}")

# after
slug = factory.Sequence(lambda n: f"code_{n}")
```

The unused `faker` module-level instance and `Faker` import are removed as a side-effect.

## Verification

Full suite (1754 tests) passes locally. The previously failing test was run 3× consecutively after the fix with zero failures.

## Flaky test report context

Scanned 25 CI runs on `main` from 2026-05-30 → 2026-06-06. Two runs failed:

| Run | SHA | Failure |
|-----|-----|---------|
| [#1143](https://github.com/zagrajmy/ludamus/actions/runs/26840767514) | `9ef0d835` | `UNIQUE constraint failed: user.slug` (fixed here) |
| [#1126](https://github.com/zagrajmy/ludamus/actions/runs/26802171591) | `89f48e3f` | E2E: DNS failure for `membership-test.example.com` + Playwright strict-mode violation in `panel.spec.ts:1363` |

The E2E failures are tracked separately — the DNS failure is an infrastructure/network issue, and the strict-mode violation (`'Beginner Friendly firefox' .add-field resolved to 2/3 elements`) indicates accumulated shared DOM state across tests in the CFP flow suite.

https://claude.ai/code/session_01NpCjAoXdc4kbMi6MBHdBkR

---
_Generated by [Claude Code](https://claude.ai/code/session_01NpCjAoXdc4kbMi6MBHdBkR)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test data generation in integration tests for better consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->