### PR TITLE
fix(auth): validate next redirect target (open redirect)

### DIFF
--- a/src/ludamus/adapters/web/django/views.py
+++ b/src/ludamus/adapters/web/django/views.py
@@ -24,6 +24,7 @@ from django.http import Http404, HttpRequest, HttpResponse, HttpResponseRedirect
 from django.shortcuts import redirect
 from django.template.response import TemplateResponse
 from django.urls import reverse, reverse_lazy
+from django.utils.http import url_has_allowed_host_and_scheme
 from django.utils.text import slugify
 from django.utils.translation import gettext as _
 from django.views.generic.base import ContextMixin, RedirectView, TemplateView, View
@@ -107,6 +108,16 @@ MINIMUM_ALLOWED_USER_AGE = 16
 CACHE_TIMEOUT = 600  # 10 minutes
 
 
+def _is_safe_login_redirect(url: str, root_domain: str, *, require_https: bool) -> bool:
+    host = urlparse(url).netloc
+    allowed = {root_domain}
+    if host and (host == root_domain or host.endswith(f".{root_domain}")):
+        allowed.add(host)
+    return url_has_allowed_host_and_scheme(
+        url, allowed_hosts=allowed, require_https=require_https
+    )
+
+
 class LoginRequiredPageView(TemplateView):
     template_name = "crowd/login_required.html"
 
@@ -135,6 +146,10 @@ class Auth0LoginActionView(View):
             request.context.root_sphere_id
         ).domain
         next_path = request.GET.get("next")
+        if next_path and not _is_safe_login_redirect(
+            next_path, root_domain, require_https=request.is_secure()
+        ):
+            next_path = None
         if request.get_host() != root_domain:
             if next_path:
                 next_path = request.build_absolute_uri(next_path)
@@ -227,6 +242,14 @@ class Auth0LoginCallbackActionView(RedirectView):
 
         if (redirect_to := self._resolve_oauth_state(default_redirect)) is None:
             return index_url
+
+        root_domain = self.request.di.uow.spheres.read_site(
+            self.request.context.root_sphere_id
+        ).domain
+        if redirect_to and not _is_safe_login_redirect(
+            redirect_to, root_domain, require_https=self.request.is_secure()
+        ):
+            redirect_to = ""
 
         if self.request.context.current_user_slug:
             return redirect_to or index_url

--- a/src/ludamus/adapters/web/django/views.py
+++ b/src/ludamus/adapters/web/django/views.py
@@ -142,7 +142,7 @@ class Auth0LoginActionView(View):
         Raises:
             RedirectError: If the request is not from the root domain.
         """
-        root_domain = request.di.uow.spheres.read_site(
+        root_domain = request.services.sites.read_site(
             request.context.root_sphere_id
         ).domain
         next_path = request.GET.get("next")
@@ -243,7 +243,7 @@ class Auth0LoginCallbackActionView(RedirectView):
         if (redirect_to := self._resolve_oauth_state(default_redirect)) is None:
             return index_url
 
-        root_domain = self.request.di.uow.spheres.read_site(
+        root_domain = self.request.services.sites.read_site(
             self.request.context.root_sphere_id
         ).domain
         if redirect_to and not _is_safe_login_redirect(

--- a/src/ludamus/inits/services.py
+++ b/src/ludamus/inits/services.py
@@ -18,6 +18,7 @@ from ludamus.mills.chronology import (
 from ludamus.mills.multiverse import (
     ConnectionsService,
     EventsService,
+    SitesService,
     SpherePanelService,
 )
 from ludamus.mills.printing import PrintMaterialsService
@@ -73,6 +74,10 @@ class Services:
     @cached_property
     def sphere_panel(self) -> SpherePanelService:
         return SpherePanelService(self._repos.spheres, self._repos.events)
+
+    @cached_property
+    def sites(self) -> SitesService:
+        return SitesService(self._repos.spheres)
 
     @cached_property
     def session_content_edit(self) -> SessionContentEditService:

--- a/src/ludamus/mills/multiverse.py
+++ b/src/ludamus/mills/multiverse.py
@@ -12,6 +12,7 @@ if TYPE_CHECKING:
         EventDTO,
         EventListItemDTO,
         EventRepositoryProtocol,
+        SiteDTO,
         SphereDTO,
         SphereRepositoryProtocol,
     )
@@ -113,3 +114,13 @@ class SpherePanelService:
             sphere_id,
             {"allow_facilitator_session_edit": allow_facilitator_session_edit},
         )
+
+
+class SitesService:
+    """Read-side loader for a sphere's site (domain lookup)."""
+
+    def __init__(self, spheres: SphereRepositoryProtocol) -> None:
+        self._spheres = spheres
+
+    def read_site(self, sphere_id: int) -> SiteDTO:
+        return self._spheres.read_site(sphere_id)

