### PR TITLE
Make manual staging dispatch deploy and claim staging exclusively

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -57,6 +57,16 @@ jobs:
       url: https://test.zagrajmy.net
       deployment: false
     steps:
+      # Order matters: the deploy-SHA checkout lands in the workspace root, and
+      # actions/checkout wipes the root's existing contents on init. It must run
+      # BEFORE the workflow-helpers checkout, otherwise it deletes .workflow/ and
+      # the github-script steps below fail with ERR_MODULE_NOT_FOUND.
+      - name: Checkout (provides .env.schema for varlock validation)
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.resolve-staging.outputs.sha }}
+          persist-credentials: false
+
       - name: Checkout workflow helpers
         uses: actions/checkout@v4
         with:
@@ -83,13 +93,6 @@ jobs:
               sha: process.env.TARGET_SHA,
               environmentUrl: process.env.STAGING_URL,
             });
-
-      - name: Checkout (provides .env.schema for varlock validation)
-        uses: actions/checkout@v4
-        with:
-          ref: ${{ needs.resolve-staging.outputs.sha }}
-          clean: false
-          persist-credentials: false
 
       - name: Materialize .env.local from environment variables and secrets
         env:

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -31,10 +31,10 @@ jobs:
       sha: ${{ steps.resolve.outputs.sha }}
       should_deploy: ${{ steps.resolve.outputs.should_deploy }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           persist-credentials: false
-      - uses: actions/github-script@v8
+      - uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
         id: resolve
         with:
           script: |
@@ -62,13 +62,13 @@ jobs:
       # BEFORE the workflow-helpers checkout, otherwise it deletes .workflow/ and
       # the github-script steps below fail with ERR_MODULE_NOT_FOUND.
       - name: Checkout (provides .env.schema for varlock validation)
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           ref: ${{ needs.resolve-staging.outputs.sha }}
           persist-credentials: false
 
       - name: Checkout workflow helpers
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           ref: ${{ github.sha }}
           path: .workflow
@@ -76,7 +76,7 @@ jobs:
 
       - name: Create GitHub deployment
         id: deployment
-        uses: actions/github-script@v8
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
         env:
           STAGING_URL: https://test.zagrajmy.net
           TARGET_SHA: ${{ needs.resolve-staging.outputs.sha }}
@@ -159,7 +159,7 @@ jobs:
           npx -y varlock@1.1.0 load > /dev/null
 
       - name: Upload .env.local to host
-        uses: appleboy/scp-action@v0.1.7
+        uses: appleboy/scp-action@917f8b81dfc1ccd331fef9e2d61bdc6c8be94634 # v0.1.7
         with:
           host: ${{ secrets.STAGING_HOST }}
           username: ${{ secrets.STAGING_USER }}
@@ -168,7 +168,7 @@ jobs:
           target: ludamus/
 
       - name: Deploy
-        uses: appleboy/ssh-action@v1
+        uses: appleboy/ssh-action@0ff4204d59e8e51228ff73bce53f80d53301dee2 # v1
         env:
           GITHUB_COMMIT_SHA: ${{ needs.resolve-staging.outputs.sha }}
         with:
@@ -191,7 +191,7 @@ jobs:
 
       - name: Mark GitHub deployment complete
         if: always() && steps.deployment.outputs.id != ''
-        uses: actions/github-script@v8
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
         env:
           DEPLOYMENT_ID: ${{ steps.deployment.outputs.id }}
           JOB_STATUS: ${{ job.status }}

--- a/scripts/github-staging.mts
+++ b/scripts/github-staging.mts
@@ -229,7 +229,7 @@ const removeStagingFrom = async ({
   );
 };
 
-const exclusiveStagingFor = async (args: ActionArgs, exceptNumber: number) => {
+const exclusiveStagingFor = async (args: ActionArgs, exceptNumber?: number) => {
   const stagingPrs = await listStagingPrIssues(args);
   await removeStagingFrom({
     ...args,
@@ -439,50 +439,43 @@ const resolveManualDeploy = async ({
   core,
   sha,
 }: ResolveManualDeployArgs) => {
-  const [stagingPrs, prsForSha] = await Promise.all([
-    listStagingPrIssues({ github, context, core }),
-    listPullRequestsForSha({ github, context, sha }),
-  ]);
-  const prNumbersForSha = new Set(
-    prsForSha
-      .filter((pr) => isSameRepositoryPullRequest(context, pr))
-      .map((pr) => pr.number),
-  );
-  const matchingStagingPrs = stagingPrs.filter(
-    (pr) => pr.state === "open" && prNumbersForSha.has(pr.number),
+  const openPrsForSha = (
+    await listPullRequestsForSha({ github, context, sha })
+  ).filter((pr) => pr.state === "open");
+  const candidates = openPrsForSha.filter((pr) =>
+    isSameRepositoryPullRequest(context, pr),
   );
 
-  if (matchingStagingPrs.length !== 1) {
+  // A manual dispatch is itself the authorization to deploy `sha`, so we do NOT
+  // require the staging label. Whatever we deploy takes over staging, so we
+  // strip the label off every other PR (claimStagingTarget semantics). Fork
+  // commits never reach staging — we won't run untrusted code on the host.
+  if (candidates.length > 1) {
     setShouldDeploy(
       core,
       false,
-      `No unique open PR with ${STAGING_LABEL} for ${sha}`,
+      `Multiple open PRs for ${sha}; pass pr_number to disambiguate`,
     );
     return;
   }
 
-  const winner = await fetchPullRequest({
-    github,
-    context,
-    number: matchingStagingPrs[0].number,
-  });
-
-  if (
-    winner.state !== "open" ||
-    winner.draft ||
-    !hasStagingLabel(winner) ||
-    !isSameRepositoryPullRequest(context, winner)
-  ) {
-    setShouldDeploy(
-      core,
-      false,
-      `No unique open PR with ${STAGING_LABEL} for ${sha}`,
-    );
+  if (candidates.length === 0) {
+    if (openPrsForSha.length > 0) {
+      setShouldDeploy(
+        core,
+        false,
+        `Skipping ${STAGING_LABEL} deploy for fork PR #${openPrsForSha[0].number}`,
+      );
+      return;
+    }
+    await exclusiveStagingFor({ github, context, core });
+    setShouldDeploy(core, true, `Deploying ${sha}`);
     return;
   }
 
-  await exclusiveStagingFor({ github, context, core }, winner.number);
-  setShouldDeploy(core, true, `Deploying PR #${winner.number} at ${sha}`);
+  const target = candidates[0];
+  await exclusiveStagingFor({ github, context, core }, target.number);
+  setShouldDeploy(core, true, `Deploying PR #${target.number} at ${sha}`);
 };
 
 export const resolveDeploy = async ({ github, context, core }: ActionArgs) => {

--- a/scripts/github-staging.mts
+++ b/scripts/github-staging.mts
@@ -442,15 +442,13 @@ const resolveManualDeploy = async ({
   const openPrsForSha = (
     await listPullRequestsForSha({ github, context, sha })
   ).filter((pr) => pr.state === "open");
-  const candidates = openPrsForSha.filter((pr) =>
-    isSameRepositoryPullRequest(context, pr),
-  );
 
   // A manual dispatch is itself the authorization to deploy `sha`, so we do NOT
-  // require the staging label. Whatever we deploy takes over staging, so we
-  // strip the label off every other PR (claimStagingTarget semantics). Fork
-  // commits never reach staging — we won't run untrusted code on the host.
-  if (candidates.length > 1) {
+  // require the staging label, and (unlike the explicit/label paths) we accept
+  // drafts — a human asking for a draft preview is intentional. Whatever we
+  // deploy takes over staging, so we strip the label off every other PR
+  // (claimStagingTarget semantics).
+  if (openPrsForSha.length > 1) {
     setShouldDeploy(
       core,
       false,
@@ -459,23 +457,31 @@ const resolveManualDeploy = async ({
     return;
   }
 
-  if (candidates.length === 0) {
-    if (openPrsForSha.length > 0) {
-      setShouldDeploy(
-        core,
-        false,
-        `Skipping ${STAGING_LABEL} deploy for fork PR #${openPrsForSha[0].number}`,
-      );
-      return;
-    }
+  if (openPrsForSha.length === 0) {
     await exclusiveStagingFor({ github, context, core });
     setShouldDeploy(core, true, `Deploying ${sha}`);
     return;
   }
 
-  const target = candidates[0];
-  await exclusiveStagingFor({ github, context, core }, target.number);
-  setShouldDeploy(core, true, `Deploying PR #${target.number} at ${sha}`);
+  // Re-fetch the single PR for an authoritative head repo: the associated-
+  // commits payload can carry a null/sparse head (e.g. a deleted fork) that
+  // would misclassify a real PR. Fork PRs stay off staging.
+  const pr = await fetchPullRequest({
+    github,
+    context,
+    number: openPrsForSha[0].number,
+  });
+  if (!isSameRepositoryPullRequest(context, pr)) {
+    setShouldDeploy(
+      core,
+      false,
+      `Skipping ${STAGING_LABEL} deploy for fork PR #${pr.number}`,
+    );
+    return;
+  }
+
+  await exclusiveStagingFor({ github, context, core }, pr.number);
+  setShouldDeploy(core, true, `Deploying PR #${pr.number} at ${sha}`);
 };
 
 export const resolveDeploy = async ({ github, context, core }: ActionArgs) => {

--- a/scripts/github-staging.test.mts
+++ b/scripts/github-staging.test.mts
@@ -362,6 +362,7 @@ test("manual dispatch deploys the associated PR and clears other staging labels"
 test("manual dispatch deploys an unlabeled PR and rips staging from the labeled one", async () => {
   const args = makeArgs({
     inputs: { sha: "manual-sha" },
+    currentPr: { ...basePr, labels: [] },
     prsForSha: [
       {
         head: { repo: { full_name: "owner/repo" }, sha: "manual-sha" },
@@ -438,15 +439,15 @@ test("manual dispatch with several associated PRs refuses without mutating label
 });
 
 test("manual dispatch ignores fork pull requests", async () => {
+  const forkPr = {
+    head: { repo: { full_name: "contributor/repo" }, sha: "manual-sha" },
+    number: 1,
+    state: "open",
+  };
   const args = makeArgs({
     inputs: { sha: "manual-sha" },
-    prsForSha: [
-      {
-        head: { repo: { full_name: "contributor/repo" }, sha: "manual-sha" },
-        number: 1,
-        state: "open",
-      },
-    ],
+    currentPr: forkPr,
+    prsForSha: [forkPr],
     stagingPrs: [{ number: 1, pull_request: {}, state: "open" }],
   });
 
@@ -456,6 +457,30 @@ test("manual dispatch ignores fork pull requests", async () => {
     ["output", "sha", "manual-sha"],
     ["output", "should_deploy", "false"],
     ["info", "Skipping staging deploy for fork PR #1"],
+  ]);
+});
+
+test("manual dispatch deploys a draft PR", async () => {
+  const args = makeArgs({
+    inputs: { sha: "manual-sha" },
+    currentPr: { ...basePr, draft: true },
+    prsForSha: [
+      {
+        head: { repo: { full_name: "owner/repo" }, sha: "manual-sha" },
+        draft: true,
+        number: 2,
+        state: "open",
+      },
+    ],
+    stagingPrs: [{ number: 2, pull_request: {}, state: "open" }],
+  });
+
+  await staging.resolveDeploy(args);
+
+  assert.deepEqual(args.calls, [
+    ["output", "sha", "manual-sha"],
+    ["output", "should_deploy", "true"],
+    ["info", "Deploying PR #2 at manual-sha"],
   ]);
 });
 

--- a/scripts/github-staging.test.mts
+++ b/scripts/github-staging.test.mts
@@ -332,13 +332,14 @@ test("explicit dispatch on closed pull request does not deploy or mutate labels"
   ]);
 });
 
-test("manual dispatch deploys and clears other staging labels", async () => {
+test("manual dispatch deploys the associated PR and clears other staging labels", async () => {
   const args = makeArgs({
     inputs: { sha: "manual-sha" },
     prsForSha: [
       {
         head: { repo: { full_name: "owner/repo" }, sha: "manual-sha" },
         number: 2,
+        state: "open",
       },
     ],
     stagingPrs: [
@@ -358,11 +359,70 @@ test("manual dispatch deploys and clears other staging labels", async () => {
   ]);
 });
 
-test("manual dispatch with no unique staging PR is non-mutating", async () => {
+test("manual dispatch deploys an unlabeled PR and rips staging from the labeled one", async () => {
   const args = makeArgs({
     inputs: { sha: "manual-sha" },
-    prsForSha: [{ number: 1 }],
-    stagingPrs: [{ number: 2, pull_request: {}, state: "open" }],
+    prsForSha: [
+      {
+        head: { repo: { full_name: "owner/repo" }, sha: "manual-sha" },
+        labels: [],
+        number: 2,
+        state: "open",
+      },
+    ],
+    stagingPrs: [{ number: 1, pull_request: {}, state: "open" }],
+  });
+
+  await staging.resolveDeploy(args);
+
+  assert.deepEqual(args.calls, [
+    ["output", "sha", "manual-sha"],
+    ["remove", 1],
+    ["info", "Removed staging from PR #1"],
+    ["output", "should_deploy", "true"],
+    ["info", "Deploying PR #2 at manual-sha"],
+  ]);
+});
+
+test("manual dispatch of a commit without a PR clears every staging label", async () => {
+  const args = makeArgs({
+    inputs: { sha: "manual-sha" },
+    prsForSha: [],
+    stagingPrs: [
+      { number: 1, pull_request: {}, state: "open" },
+      { number: 2, pull_request: {}, state: "open" },
+    ],
+  });
+
+  await staging.resolveDeploy(args);
+
+  assert.deepEqual(args.calls, [
+    ["output", "sha", "manual-sha"],
+    ["remove", 1],
+    ["remove", 2],
+    ["info", "Removed staging from PR #1"],
+    ["info", "Removed staging from PR #2"],
+    ["output", "should_deploy", "true"],
+    ["info", "Deploying manual-sha"],
+  ]);
+});
+
+test("manual dispatch with several associated PRs refuses without mutating labels", async () => {
+  const args = makeArgs({
+    inputs: { sha: "manual-sha" },
+    prsForSha: [
+      {
+        head: { repo: { full_name: "owner/repo" }, sha: "manual-sha" },
+        number: 1,
+        state: "open",
+      },
+      {
+        head: { repo: { full_name: "owner/repo" }, sha: "manual-sha" },
+        number: 2,
+        state: "open",
+      },
+    ],
+    stagingPrs: [{ number: 3, pull_request: {}, state: "open" }],
   });
 
   await staging.resolveDeploy(args);
@@ -370,7 +430,10 @@ test("manual dispatch with no unique staging PR is non-mutating", async () => {
   assert.deepEqual(args.calls, [
     ["output", "sha", "manual-sha"],
     ["output", "should_deploy", "false"],
-    ["info", "No unique open PR with staging for manual-sha"],
+    [
+      "info",
+      "Multiple open PRs for manual-sha; pass pr_number to disambiguate",
+    ],
   ]);
 });
 
@@ -381,6 +444,7 @@ test("manual dispatch ignores fork pull requests", async () => {
       {
         head: { repo: { full_name: "contributor/repo" }, sha: "manual-sha" },
         number: 1,
+        state: "open",
       },
     ],
     stagingPrs: [{ number: 1, pull_request: {}, state: "open" }],
@@ -391,7 +455,7 @@ test("manual dispatch ignores fork pull requests", async () => {
   assert.deepEqual(args.calls, [
     ["output", "sha", "manual-sha"],
     ["output", "should_deploy", "false"],
-    ["info", "No unique open PR with staging for manual-sha"],
+    ["info", "Skipping staging deploy for fork PR #1"],
   ]);
 });
 


### PR DESCRIPTION
Manual workflow_dispatch with no inputs previously took the manual
resolve path, which only deployed when the target PR already carried
the `staging` label. Running it on an unlabeled PR resolved to
should_deploy=false, the build job was skipped, and the run still
reported success — so it looked like it worked but nothing deployed.

resolveManualDeploy now treats the dispatch itself as authorization:
it deploys the PR (or raw commit) associated with the dispatched SHA
and strips the `staging` label off every other PR, so the dispatched
target takes over staging. Fork commits are still refused. Both entry
points (label flow and manual dispatch) now end in the same state.

Also fix the deploy job's GitHub-deployment bookkeeping: the deploy-SHA
checkout lands in the workspace root and actions/checkout wipes the
root on init, which deleted the .workflow/ helper checkout and made the
final "Mark GitHub deployment complete" step fail with
ERR_MODULE_NOT_FOUND (the app deployed, but the run went red). Run the
root checkout before the helpers checkout so .workflow/ survives.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved manual staging deployment resolution to correctly disambiguate when multiple open pull requests match the provided commit SHA.
  * Adjusted label-clearing behavior for manual deployments, including deploying when the associated pull request has no staging label, while clearing other staging labels.
  * Refined draft and fork handling during manual staging deployments.
* **Chores**
  * Improved the staging deployment workflow checkout order to prevent reliability issues during staging builds.
* **Tests**
  * Expanded manual dispatch staging deployment coverage for ambiguous, label-clearing, draft, and fork scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->