### PR TITLE
Use scrollbar-gutter: stable to reserve scrollbar space

### DIFF
--- a/src/ludamus/client/src/index.css
+++ b/src/ludamus/client/src/index.css
@@ -142,7 +142,7 @@
 html,
 body {
   height: 100%;
-  overflow-y: scroll;
+  scrollbar-gutter: stable;
   -webkit-overflow-scrolling: touch;
 }
 


### PR DESCRIPTION
Replace overflow-y: scroll on html/body with scrollbar-gutter: stable.
Both prevent horizontal layout shift when content height crosses the
viewport, but scrollbar-gutter reserves the gutter without forcing an
always-visible scrollbar track.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved scrollbar display behavior to prevent layout shifting when scrollbars appear or disappear. The page now reserves stable space for the scrollbar, ensuring a smoother and more stable viewing experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->