--- a/src/ludamus/pacts/multiverse.py
+++ b/src/ludamus/pacts/multiverse.py
@@ -10,7 +10,7 @@ from typing import TYPE_CHECKING, Protocol
 from pydantic import BaseModel, ConfigDict
 
 if TYPE_CHECKING:
-    from ludamus.pacts.legacy import EventDTO, EventListItemDTO, SphereDTO
+    from ludamus.pacts.legacy import EventDTO, EventListItemDTO, SiteDTO, SphereDTO
 
 
 class DuplicateConnectionDisplayNameError(Exception):
@@ -81,3 +81,7 @@ class SpherePanelServiceProtocol(Protocol):
     def update_settings(
         self, sphere_id: int, *, allow_facilitator_session_edit: bool
     ) -> None: ...
+
+
+class SitesServiceProtocol(Protocol):
+    def read_site(self, sphere_id: int) -> SiteDTO: ...

--- a/src/ludamus/pacts/services.py
+++ b/src/ludamus/pacts/services.py
@@ -19,6 +19,7 @@ if TYPE_CHECKING:
     from ludamus.pacts.multiverse import (
         ConnectionsServiceProtocol,
         EventsServiceProtocol,
+        SitesServiceProtocol,
         SpherePanelServiceProtocol,
     )
     from ludamus.pacts.printing import PrintMaterialsServiceProtocol
@@ -39,6 +40,8 @@ class ServicesProtocol(Protocol):
     def events(self) -> EventsServiceProtocol: ...
     @property
     def sphere_panel(self) -> SpherePanelServiceProtocol: ...
+    @property
+    def sites(self) -> SitesServiceProtocol: ...
     @property
     def event_integrations(self) -> EventIntegrationsServiceProtocol: ...
     @property

--- a/tests/integration/web/crowd/test_auth0_login_action.py
+++ b/tests/integration/web/crowd/test_auth0_login_action.py
@@ -32,6 +32,19 @@ class TestAuth0LoginActionView:
             "csrf_token": "",
         }
 
+    @patch("ludamus.adapters.web.django.views.oauth")
+    def test_ok_redirect_drops_external_next(self, oauth_mock, client):
+        oauth_mock.auth0.authorize_redirect.return_value = HttpResponse()
+
+        response = client.get(f"{self.URL}?next=https://evil.example.com/")
+
+        assert_response(response, HTTPStatus.OK)
+        cache_key = (
+            f"oauth_state:{oauth_mock.auth0.authorize_redirect.call_args[1]['state']}"
+        )
+        cached_data = json.loads(cache.get(cache_key))
+        assert cached_data["redirect_to"] is None
+
     def test_error_non_root_domain(self, client, non_root_sphere):
         response = client.get(self.URL, HTTP_HOST=non_root_sphere.site.domain)
 

--- a/tests/integration/web/crowd/test_auth0_login_callback_action.py
+++ b/tests/integration/web/crowd/test_auth0_login_callback_action.py
@@ -75,7 +75,7 @@ class TestAuth0LoginCallbackActionView:
     def test_ok_redirect_to(self, authorize_access_token_mock, client, faker):
         sub = faker.uuid4()
         authorize_access_token_mock.return_value = {"userinfo": {"sub": sub}}
-        redirect_to = "https://www.domain.example.com/a/b/c"
+        redirect_to = "https://www.testserver/a/b/c"
         state_token = self._setup_valid_state(redirect_to)
 
         response = client.get(self.URL, data={"state": state_token})
@@ -83,7 +83,7 @@ class TestAuth0LoginCallbackActionView:
         assert_response(
             response,
             HTTPStatus.FOUND,
-            url="https://www.domain.example.com/crowd/profile/",
+            url="https://www.testserver/crowd/profile/",
             messages=[(messages.SUCCESS, "Please complete your profile.")],
         )
         assert User.objects.get().username == f"auth0|{sub}"
@@ -94,12 +94,46 @@ class TestAuth0LoginCallbackActionView:
 
         assert_response(response, HTTPStatus.FOUND, url="http://testserver/")
 
-    def test_ok_already_authenticated_redirect_to(self, authenticated_client, faker):
-        redirect_to = faker.url()
+    def test_ok_already_authenticated_redirect_to(self, authenticated_client):
+        redirect_to = "https://sphere.testserver/a/b/"
         state_token = self._setup_valid_state(redirect_to)
         response = authenticated_client.get(self.URL, data={"state": state_token})
 
         assert_response(response, HTTPStatus.FOUND, url=redirect_to)
