### PR TITLE
perf(event-page): fix two per-session N+1 queries

### DIFF
--- a/src/ludamus/adapters/web/django/views.py
+++ b/src/ludamus/adapters/web/django/views.py
@@ -813,6 +813,7 @@ class EventPageView(DetailView):  # type: ignore [type-arg]
                 "tags__category",
                 "session_participations__user__manager",
                 "session_participations__user__connected",
+                "field_values__field",
                 "agenda_item__space__area__venue__event__enrollment_configs",
             )
             .annotate(
@@ -1155,9 +1156,7 @@ class EventPageView(DetailView):  # type: ignore [type-arg]
                         status=sp.status,
                         creation_time=sp.creation_time,
                     )
-                    for sp in session.session_participations.select_related(
-                        "user"
-                    ).all()
+                    for sp in session.session_participations.all()
                 ],
             )
 

--- a/tests/integration/web/chronology/test_event_page.py
+++ b/tests/integration/web/chronology/test_event_page.py
@@ -6,7 +6,9 @@ from unittest.mock import ANY
 import pytest
 import responses
 from django.core.files.uploadedfile import SimpleUploadedFile
+from django.db import connection
 from django.test import override_settings
+from django.test.utils import CaptureQueriesContext
 from django.urls import reverse
 from django.utils import timezone
 
@@ -332,6 +334,54 @@ class TestEventPageView:
         assert response.status_code == HTTPStatus.OK
         assert b"session-tags-more" in response.content
         assert b"+1" in response.content
+
+    def _add_scheduled_session(self, event, space, session_field):
+        presenter = UserFactory()
+        session = SessionFactory(
+            presenter=presenter,
+            display_name=presenter.name,
+            sphere=event.sphere,
+            participants_limit=10,
+            min_age=0,
+        )
+        AgendaItemFactory(session=session, space=space)
+        SessionFieldValue.objects.create(
+            session=session, field=session_field, value=["a", "b"]
+        )
+        SessionParticipation.objects.create(
+            session=session,
+            user=UserFactory(),
+            status=SessionParticipationStatus.CONFIRMED,
+        )
+
+    def test_query_count_constant_in_session_count(self, client, event, space):
+        session_field = SessionField.objects.create(
+            event=event,
+            name="Genre",
+            question="Genre",
+            slug="genre",
+            field_type="select",
+            is_multiple=True,
+            is_public=True,
+        )
+        for _ in range(2):
+            self._add_scheduled_session(event, space, session_field)
+        client.get(self._get_url(event.slug))
+
+        with CaptureQueriesContext(connection) as small_event_queries:
+            response = client.get(self._get_url(event.slug))
+        assert response.status_code == HTTPStatus.OK
+
+        for _ in range(6):
+            self._add_scheduled_session(event, space, session_field)
+
+        with CaptureQueriesContext(connection) as big_event_queries:
+            response = client.get(self._get_url(event.slug))
+        assert response.status_code == HTTPStatus.OK
+
+        assert len(big_event_queries.captured_queries) == len(
+            small_event_queries.captured_queries
+        )
 
     def test_shows_session_cover_image(self, active_user, agenda_item, client, event):
         session = agenda_item.session


### PR DESCRIPTION
Implements [plan 001](https://github.com/zagrajmy/ludamus/blob/improvement-plan-2026-06/plans/001-event-page-n-plus-one.md) from #364. Part of #323.

## Problem

The public event page issued **two extra queries per session**:

1. `_get_session_data` iterated `session.session_participations.select_related("user").all()` — calling `.select_related().all()` on a related manager builds a *new* queryset, silently bypassing the `session_participations__user__*` prefetch that was already set up.
2. `session.field_values.all()` was never prefetched on the `event_sessions` queryset (a `field_values__field` prefetch exists on the *Event* queryset, but the view iterates the separate sessions queryset).

A 200-session event page paid 400+ avoidable queries.

## Fix

- Add `field_values__field` to the `event_sessions` prefetch.
- Iterate `session.session_participations.all()` so the existing prefetch cache is used.

## Verification

- New regression test `test_query_count_constant_in_session_count`: renders the page at 2 and 8 sessions and asserts identical query counts. **Fails without the fix** (verified by stashing the views change), passes with it.
- `mise run _pytest -- tests/integration/web/chronology -q` → 272 passed
- black + ruff clean on changed files

## Follow-ups (deferred, tracked in #364)

- Per-session in-memory iteration of enrollment configs (`effective_participants_limit` / `is_enrollment_available`) — only worth it if the page is still slow after this.
- Plan 006 generalizes this guard: a query-auditing test client that fails any view test repeating an identical SELECT.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved event page database query efficiency.

* **Tests**
  * Added performance verification tests for event page rendering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->