### PR TITLE
fix(flaky): configures session type with all fields and time slots

### DIFF
--- a/tests/e2e/tests/panel.spec.ts
+++ b/tests/e2e/tests/panel.spec.ts
@@ -1075,7 +1075,10 @@ test.describe('Backoffice Panel', () => {
       test('creates session type for proposal flow', async ({
         page,
       }, testInfo) => {
-        const suffix = testInfo.project.name;
+        const suffix =
+          testInfo.retry > 0
+            ? `${testInfo.project.name}-r${testInfo.retry}`
+            : testInfo.project.name;
         proposalCategoryName = `Tabletop RPG ${suffix}`;
         proposalTitle = `Dragon's Lair ${suffix}: A Beginner Adventure`;
         cityName = `City ${suffix}`;

--- a/tests/integration/factories.py
+++ b/tests/integration/factories.py
@@ -26,6 +26,6 @@ class AnonymousUserFactory(DjangoModelFactory):
 
     is_active = False
     password = factory.LazyFunction(lambda: make_password(None))
-    slug = factory.LazyFunction(lambda: f"code_{faker.word()}")
+    slug = factory.Sequence(lambda n: f"code_{n}")
     user_type = UserType.ANONYMOUS
     username = factory.Faker("uuid4")


### PR DESCRIPTION
## Root-cause analysis

### #1 flaky: `[firefox] › tests/e2e/tests/panel.spec.ts:1363` — "configures session type with all fields and time slots"

**Flake rate**: Playwright reported **"1 flaky"** on run [#1126](https://github.com/zagrajmy/ludamus/actions/runs/26802171591) (SHA `89f48e3f`). The test passed on its first attempt but failed on both retries with a strict-mode violation.

**Root cause – serial retry contamination**

The failing test lives inside `test.describe.serial('CFP to proposal to panel flow', ...)`. Playwright's serial semantics re-run the *entire group from test 1* whenever any test in the group fails. An earlier test in the group creates a database entity named `"Beginner Friendly ${suffix}"` (where `suffix = testInfo.project.name`, e.g. `"firefox"`). On the first run it creates one entry. When the group is retried it runs again and creates a second entry with the *same name*. By retry #1 the locator resolves to 2 elements; by retry #2 it resolves to 3 — Playwright throws a strict-mode violation each time.

```
Error: locator('#session-fields-list .avail-list .field-item')
  .filter({ hasText: 'Beginner Friendly firefox' })
  .locator('.add-field') resolved to 2 elements   ← retry #1
                          resolved to 3 elements   ← retry #2
```

**Fix** (`tests/e2e/tests/panel.spec.ts`): append `-r<N>` to the naming suffix when `testInfo.retry > 0`. Each retry attempt now uses distinct entity names (`"Beginner Friendly firefox-r1"`, `"Beginner Friendly firefox-r2"`), so there is never more than one matching element in the locator.

---

### Bonus fix: `test_post_session_full` — slug collision in `AnonymousUserFactory`

Run [#1143](https://github.com/zagrajmy/ludamus/actions/runs/26840767514) (SHA `9ef0d835`) saw a single failure:

```
FAILED tests/integration/web/chronology/test_session_enrollment_anonymous_page.py::…::test_post_session_full
django.db.utils.IntegrityError: UNIQUE constraint failed: user.slug
```

The factory used `slug = factory.LazyFunction(lambda: f"code_{faker.word()}")`. `faker.word()` draws from ~550 English words; the test calls the factory *twice* in the same transaction, and the same word can be drawn both times. Replaced with `factory.Sequence(lambda n: f"code_{n}")` which is guaranteed unique within a test run.

## Changes

| File | Change |
|------|--------|
| `tests/e2e/tests/panel.spec.ts` | Include `testInfo.retry` in the naming suffix for the CFP serial group |
| `tests/integration/factories.py` | Replace `faker.word()` with `factory.Sequence` in `AnonymousUserFactory.slug` |

## Test plan

- [x] Full unit+integration test suite passes locally: 1754 passed, 3 skipped
- [ ] E2E suite — cannot run Playwright locally in this environment; the fix is structural (unique names per retry) and the root cause is deterministic

https://claude.ai/code/session_01TBVg6ssKjGi8MG8ttX7kJR

---
_Generated by [Claude Code](https://claude.ai/code/session_01TBVg6ssKjGi8MG8ttX7kJR)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Tests
* Improved test reliability for retry scenarios by ensuring unique test identifiers
* Enhanced consistency of test data generation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->