+
+    def test_ok_already_authenticated_relative_redirect_to(self, authenticated_client):
+        state_token = self._setup_valid_state("/event/foo/")
+        response = authenticated_client.get(self.URL, data={"state": state_token})
+
+        assert_response(response, HTTPStatus.FOUND, url="/event/foo/")
+
+    def test_external_redirect_to_dropped(self, authenticated_client):
+        state_token = self._setup_valid_state("https://evil.example.com/phish/")
+        response = authenticated_client.get(self.URL, data={"state": state_token})
+
+        assert_response(response, HTTPStatus.FOUND, url="http://testserver/")
+
+    def test_protocol_relative_redirect_to_dropped(self, authenticated_client):
+        state_token = self._setup_valid_state("//evil.example.com/phish/")
+        response = authenticated_client.get(self.URL, data={"state": state_token})
+
+        assert_response(response, HTTPStatus.FOUND, url="http://testserver/")
+
+    @patch("ludamus.adapters.web.django.views.oauth.auth0.authorize_access_token")
+    def test_external_redirect_to_dropped_on_login(
+        self, authorize_access_token_mock, client, faker
+    ):
+        authorize_access_token_mock.return_value = {"userinfo": {"sub": faker.uuid4()}}
+        state_token = self._setup_valid_state("https://evil.example.com/a/b/c")
+
+        response = client.get(self.URL, {"state": state_token})
+
+        assert_response(
+            response,
+            HTTPStatus.FOUND,
+            url="http://testserver/crowd/profile/",
+            messages=[(messages.SUCCESS, "Please complete your profile.")],
+        )
 
     @patch("ludamus.adapters.web.django.views.oauth.auth0.authorize_access_token")
     def test_ok_complete_user(

--- a/tests/unit/test_sites_mills.py
+++ b/tests/unit/test_sites_mills.py
@@ -1,0 +1,20 @@
+from types import SimpleNamespace
+
+from ludamus.mills.multiverse import SitesService
+
+
+class _Spheres:
+    def __init__(self, sites):
+        self._sites = dict(sites)
+
+    def read_site(self, sphere_id):
+        return self._sites[sphere_id]
+
+
+def test_read_site_returns_repo_site():
+    site = SimpleNamespace(domain="ludamus.example.com", name="Root", pk=7)
+    service = SitesService(_Spheres({1: site}))
+
+    result = service.read_site(1)
+
+    assert result is site


### PR DESCRIPTION
Implements [plan 002](https://github.com/zagrajmy/ludamus/blob/improvement-plan-2026-06/plans/002-oauth-next-open-redirect.md) from #364.

## Problem

`/crowd/auth0/login?next=<url>` stored the raw `next` in the OAuth state (cache) and the callback redirected to it without host validation — a classic open redirect: a crafted login link bounces the victim to an attacker page *after a successful login*, prime phishing territory. CodeQL missed it because the taint path goes through the cache (store at login, read at callback).

## Fix

New `_is_safe_login_redirect` helper using Django's `url_has_allowed_host_and_scheme`, applied at **both ends** (login view before storing/forwarding, callback after resolving state — defense in depth, also neutralizes the scheme/netloc reuse on the profile-redirect path). Allowed: relative URLs, the root domain, and its subdomains (the legitimate multi-tenant cross-subdomain flow). `require_https` follows `request.is_secure()`, matching `django.contrib.auth` conventions.

## ⚠️ Reviewer attention

Two existing callback tests asserted redirects to **arbitrary external hosts** (`www.domain.example.com`, `faker.url()`) — they encoded the vulnerable behavior. I judged them stand-ins for the cross-subdomain flow and rewrote them with subdomain targets (`www.testserver`, `sphere.testserver`). If redirecting to truly external hosts after login is somehow intended, say so and this PR needs a different design (an allowlist setting).

Also note: the allowlist intentionally accepts *any* subdomain of the root domain, matching how spheres work today.

## Verification

- 6 new tests: external absolute → dropped (authed + full-login paths), protocol-relative → dropped, relative → honored, subdomain absolute → honored (×2 rewritten)
- Without the views.py change, 4 of the new/updated tests fail (revert-proofed)
- `mise run _pytest -- tests/integration -q` → 1444 passed · `mise run mypy` → clean · black + ruff clean

## Deferred (tracked in #364)

Stop storing `CSRF_COOKIE` in the cached OAuth state; rate limiting on auth endpoints (#304).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced login security by implementing validation checks on redirect destinations.
  * Redirects to external or untrusted domains are now blocked to prevent unauthorized redirections.
  * Both login initiation and callback flows now enforce safe redirect validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->