### PR TITLE
Sort sphere events by date on events page

### DIFF
--- a/src/ludamus/adapters/web/django/views.py
+++ b/src/ludamus/adapters/web/django/views.py
@@ -499,8 +499,14 @@ class EventsPageView(TemplateView):
             )
             for i, item in enumerate(items)
         ]
-        context["upcoming_events"] = [e for e in event_datas if not e.is_ended]
-        context["past_events"] = [e for e in event_datas if e.is_ended]
+        context["upcoming_events"] = sorted(
+            (e for e in event_datas if not e.is_ended), key=lambda e: e.start_time
+        )
+        context["past_events"] = sorted(
+            (e for e in event_datas if e.is_ended),
+            key=lambda e: e.start_time,
+            reverse=True,
+        )
         return context
 
 

--- a/src/ludamus/adapters/web/django/views.py
+++ b/src/ludamus/adapters/web/django/views.py
@@ -67,6 +67,7 @@ from ludamus.pacts import (
     AgendaItemDTO,
     AreaDTO,
     EventDTO,
+    EventListItemDTO,
     LocationData,
     NotFoundError,
     RedirectError,
@@ -488,8 +489,25 @@ class EventsPageView(TemplateView):
             self.request.context.current_sphere_id,
             include_unpublished=_is_manager(self.request),
         )
-        # Uploaded cover when present, otherwise a placeholder assigned by index.
-        event_datas = [
+        context["upcoming_events"] = self._with_covers(
+            sorted(
+                (item for item in items if not item.is_ended),
+                key=lambda item: item.start_time,
+            )
+        )
+        context["past_events"] = self._with_covers(
+            sorted(
+                (item for item in items if item.is_ended),
+                key=lambda item: item.start_time,
+                reverse=True,
+            )
+        )
+        return context
+
+    @staticmethod
+    def _with_covers(items: list[EventListItemDTO]) -> list[EventInfo]:
+        # Uploaded cover when present, otherwise a placeholder cycled by position.
+        return [
             EventInfo.from_list_item(
                 item,
                 cover_image_url=item.cover_image_url
@@ -499,15 +517,6 @@ class EventsPageView(TemplateView):
             )
             for i, item in enumerate(items)
         ]
-        context["upcoming_events"] = sorted(
-            (e for e in event_datas if not e.is_ended), key=lambda e: e.start_time
-        )
-        context["past_events"] = sorted(
-            (e for e in event_datas if e.is_ended),
-            key=lambda e: e.start_time,
-            reverse=True,
-        )
-        return context
 
 
 class ProfilePageView(

--- a/tests/integration/web/test_index_page.py
+++ b/tests/integration/web/test_index_page.py
@@ -244,8 +244,8 @@ class TestEventsPageView:
             HTTPStatus.OK,
             context_data={
                 "past_events": [
-                    _expected_event_info(recent, cover_index=1),
-                    _expected_event_info(older, cover_index=0),
+                    _expected_event_info(recent, cover_index=0),
+                    _expected_event_info(older, cover_index=1),
                 ],
                 "upcoming_events": [],
                 "view": ANY,

--- a/tests/integration/web/test_index_page.py
+++ b/tests/integration/web/test_index_page.py
@@ -1,4 +1,4 @@
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 from http import HTTPStatus
 from unittest.mock import ANY
 
@@ -188,6 +188,66 @@ class TestEventsPageView:
             context_data={
                 "past_events": [],
                 "upcoming_events": [_expected_event_info(event)],
+                "view": ANY,
+            },
+            template_name=["index.html"],
+        )
+
+    def test_upcoming_events_sorted_soonest_first(self, client, sphere):
+        now = datetime.now(UTC)
+        far = EventFactory(
+            sphere=sphere,
+            start_time=now + timedelta(days=30),
+            end_time=now + timedelta(days=31),
+        )
+        soon = EventFactory(
+            sphere=sphere,
+            start_time=now + timedelta(days=2),
+            end_time=now + timedelta(days=3),
+        )
+
+        response = client.get(self.URL)
+
+        assert_response(
+            response,
+            HTTPStatus.OK,
+            context_data={
+                "past_events": [],
+                "upcoming_events": [
+                    _expected_event_info(soon, cover_index=0),
+                    _expected_event_info(far, cover_index=1),
+                ],
+                "view": ANY,
+            },
+            template_name=["index.html"],
+        )
+
+    def test_past_events_sorted_most_recent_first(self, client, sphere):
+        now = datetime.now(UTC)
+        older = EventFactory(
+            sphere=sphere,
+            start_time=now - timedelta(days=30),
+            end_time=now - timedelta(days=29),
+            publication_time=now - timedelta(days=31),
+        )
+        recent = EventFactory(
+            sphere=sphere,
+            start_time=now - timedelta(days=3),
+            end_time=now - timedelta(days=2),
+            publication_time=now - timedelta(days=4),
+        )
+
+        response = client.get(self.URL)
+
+        assert_response(
+            response,
+            HTTPStatus.OK,
+            context_data={
+                "past_events": [
+                    _expected_event_info(recent, cover_index=1),
+                    _expected_event_info(older, cover_index=0),
+                ],
+                "upcoming_events": [],
                 "view": ANY,
             },
             template_name=["index.html"],


### PR DESCRIPTION
## What

On the sphere events page (`EventsPageView`), events are now ordered by date:

- **Upcoming events** display soonest-first.
- **Past events** display most-recent-first.

## Why

Previously both lists were rendered in the repository's raw `order_by("start_time")` order, so past events read oldest-first — the opposite of what you'd expect when looking back at recent editions.

## How

`EventsPageView.get_context_data` now sorts each bucket explicitly (upcoming ascending, past descending by `start_time`).

Following a thermo-nuclear code-quality review, placeholder cover images are now assigned **after** sorting, so the placeholder cycling tracks on-screen position instead of database fetch order (previously the index was keyed to fetch order while cards rendered in a different order). The cover-assignment logic was extracted into a small `_with_covers` helper to avoid duplicating it across the two lists.

## Tests

Added two integration tests covering both orderings (`test_upcoming_events_sorted_soonest_first`, `test_past_events_sorted_most_recent_first`). Full suite: 1860 passed, 3 skipped. `mise run check` clean (pylint 10.00/10, no other issues).

https://claude.ai/code/session_01BnmEFFcA9LX8KV8bAspmTA