### PR TITLE
Fix confirm E2E test for auto-confirm default

### DIFF
--- a/tests/e2e/tests/timetable.spec.ts
+++ b/tests/e2e/tests/timetable.spec.ts
@@ -404,7 +404,8 @@ test.describe('Timetable', () => {
   test('confirms and unconfirms a scheduled session', async ({
     page,
   }) => {
-    // Assign "Storytelling Workshop" so a scheduled item exists to confirm.
+    // Assign "Storytelling Workshop" so a scheduled item exists. Auto-confirm
+    // is on by default, so the freshly scheduled item starts confirmed.
     await page.goto('/panel/event/autumn-open/timetable/');
 
     await page
@@ -443,25 +444,25 @@ test.describe('Timetable', () => {
 
     await expect(
       leftPane.getByRole('button', {
-        name: 'Confirm program item',
+        name: 'Undo confirmation',
       }),
     ).toBeVisible({ timeout: 5000 });
 
-    // Confirm — the button flips to the "Undo confirmation" state.
-    await leftPane
-      .getByRole('button', { name: 'Confirm program item' })
-      .click();
-    await expect(
-      leftPane.getByRole('button', { name: 'Undo confirmation' }),
-    ).toBeVisible({ timeout: 5000 });
-
-    // Undo — the button returns to the "Confirm program item" state.
+    // Undo — the button flips to the "Confirm program item" state.
     await leftPane
       .getByRole('button', { name: 'Undo confirmation' })
       .click();
     await expect(
+      leftPane.getByRole('button', { name: 'Confirm program item' }),
+    ).toBeVisible({ timeout: 5000 });
+
+    // Confirm again — the button returns to the "Undo confirmation" state.
+    await leftPane
+      .getByRole('button', { name: 'Confirm program item' })
+      .click();
+    await expect(
       leftPane.getByRole('button', {
-        name: 'Confirm program item',
+        name: 'Undo confirmation',
       }),
     ).toBeVisible({ timeout: 5000 });
 


### PR DESCRIPTION
## Problem

#391 shipped per-event **auto-confirm** defaulting to **on**. The seed event's `auto_confirm_sessions` is `True`, so assigning a session now schedules it **already confirmed**.

The per-item confirm E2E (`tests/e2e/tests/timetable.spec.ts` → "confirms and unconfirms a scheduled session") was written for the old behaviour: it assigned a session and expected the detail pane to show **"Confirm program item"**. With auto-confirm on, the pane shows **"Undo confirmation"** instead, so the assertion failed — *before* the test's unassign cleanup ran. That left "Storytelling Workshop" scheduled in the shared serial seed DB, cascading into the early **"session list … shows unscheduled sessions"** test (`:41`) in the next browser project.

This was a latent regression merged with #391 (the Playwright `test` job wasn't gating that merge); it surfaced on `main` and in #392's CI (which runs against the merge into `main`).

## Fix

Test-only. Start the toggle from the **confirmed** state to match auto-confirm:
assign → expect **"Undo confirmation"** → unconfirm → expect **"Confirm program item"** → confirm again → expect **"Undo confirmation"** → unassign (restore shared seed state). Uses the existing `getByRole` button selectors.

## Not in scope

The `event-details` / `event-filters` (firefox/webkit iOS-touch/modal) E2E flakes that also appear intermittently are pre-existing and unrelated — tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JGAT6FAhSwE2zk5fbcaGUW

---
_Generated by [Claude Code](https://claude.ai/code/session_01JGAT6FAhSwE2zk5fbcaGUW)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated E2E test to validate scheduled session confirmation behavior and state transitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->