### PR TITLE
fix(flaky): deterministic factory slugs via Sequence

### DIFF
--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -5,7 +5,7 @@ import pytest
 from django.contrib.auth import get_user_model
 from django.contrib.auth.hashers import make_password
 from django.contrib.sites.models import Site
-from factory import Faker, LazyAttribute, SubFactory
+from factory import Faker, LazyAttribute, Sequence, SubFactory
 from factory.django import DjangoModelFactory
 from pytest_factoryboy import register
 
@@ -80,7 +80,7 @@ class EventFactory(DjangoModelFactory):
         model = Event
 
     name = Faker("sentence", nb_words=4)
-    slug = Faker("slug")
+    slug = Sequence(lambda n: f"event-{n}")
     description = Faker("text")
     sphere = SubFactory(SphereFactory)
     start_time = LazyAttribute(lambda __: datetime.now(UTC) + timedelta(days=7))
@@ -105,7 +105,7 @@ class VenueFactory(DjangoModelFactory):
         model = Venue
 
     name = Faker("company")
-    slug = Faker("slug")
+    slug = Sequence(lambda n: f"venue-{n}")
     event = SubFactory(EventFactory)
     order = 0
 
@@ -115,7 +115,7 @@ class AreaFactory(DjangoModelFactory):
         model = Area
 
     name = Faker("word")
-    slug = Faker("slug")
+    slug = Sequence(lambda n: f"area-{n}")
     venue = SubFactory(VenueFactory)
     order = 0
 
@@ -125,7 +125,7 @@ class SpaceFactory(DjangoModelFactory):
         model = Space
 
     name = Faker("word")
-    slug = Faker("slug")
+    slug = Sequence(lambda n: f"space-{n}")
     area = SubFactory(AreaFactory)
 
 
@@ -143,7 +143,7 @@ class TagCategoryFactory(DjangoModelFactory):
         model = TagCategory
 
     name = Faker("word")
-    slug = Faker("slug")
+    slug = Sequence(lambda n: f"tag-category-{n}")
     event = SubFactory(EventFactory)
     category_type = "SELECT"
     icon = "dice"
@@ -154,7 +154,7 @@ class TagFactory(DjangoModelFactory):
         model = Tag
 
     name = Faker("word")
-    slug = Faker("slug")
+    slug = Sequence(lambda n: f"tag-{n}")
     category = SubFactory(TagCategoryFactory)
 
 
@@ -163,7 +163,7 @@ class SessionFactory(DjangoModelFactory):
         model = Session
 
     title = Faker("sentence", nb_words=5)
-    slug = Faker("slug")
+    slug = Sequence(lambda n: f"session-{n}")
     description = Faker("text")
     presenter = SubFactory(UserFactory)
     display_name = Faker("name")
@@ -189,7 +189,7 @@ class ProposalCategoryFactory(DjangoModelFactory):
         model = ProposalCategory
 
     name = Faker("word")
-    slug = Faker("slug")
+    slug = Sequence(lambda n: f"proposal-category-{n}")
     event = SubFactory(EventFactory)
     max_participants_limit = 20
     min_participants_limit = 2


### PR DESCRIPTION
Implements [plan 003](https://github.com/zagrajmy/ludamus/blob/improvement-plan-2026-06/plans/003-deterministic-factory-slugs.md) from #364.

## Why

`Faker("slug")` draws from a finite word list, so two factory-built rows in one test can collide on a unique `slug` column and fail nondeterministically — the same failure class already fixed once for `AnonymousUserFactory` in bde5be84. Eight more declarations remained in `tests/integration/conftest.py`; each was a latent flaky-CI bug.

## What

All eight `slug = Faker("slug")` declarations replaced with per-model `Sequence` values (`event-{n}`, `venue-{n}`, `area-{n}`, `space-{n}`, `tag-category-{n}`, `tag-{n}`, `session-{n}`, `proposal-category-{n}`) — unique within and across factories, readable in test output.

## Verification

- `grep -rn 'Faker("slug")' tests/` → no matches
- `mise run _pytest -- tests/integration -q` → 1439 passed, 3 skipped

Follow-up (plan 006 in #364): ast-grep rule banning `Faker("slug")` so the class can't return.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test infrastructure for more stable and deterministic test data generation across multiple test factories.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->