### PR TITLE
Fix iOS Safari input zoom on focus

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -10,7 +10,7 @@ node = "v25.6.1"
 poetry = { version = "2.3.2", pyproject = "{{ config_root }}/pyproject.toml" }
 "ast-grep" = "0.42.1"
 markdownlint-cli2 = "0.22.1"
-aube = "latest"
+"github:endevco/aube" = "latest"
 
 [env]
 _.python.venv = { path = ".venv", create = true }

--- a/src/ludamus/client/src/index.css
+++ b/src/ludamus/client/src/index.css
@@ -257,6 +257,15 @@ select:focus-visible {
   border-color: var(--color-border-focus) !important;
 }
 
+/* Prevent iOS Safari from zooming into inputs on focus (requires font-size >= 16px) */
+@media (max-width: 640px) {
+  input,
+  textarea,
+  select {
+    font-size: 1rem;
+  }
+}
+
 button:active {
   @apply scale-97;
 }

--- a/src/ludamus/templates/chronology/event.html
+++ b/src/ludamus/templates/chronology/event.html
@@ -196,7 +196,9 @@
                         <p class="text-sm text-foreground-muted">
                             {% for s in user_enrolled_sessions %}
                                 {{ s.session.title }}
-                                {% if not forloop.last %},{% endif %}
+                                {% if not forloop.last %}
+                                    ,
+                                {% endif %}
                             {% endfor %}
                         </p>
                     </div>


### PR DESCRIPTION
Prevent iOS Safari from automatically zooming into input fields when they receive focus by ensuring form inputs have a minimum font size of 16px on mobile devices.

## Summary

iOS Safari zooms into any input, textarea, or select element with a font size smaller than 16px when it receives focus. This is a UX annoyance that can be prevented by setting the font size to at least 16px on mobile viewports.

## Changes

- Added a mobile-specific media query (`max-width: 640px`) that sets `font-size: 1rem` (16px) on all form inputs, textareas, and selects
- This prevents the unwanted zoom behavior while maintaining the existing desktop styling

## Implementation Details

The fix uses a standard CSS media query approach that's widely recommended for this iOS Safari quirk. The 16px threshold is the minimum font size iOS Safari recognizes to prevent zoom on focus.

https://claude.ai/code/session_01EkbTJVfQD3y7YxJ81wMXR6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented iOS Safari from unexpectedly zooming when focusing inputs on small screens, improving mobile form usability.
* **Style**
  * Adjusted list punctuation rendering in session banners for more consistent comma spacing.
* **Chores**
  * Updated project tooling reference to a namespaced source to align configuration with repository tooling conventions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->