### PR TITLE
Deploy explicitly-dispatched PR to staging without requiring the staging label

### DIFF
--- a/scripts/github-staging.mts
+++ b/scripts/github-staging.mts
@@ -116,7 +116,8 @@ const repoParams = (context: Context) => ({
   repo: context.repo.repo,
 });
 
-const repoFullName = (context: Context) => `${context.repo.owner}/${context.repo.repo}`;
+const repoFullName = (context: Context) =>
+  `${context.repo.owner}/${context.repo.repo}`;
 
 const isSameRepositoryPullRequest = (context: Context, pr: PullRequestLike) =>
   pr.head?.repo?.full_name === repoFullName(context);
@@ -223,10 +224,16 @@ const dispatchDeploy = async ({
       sha: pr.head.sha,
     },
   });
-  core.info(`Dispatched ${DEPLOY_WORKFLOW_ID} for PR #${pr.number} at ${pr.head.sha}`);
+  core.info(
+    `Dispatched ${DEPLOY_WORKFLOW_ID} for PR #${pr.number} at ${pr.head.sha}`,
+  );
 };
 
-export const handlePullRequest = async ({ github, context, core }: ActionArgs) => {
+export const handlePullRequest = async ({
+  github,
+  context,
+  core,
+}: ActionArgs) => {
   const eventPr = context.payload.pull_request;
   if (!eventPr) throw new Error("Expected pull_request payload");
 
@@ -238,7 +245,11 @@ export const handlePullRequest = async ({ github, context, core }: ActionArgs) =
     return;
   }
 
-  const pr = await fetchPullRequest({ github, context, number: eventPr.number });
+  const pr = await fetchPullRequest({
+    github,
+    context,
+    number: eventPr.number,
+  });
 
   if (pr.draft) {
     core.info(`PR #${pr.number} is a draft`);
@@ -295,12 +306,22 @@ const resolveExplicitDeploy = async ({
 }: ResolveExplicitDeployArgs) => {
   const pr = await fetchPullRequest({ github, context, number: prNumber });
 
-  if (pr.state !== "open" || pr.draft || !hasStagingLabel(pr) || pr.head?.sha !== sha) {
+  // An explicit dispatch is itself the authorization to deploy, so we do NOT
+  // require the staging label here (that gate is only for the auto-flow). We
+  // still refuse closed/draft PRs and stale commits, and claimStagingTarget
+  // strips the label from any other PR so only the explicit target is on
+  // staging.
+  if (pr.state !== "open" || pr.draft) {
     setShouldDeploy(
       core,
       false,
-      `PR #${prNumber} is no longer the current ${STAGING_LABEL} target for ${sha}`,
+      `PR #${prNumber} is not an open, non-draft pull request`,
     );
+    return;
+  }
+
+  if (pr.head?.sha !== sha) {
+    setShouldDeploy(core, false, `PR #${prNumber} head is no longer ${sha}`);
     return;
   }
 
@@ -333,7 +354,11 @@ const resolveManualDeploy = async ({
   );
 
   if (matchingStagingPrs.length !== 1) {
-    setShouldDeploy(core, false, `No unique open PR with ${STAGING_LABEL} for ${sha}`);
+    setShouldDeploy(
+      core,
+      false,
+      `No unique open PR with ${STAGING_LABEL} for ${sha}`,
+    );
     return;
   }
 
@@ -349,7 +374,11 @@ const resolveManualDeploy = async ({
     !hasStagingLabel(winner) ||
     !isSameRepositoryPullRequest(context, winner)
   ) {
-    setShouldDeploy(core, false, `No unique open PR with ${STAGING_LABEL} for ${sha}`);
+    setShouldDeploy(
+      core,
+      false,
+      `No unique open PR with ${STAGING_LABEL} for ${sha}`,
+    );
     return;
   }
 
@@ -361,12 +390,18 @@ export const resolveDeploy = async ({ github, context, core }: ActionArgs) => {
   const inputSha = context.payload.inputs?.sha?.trim();
   const sha = inputSha || context.sha;
   const prNumberInput = context.payload.inputs?.pr_number?.trim();
-  const prNumber = prNumberInput ? Number.parseInt(prNumberInput, 10) : undefined;
+  const prNumber = prNumberInput
+    ? Number.parseInt(prNumberInput, 10)
+    : undefined;
 
   core.setOutput("sha", sha);
 
   if (prNumberInput && (!prNumber || String(prNumber) !== prNumberInput)) {
-    setShouldDeploy(core, false, `Invalid pull request number: ${prNumberInput}`);
+    setShouldDeploy(
+      core,
+      false,
+      `Invalid pull request number: ${prNumberInput}`,
+    );
     return;
   }
 

--- a/scripts/github-staging.mts
+++ b/scripts/github-staging.mts
@@ -397,10 +397,16 @@ export const resolveDeploy = async ({ github, context, core }: ActionArgs) => {
   const prNumber = prNumberInput
     ? Number.parseInt(prNumberInput, 10)
     : undefined;
+  const isValidPrNumber =
+    !prNumberInput ||
+    (prNumber !== undefined &&
+      Number.isSafeInteger(prNumber) &&
+      prNumber > 0 &&
+      String(prNumber) === prNumberInput);
 
   core.setOutput("sha", sha);
 
-  if (prNumberInput && (!prNumber || String(prNumber) !== prNumberInput)) {
+  if (!isValidPrNumber) {
     setShouldDeploy(
       core,
       false,

--- a/scripts/github-staging.mts
+++ b/scripts/github-staging.mts
@@ -321,7 +321,11 @@ const resolveExplicitDeploy = async ({
   }
 
   if (pr.head?.sha !== sha) {
-    setShouldDeploy(core, false, `PR #${prNumber} head is no longer ${sha}`);
+    setShouldDeploy(
+      core,
+      false,
+      `PR #${prNumber} head ${pr.head?.sha} no longer matches requested ${sha}`,
+    );
     return;
   }
 

--- a/scripts/github-staging.test.mts
+++ b/scripts/github-staging.test.mts
@@ -203,7 +203,10 @@ test("stale explicit dispatch does not remove another PR staging label", async (
   assert.deepEqual(args.calls, [
     ["output", "sha", "old-head-sha"],
     ["output", "should_deploy", "false"],
-    ["info", "PR #1 head is no longer old-head-sha"],
+    [
+      "info",
+      "PR #1 head new-head-sha no longer matches requested old-head-sha",
+    ],
   ]);
 });
 
@@ -251,6 +254,27 @@ test("explicit dispatch does not deploy fork pull requests", async () => {
     currentPr: {
       head: { repo: { full_name: "contributor/repo" }, sha: "head-sha" },
       labels: [{ name: "staging" }],
+      number: 2,
+      state: "open",
+    },
+    inputs: { pr_number: "2", sha: "head-sha" },
+    stagingPrs: [{ number: 1, pull_request: {}, state: "open" }],
+  });
+
+  await staging.resolveDeploy(args);
+
+  assert.deepEqual(args.calls, [
+    ["output", "sha", "head-sha"],
+    ["output", "should_deploy", "false"],
+    ["info", "Skipping staging deploy for fork PR #2"],
+  ]);
+});
+
+test("explicit dispatch does not deploy an unlabeled fork PR", async () => {
+  const args = makeArgs({
+    currentPr: {
+      head: { repo: { full_name: "contributor/repo" }, sha: "head-sha" },
+      labels: [],
       number: 2,
       state: "open",
     },

--- a/scripts/github-staging.test.mts
+++ b/scripts/github-staging.test.mts
@@ -401,6 +401,21 @@ test("manual dispatch with invalid PR number is non-mutating", async () => {
   ]);
 });
 
+test("dispatch with non-positive PR number is non-mutating", async () => {
+  const args = makeArgs({
+    inputs: { pr_number: "-1", sha: "manual-sha" },
+    stagingPrs: [{ number: 2, pull_request: {}, state: "open" }],
+  });
+
+  await staging.resolveDeploy(args);
+
+  assert.deepEqual(args.calls, [
+    ["output", "sha", "manual-sha"],
+    ["output", "should_deploy", "false"],
+    ["info", "Invalid pull request number: -1"],
+  ]);
+});
+
 test("ignores non-staging labels", async () => {
   const args = makeArgs({ labelName: "bug" });
 

--- a/scripts/github-staging.test.mts
+++ b/scripts/github-staging.test.mts
@@ -44,7 +44,8 @@ const makeArgs = ({
   const calls: Call[] = [];
   const core = {
     info: (message: string) => calls.push(["info", message]),
-    setOutput: (name: string, value: string) => calls.push(["output", name, value]),
+    setOutput: (name: string, value: string) =>
+      calls.push(["output", name, value]),
   };
   const github: ActionArgs["github"] = {
     paginate: async (
@@ -180,7 +181,9 @@ test("does not redeploy a fork PR on synchronize", async () => {
 
   await staging.handlePullRequest(args);
 
-  assert.deepEqual(args.calls, [["info", "Skipping staging deploy for fork PR #3"]]);
+  assert.deepEqual(args.calls, [
+    ["info", "Skipping staging deploy for fork PR #3"],
+  ]);
 });
 
 test("stale explicit dispatch does not remove another PR staging label", async () => {
@@ -200,7 +203,7 @@ test("stale explicit dispatch does not remove another PR staging label", async (
   assert.deepEqual(args.calls, [
     ["output", "sha", "old-head-sha"],
     ["output", "should_deploy", "false"],
-    ["info", "PR #1 is no longer the current staging target for old-head-sha"],
+    ["info", "PR #1 head is no longer old-head-sha"],
   ]);
 });
 
@@ -212,6 +215,24 @@ test("current explicit dispatch deploys and clears other staging labels", async 
       { number: 1, pull_request: {}, state: "open" },
       { number: 2, pull_request: {}, state: "open" },
     ],
+  });
+
+  await staging.resolveDeploy(args);
+
+  assert.deepEqual(args.calls, [
+    ["output", "sha", "head-sha"],
+    ["remove", 1],
+    ["info", "Removed staging from PR #1"],
+    ["output", "should_deploy", "true"],
+    ["info", "Deploying PR #2 at head-sha"],
+  ]);
+});
+
+test("explicit dispatch deploys an unlabeled PR and rips staging from others", async () => {
+  const args = makeArgs({
+    currentPr: { ...basePr, labels: [] },
+    inputs: { pr_number: "2", sha: "head-sha" },
+    stagingPrs: [{ number: 1, pull_request: {}, state: "open" }],
   });
 
   await staging.resolveDeploy(args);
@@ -258,7 +279,7 @@ test("explicit dispatch does not deploy draft pull requests", async () => {
   assert.deepEqual(args.calls, [
     ["output", "sha", "head-sha"],
     ["output", "should_deploy", "false"],
-    ["info", "PR #2 is no longer the current staging target for head-sha"],
+    ["info", "PR #2 is not an open, non-draft pull request"],
   ]);
 });
 
@@ -274,7 +295,7 @@ test("explicit dispatch on closed pull request does not deploy or mutate labels"
   assert.deepEqual(args.calls, [
     ["output", "sha", "head-sha"],
     ["output", "should_deploy", "false"],
-    ["info", "PR #2 is no longer the current staging target for head-sha"],
+    ["info", "PR #2 is not an open, non-draft pull request"],
   ]);
 });
 
@@ -379,7 +400,9 @@ test("does not dispatch staging deploys for fork pull requests", async () => {
 
   await staging.handlePullRequest(args);
 
-  assert.deepEqual(args.calls, [["info", "Skipping staging deploy for fork PR #3"]]);
+  assert.deepEqual(args.calls, [
+    ["info", "Skipping staging deploy for fork PR #3"],
+  ]);
 });
 
 test("does not dispatch or mutate labels for closed pull requests", async () => {


### PR DESCRIPTION
## Problem

Running the **Deploy to staging** `workflow_dispatch` with an explicit `pr_number` silently skips unless the target PR also carries the `staging` label. The resolve step sets `should_deploy=false` and the build job's `if:` guard skips it — e.g. `No unique open PR with staging for <sha>` / `PR #N is no longer the current staging target`.

That's a bug: a human invoking the dispatch with an explicit PR has **already** authorized the deploy. The `staging` label is meant to drive the *auto*-deploy flow (label/push → `handlePullRequest` dispatches), not to gate an explicit manual deploy.

## Fix

In `resolveExplicitDeploy` (the path taken when `pr_number` is provided), drop the `!hasStagingLabel(pr)` gate. It still:

- refuses **closed / draft** PRs,
- refuses **stale** commits (PR head no longer matches the dispatched `sha`),
- refuses **fork** PRs (`claimStagingTarget`),
- and **rips `staging` off every other PR** via the existing `exclusiveStagingFor`, so only one PR is the staging target at a time.

The auto-flow (`handlePullRequest`) and the no-`pr_number` manual path are unchanged — both still require the label.

> Note: it deliberately does **not** *add* the label to the explicitly-deployed PR — that would re-fire the `labeled` automation. Per the requirement, it only strips the label from other PRs.

## Tests

`scripts/github-staging.test.mts` (`node --test`): added a positive case — *"explicit dispatch deploys an unlabeled PR and rips staging from others"* — and updated the draft/closed/stale messages. **18/18 pass.** prettier clean.

https://claude.ai/code/session_015a7cF2YMpaJ3cxTBP7b1GK

---
_Generated by [Claude Code](https://claude.ai/code/session_015a7cF2YMpaJ3cxTBP7b1GK)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Explicit staging deploys can target a pull request even if it lacks the staging label.
  * Claiming an explicit deploy moves staging status to the targeted PR and removes it from others.
  * Additional informational logging for deploy dispatch decisions and outcomes.
* **Bug Fixes**
  * Explicit deploys now reject non-open or draft PRs and those whose commit SHA no longer matches.
  * PR number parsing tightened to require a positive integer.
* **Tests**
  * Added/updated tests covering unlabeled explicit dispatches, staging-claim behavior, logging, and PR-number validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->