### PR TITLE
feat(panel): report program-hours left to fill on timetable overview

### DIFF
--- a/src/ludamus/gates/web/django/chronology/panel/views/timetable.py
+++ b/src/ludamus/gates/web/django/chronology/panel/views/timetable.py
@@ -471,6 +471,7 @@ class TimetableOverviewPageView(PanelAccessMixin, EventContextMixin, View):
             current_event.pk, tz=get_current_timezone()
         )
         context["track_progress"] = overview.track_progress(current_event.pk)
+        context["capacity_hours"] = overview.capacity_hours(current_event.pk)
         context["slug"] = slug
         context["tab_urls"] = _timetable_tab_urls(slug)
         return TemplateResponse(self.request, "panel/timetable-overview.html", context)

--- a/src/ludamus/locale/pl/LC_MESSAGES/django.po
+++ b/src/ludamus/locale/pl/LC_MESSAGES/django.po
@@ -5060,6 +5060,28 @@ msgid "No entries in the log."
 msgstr "Brak wpisów w dzienniku."
 
 #: src/ludamus/templates/panel/timetable-overview.html
+msgid "Hours to fill"
+msgstr "Godziny do zapełnienia"
+
+#: src/ludamus/templates/panel/timetable-overview.html
+msgid "Scheduled hours"
+msgstr "Godziny zaplanowane"
+
+#: src/ludamus/templates/panel/timetable-overview.html
+msgid "Capacity hours"
+msgstr "Godziny dostępne"
+
+#: src/ludamus/templates/panel/timetable-overview.html
+msgid "filled"
+msgstr "zapełnione"
+
+#: src/ludamus/templates/panel/timetable-overview.html
+msgid "Add rooms and time slots to see how many program-hours are left to fill."
+msgstr ""
+"Dodaj sale i przedziały czasowe, aby zobaczyć, ile godzin programu pozostało "
+"do zapełnienia."
+
+#: src/ludamus/templates/panel/timetable-overview.html
 msgid "Occupancy map"
 msgstr "Mapa obłożenia"
 

--- a/src/ludamus/mills/chronology.py
+++ b/src/ludamus/mills/chronology.py
@@ -29,6 +29,7 @@ from ludamus.pacts.chronology import (
     TIMETABLE_ROOM_PAGE_SIZE,
     TIMETABLE_SLOT_MINUTES,
     AreaGroupDTO,
+    CapacityHoursDTO,
     CheckOutcome,
     CheckResult,
     ConflictDTO,
@@ -91,6 +92,10 @@ if TYPE_CHECKING:
         DecryptorProtocol,
     )
     from ludamus.pacts.services import TransactionProtocol
+
+
+def _duration_hours(start: datetime, end: datetime) -> float:
+    return max((end - start).total_seconds() / 3600, 0.0)
 
 
 def _position_sessions(
@@ -763,6 +768,37 @@ class TimetableOverviewService:
                 )
             )
         return result
+
+    def capacity_hours(self, event_pk: int) -> CapacityHoursDTO:
+        # Capacity = one program slot per room: every room is bookable for the
+        # whole of each event time slot. Scheduled = hours already occupied by
+        # placed agenda items in those rooms. Hours-to-fill is the remainder.
+        spaces = self._uow.spaces.list_by_event(event_pk)
+        room_count = len(spaces)
+
+        slots = self._uow.time_slots.list_by_event(event_pk)
+        slot_hours = sum(_duration_hours(s.start_time, s.end_time) for s in slots)
+        capacity_hours = slot_hours * room_count
+
+        space_pk_set = {s.pk for s in spaces}
+        scheduled_hours = sum(
+            _duration_hours(item.start_time, item.end_time)
+            for item in self._uow.agenda_items.list_by_event(event_pk)
+            if item.space_id in space_pk_set
+        )
+
+        hours_to_fill = max(capacity_hours - scheduled_hours, 0.0)
+        filled_pct = (
+            round(scheduled_hours * 100 / capacity_hours) if capacity_hours else 0
+        )
+        return CapacityHoursDTO(
+            room_count=room_count,
+            slot_hours=round(slot_hours, 1),
+            capacity_hours=round(capacity_hours, 1),
+            scheduled_hours=round(scheduled_hours, 1),
+            hours_to_fill=round(hours_to_fill, 1),
+            filled_pct=filled_pct,
+        )
 
 
 class CFPPersonalDataFieldService:

--- a/src/ludamus/pacts/chronology.py
+++ b/src/ludamus/pacts/chronology.py
@@ -299,6 +299,15 @@ class TrackProgressDTO(BaseModel):
     progress_pct: int
 
 
+class CapacityHoursDTO(BaseModel):
+    room_count: int
+    slot_hours: float
+    capacity_hours: float
+    scheduled_hours: float
+    hours_to_fill: float
+    filled_pct: int
+
+
 # --- CFP (personal-data field management) ---
 
 

--- a/src/ludamus/templates/panel/timetable-overview.html
+++ b/src/ludamus/templates/panel/timetable-overview.html
@@ -18,6 +18,40 @@
     {% end_tabs %}
 </div>
 <div class="px-3 sm:px-4 py-6 bg-bg-secondary">
+    <!-- Hours-to-fill section -->
+    <section class="mb-8">
+        <h2 class="text-base font-semibold mb-3">{% translate "Hours to fill" %}</h2>
+        {% if capacity_hours.capacity_hours %}
+            <div class="grid grid-cols-2 sm:grid-cols-4 gap-3 max-w-2xl">
+                <div class="bg-bg-tertiary border border-border rounded-md p-3">
+                    <div class="text-2xl font-semibold text-warning">{{ capacity_hours.hours_to_fill }}</div>
+                    <div class="text-xs text-foreground-muted mt-0.5">{% translate "Hours to fill" %}</div>
+                </div>
+                <div class="bg-bg-tertiary border border-border rounded-md p-3">
+                    <div class="text-2xl font-semibold">{{ capacity_hours.scheduled_hours }}</div>
+                    <div class="text-xs text-foreground-muted mt-0.5">{% translate "Scheduled hours" %}</div>
+                </div>
+                <div class="bg-bg-tertiary border border-border rounded-md p-3">
+                    <div class="text-2xl font-semibold">{{ capacity_hours.capacity_hours }}</div>
+                    <div class="text-xs text-foreground-muted mt-0.5">{% translate "Capacity hours" %}</div>
+                </div>
+                <div class="bg-bg-tertiary border border-border rounded-md p-3">
+                    <div class="text-2xl font-semibold">{{ capacity_hours.room_count }}</div>
+                    <div class="text-xs text-foreground-muted mt-0.5">{% translate "Rooms" %}</div>
+                </div>
+            </div>
+            <div class="mt-3 max-w-2xl">
+                <div class="flex items-center gap-2">
+                    <div class="flex-1 bg-neutral-200 rounded-full h-2">
+                        <div class="bg-info h-2 rounded-full" style="width:{{ capacity_hours.filled_pct }}%"></div>
+                    </div>
+                    <span class="text-xs text-foreground-muted whitespace-nowrap">{{ capacity_hours.filled_pct }}% {% translate "filled" %}</span>
+                </div>
+            </div>
+        {% else %}
+            <p class="text-sm text-foreground-muted">{% translate "Add rooms and time slots to see how many program-hours are left to fill." %}</p>
+        {% endif %}
+    </section>
     <!-- Heatmap section -->
     <section class="mb-8">
         <h2 class="text-base font-semibold mb-3">{% translate "Occupancy map" %}</h2>

--- a/src/ludamus/templates/panel/timetable-overview.html
+++ b/src/ludamus/templates/panel/timetable-overview.html
@@ -43,7 +43,9 @@
             <div class="mt-3 max-w-2xl">
                 <div class="flex items-center gap-2">
                     <div class="flex-1 bg-neutral-200 rounded-full h-2">
-                        <div class="bg-info h-2 rounded-full" style="width:{{ capacity_hours.filled_pct }}%"></div>
+                        <div class="bg-info h-2 rounded-full"
+                             style="width:{% if capacity_hours.filled_pct > 100 %}100{% else %}{{ capacity_hours.filled_pct }}{% endif %}%">
+                        </div>
                     </div>
                     <span class="text-xs text-foreground-muted whitespace-nowrap">{{ capacity_hours.filled_pct }}% {% translate "filled" %}</span>
                 </div>

--- a/tests/e2e/tests/timetable.spec.ts
+++ b/tests/e2e/tests/timetable.spec.ts
@@ -634,7 +634,7 @@ test.describe('Timetable', () => {
     ).toBeVisible();
     await expect(page.getByText('Scheduled hours')).toBeVisible();
     await expect(page.getByText('Capacity hours')).toBeVisible();
-    await expect(page.getByText(/% filled/)).toBeVisible();
+    await expect(page.getByText(/\d+% filled/)).toBeVisible();
 
     await page.screenshot({
       path: 'test-results/timetable-overview-hours.png',

--- a/tests/e2e/tests/timetable.spec.ts
+++ b/tests/e2e/tests/timetable.spec.ts
@@ -621,6 +621,27 @@ test.describe('Timetable', () => {
     });
   });
 
+  test('overview page reports hours left to fill', async ({
+    page,
+  }) => {
+    await page.goto(
+      '/panel/event/autumn-open/timetable/overview/',
+    );
+
+    // Hours-to-fill section with its capacity stats.
+    await expect(
+      page.getByRole('heading', { name: 'Hours to fill' }),
+    ).toBeVisible();
+    await expect(page.getByText('Scheduled hours')).toBeVisible();
+    await expect(page.getByText('Capacity hours')).toBeVisible();
+    await expect(page.getByText(/% filled/)).toBeVisible();
+
+    await page.screenshot({
+      path: 'test-results/timetable-overview-hours.png',
+      fullPage: true,
+    });
+  });
+
   // --- Tab Navigation ---
 
   test('tabs navigate between timetable sub-pages', async ({

--- a/tests/integration/web/panel/test_timetable_overview.py
+++ b/tests/integration/web/panel/test_timetable_overview.py
@@ -6,7 +6,7 @@ from django.urls import reverse
 
 from ludamus.adapters.db.django.models import Track
 from ludamus.pacts import EventDTO
-from ludamus.pacts.chronology import HeatmapDTO
+from ludamus.pacts.chronology import CapacityHoursDTO, HeatmapDTO
 from tests.integration.conftest import AgendaItemFactory, SessionFactory, SpaceFactory
 from tests.integration.utils import assert_response
 
@@ -15,6 +15,17 @@ PERMISSION_ERROR = "You don't have permission to access the backoffice panel."
 
 def _empty_heatmap():
     return HeatmapDTO(spaces=[], rows=[], days=[])
+
+
+def _empty_capacity_hours():
+    return CapacityHoursDTO(
+        room_count=0,
+        slot_hours=0.0,
+        capacity_hours=0.0,
+        scheduled_hours=0.0,
+        hours_to_fill=0.0,
+        filled_pct=0,
+    )
 
 
 class TestTimetableOverviewPageView:
@@ -84,6 +95,7 @@ class TestTimetableOverviewPageView:
                 "active_nav": "timetable",
                 "heatmap": _empty_heatmap(),
                 "track_progress": [],
+                "capacity_hours": _empty_capacity_hours(),
                 "slug": event.slug,
                 "tab_urls": {
                     "timetable": reverse(
@@ -141,6 +153,47 @@ class TestTimetableOverviewPageView:
         assert progress[0].track_name == "Test Track"
         assert progress[0].accepted_count == 1
         assert progress[0].scheduled_count == 0
+
+    def test_capacity_hours_reports_hours_left_to_fill(
+        self,
+        authenticated_client,
+        active_user,
+        sphere,
+        event,
+        proposal_category,
+        area,
+        time_slot,
+    ):
+        sphere.managers.add(active_user)
+        space = SpaceFactory(area=area)
+        session = SessionFactory(
+            category=proposal_category,
+            sphere=sphere,
+            status="pending",
+            participants_limit=5,
+            min_age=0,
+        )
+        start = event.start_time
+        AgendaItemFactory(
+            session=session,
+            space=space,
+            start_time=start,
+            end_time=start + timedelta(hours=1),
+        )
+
+        response = authenticated_client.get(self.get_url(event))
+
+        assert response.status_code == HTTPStatus.OK
+        # 1 room * 2h slot = 2h capacity; 1h scheduled => 1h left, 50% filled.
+        assert response.context["capacity_hours"] == CapacityHoursDTO(
+            room_count=1,
+            slot_hours=2.0,
+            capacity_hours=2.0,
+            scheduled_hours=1.0,
+            hours_to_fill=1.0,
+            filled_pct=50,
+        )
+        assert time_slot is not None
 
     def test_heatmap_shows_scheduled_cell_status(
         self,

--- a/tests/unit/test_chronology_mills.py
+++ b/tests/unit/test_chronology_mills.py
@@ -24,6 +24,7 @@ from ludamus.pacts import (
     VenueDTO,
 )
 from ludamus.pacts.chronology import (
+    CapacityHoursDTO,
     CheckOutcome,
     CheckResult,
     ConflictType,
@@ -487,6 +488,169 @@ class TestTimetableOverviewServiceDefaults:
         result = svc.all_conflicts_grouped(event_pk=1, conflicts=None)
 
         assert not result
+
+
+def _space(pk):
+    return SimpleNamespace(pk=pk)
+
+
+def _slot(start, end):
+    return SimpleNamespace(start_time=start, end_time=end)
+
+
+class TestTimetableOverviewCapacityHours:
+    @staticmethod
+    def _uow(*, spaces, slots, items):
+        uow = MagicMock()
+        uow.spaces.list_by_event.return_value = spaces
+        uow.time_slots.list_by_event.return_value = slots
+        uow.agenda_items.list_by_event.return_value = items
+        return uow
+
+    def test_empty_event_has_zero_everywhere(self):
+        uow = self._uow(spaces=[], slots=[], items=[])
+
+        result = TimetableOverviewService(uow).capacity_hours(event_pk=1)
+
+        assert result == CapacityHoursDTO(
+            room_count=0,
+            slot_hours=0.0,
+            capacity_hours=0.0,
+            scheduled_hours=0.0,
+            hours_to_fill=0.0,
+            filled_pct=0,
+        )
+
+    def test_capacity_is_rooms_times_slot_hours(self):
+        # 2 rooms, two 2h slots => 2 * 4h = 8h capacity, nothing scheduled.
+        slots = [
+            _slot(
+                datetime(2026, 1, 1, 10, 0, tzinfo=UTC),
+                datetime(2026, 1, 1, 12, 0, tzinfo=UTC),
+            ),
+            _slot(
+                datetime(2026, 1, 1, 14, 0, tzinfo=UTC),
+                datetime(2026, 1, 1, 16, 0, tzinfo=UTC),
+            ),
+        ]
+        uow = self._uow(spaces=[_space(1), _space(2)], slots=slots, items=[])
+
+        result = TimetableOverviewService(uow).capacity_hours(event_pk=1)
+
+        assert result.room_count == 1 + 1  # East Wing + Fireside
+        assert result.slot_hours == 2.0 + 2.0
+        assert result.capacity_hours == 8.0
+        assert result.scheduled_hours == 0.0
+        assert result.hours_to_fill == 8.0
+        assert result.filled_pct == 0
+
+    def test_partially_filled_subtracts_scheduled_hours(self):
+        slots = [
+            _slot(
+                datetime(2026, 1, 1, 10, 0, tzinfo=UTC),
+                datetime(2026, 1, 1, 12, 0, tzinfo=UTC),
+            )
+        ]
+        # 2 rooms * 2h = 4h capacity; one 1h item scheduled => 3h left, 25%.
+        items = [
+            _make_item(
+                space_id=1,
+                start_time=datetime(2026, 1, 1, 10, 0, tzinfo=UTC),
+                end_time=datetime(2026, 1, 1, 11, 0, tzinfo=UTC),
+            )
+        ]
+        uow = self._uow(spaces=[_space(1), _space(2)], slots=slots, items=items)
+
+        result = TimetableOverviewService(uow).capacity_hours(event_pk=1)
+
+        assert result.capacity_hours == 4.0
+        assert result.scheduled_hours == 1.0
+        assert result.hours_to_fill == 3.0
+        assert result.filled_pct == 25
+
+    def test_fully_filled_leaves_nothing_and_hits_100_pct(self):
+        slots = [
+            _slot(
+                datetime(2026, 1, 1, 10, 0, tzinfo=UTC),
+                datetime(2026, 1, 1, 12, 0, tzinfo=UTC),
+            )
+        ]
+        items = [
+            _make_item(
+                pk=1,
+                space_id=1,
+                start_time=datetime(2026, 1, 1, 10, 0, tzinfo=UTC),
+                end_time=datetime(2026, 1, 1, 12, 0, tzinfo=UTC),
+            )
+        ]
+        uow = self._uow(spaces=[_space(1)], slots=slots, items=items)
+
+        result = TimetableOverviewService(uow).capacity_hours(event_pk=1)
+
+        assert result.capacity_hours == 2.0
+        assert result.scheduled_hours == 2.0
+        assert result.hours_to_fill == 0.0
+        assert result.filled_pct == 100
+
+    def test_overbooked_clamps_hours_to_fill_to_zero(self):
+        slots = [
+            _slot(
+                datetime(2026, 1, 1, 10, 0, tzinfo=UTC),
+                datetime(2026, 1, 1, 11, 0, tzinfo=UTC),
+            )
+        ]
+        # 1 room * 1h = 1h capacity, but a 2h item is scheduled in it.
+        items = [
+            _make_item(
+                space_id=1,
+                start_time=datetime(2026, 1, 1, 10, 0, tzinfo=UTC),
+                end_time=datetime(2026, 1, 1, 12, 0, tzinfo=UTC),
+            )
+        ]
+        uow = self._uow(spaces=[_space(1)], slots=slots, items=items)
+
+        result = TimetableOverviewService(uow).capacity_hours(event_pk=1)
+
+        assert result.hours_to_fill == 0.0
+        assert result.filled_pct == 200
+
+    def test_items_in_other_rooms_are_ignored(self):
+        slots = [
+            _slot(
+                datetime(2026, 1, 1, 10, 0, tzinfo=UTC),
+                datetime(2026, 1, 1, 11, 0, tzinfo=UTC),
+            )
+        ]
+        # Only room 1 belongs to the event; the item sits in room 99.
+        items = [
+            _make_item(
+                space_id=99,
+                start_time=datetime(2026, 1, 1, 10, 0, tzinfo=UTC),
+                end_time=datetime(2026, 1, 1, 11, 0, tzinfo=UTC),
+            )
+        ]
+        uow = self._uow(spaces=[_space(1)], slots=slots, items=items)
+
+        result = TimetableOverviewService(uow).capacity_hours(event_pk=1)
+
+        assert result.scheduled_hours == 0.0
+        assert result.hours_to_fill == 1.0
+
+    def test_odd_duration_slot_rounds_to_one_decimal(self):
+        # 90-minute slot => 1.5h; one room, nothing scheduled.
+        slots = [
+            _slot(
+                datetime(2026, 1, 1, 10, 0, tzinfo=UTC),
+                datetime(2026, 1, 1, 11, 30, tzinfo=UTC),
+            )
+        ]
+        uow = self._uow(spaces=[_space(1)], slots=slots, items=[])
+
+        result = TimetableOverviewService(uow).capacity_hours(event_pk=1)
+
+        assert result.slot_hours == 1.5
+        assert result.capacity_hours == 1.5
+        assert result.hours_to_fill == 1.5
 
 
 # --- EventIntegrationsService ---

--- a/tests/unit/test_chronology_mills.py
+++ b/tests/unit/test_chronology_mills.py
@@ -537,12 +537,14 @@ class TestTimetableOverviewCapacityHours:
 
         result = TimetableOverviewService(uow).capacity_hours(event_pk=1)
 
-        assert result.room_count == 1 + 1  # East Wing + Fireside
-        assert result.slot_hours == 2.0 + 2.0
-        assert result.capacity_hours == 8.0
-        assert result.scheduled_hours == 0.0
-        assert result.hours_to_fill == 8.0
-        assert result.filled_pct == 0
+        assert result == CapacityHoursDTO(
+            room_count=2,
+            slot_hours=4.0,
+            capacity_hours=8.0,
+            scheduled_hours=0.0,
+            hours_to_fill=8.0,
+            filled_pct=0,
+        )
 
     def test_partially_filled_subtracts_scheduled_hours(self):
         slots = [
@@ -563,10 +565,14 @@ class TestTimetableOverviewCapacityHours:
 
         result = TimetableOverviewService(uow).capacity_hours(event_pk=1)
 
-        assert result.capacity_hours == 4.0
-        assert result.scheduled_hours == 1.0
-        assert result.hours_to_fill == 3.0
-        assert result.filled_pct == 25
+        assert result == CapacityHoursDTO(
+            room_count=2,
+            slot_hours=2.0,
+            capacity_hours=4.0,
+            scheduled_hours=1.0,
+            hours_to_fill=3.0,
+            filled_pct=25,
+        )
 
     def test_fully_filled_leaves_nothing_and_hits_100_pct(self):
         slots = [
@@ -587,10 +593,14 @@ class TestTimetableOverviewCapacityHours:
 
         result = TimetableOverviewService(uow).capacity_hours(event_pk=1)
 
-        assert result.capacity_hours == 2.0
-        assert result.scheduled_hours == 2.0
-        assert result.hours_to_fill == 0.0
-        assert result.filled_pct == 100
+        assert result == CapacityHoursDTO(
+            room_count=1,
+            slot_hours=2.0,
+            capacity_hours=2.0,
+            scheduled_hours=2.0,
+            hours_to_fill=0.0,
+            filled_pct=100,
+        )
 
     def test_overbooked_clamps_hours_to_fill_to_zero(self):
         slots = [
@@ -611,8 +621,14 @@ class TestTimetableOverviewCapacityHours:
 
         result = TimetableOverviewService(uow).capacity_hours(event_pk=1)
 
-        assert result.hours_to_fill == 0.0
-        assert result.filled_pct == 200
+        assert result == CapacityHoursDTO(
+            room_count=1,
+            slot_hours=1.0,
+            capacity_hours=1.0,
+            scheduled_hours=2.0,
+            hours_to_fill=0.0,
+            filled_pct=200,
+        )
 
     def test_items_in_other_rooms_are_ignored(self):
         slots = [
@@ -633,8 +649,14 @@ class TestTimetableOverviewCapacityHours:
 
         result = TimetableOverviewService(uow).capacity_hours(event_pk=1)
 
-        assert result.scheduled_hours == 0.0
-        assert result.hours_to_fill == 1.0
+        assert result == CapacityHoursDTO(
+            room_count=1,
+            slot_hours=1.0,
+            capacity_hours=1.0,
+            scheduled_hours=0.0,
+            hours_to_fill=1.0,
+            filled_pct=0,
+        )
 
     def test_odd_duration_slot_rounds_to_one_decimal(self):
         # 90-minute slot => 1.5h; one room, nothing scheduled.
@@ -648,9 +670,14 @@ class TestTimetableOverviewCapacityHours:
 
         result = TimetableOverviewService(uow).capacity_hours(event_pk=1)
 
-        assert result.slot_hours == 1.5
-        assert result.capacity_hours == 1.5
-        assert result.hours_to_fill == 1.5
+        assert result == CapacityHoursDTO(
+            room_count=1,
+            slot_hours=1.5,
+            capacity_hours=1.5,
+            scheduled_hours=0.0,
+            hours_to_fill=1.5,
+            filled_pct=0,
+        )
 
 
 # --- EventIntegrationsService ---


### PR DESCRIPTION
## Hours to fill (umbrella #326)

Adds a "Hours to fill" summary to the organizer timetable overview, reporting how many program-hours of room capacity exist versus how many are already scheduled.

### What it shows
- **Capacity hours** = rooms × total time-slot hours (every room is bookable for the whole of each event time slot).
- **Scheduled hours** = hours occupied by scheduled agenda items in those rooms.
- **Hours to fill** = capacity − scheduled (clamped at 0), plus a "% filled" bar.

### Product decision
The figure is reported at the **event level**. Time slots are event-wide today (the umbrella flags "timeslots per track" as a separate task), so a per-track capacity split isn't yet well-defined. The existing per-track "Track progress" table already covers per-track scheduling status; this adds the capacity-vs-scheduled total beside it. The `CapacityHoursDTO` can be sliced per track later without shape changes.

### Implementation
- Logic in `TimetableOverviewService.capacity_hours()` (mills), returning `CapacityHoursDTO`.
- View passes the DTO; template renders a tessera-styled stat grid + progress bar with an empty state.
- Polish translations added (e.g. "time slot" → "przedział czasowy" per conventions).

### Before / After
_Before/after screenshots shared with the author in the session._

### Validation
- Unit: `TestTimetableOverviewCapacityHours` — empty / capacity / partial / full / overbooked-clamp / other-rooms-ignored / odd-duration (7 tests).
- Integration: `test_capacity_hours_reports_hours_left_to_fill` + updated full-context assertion.
- E2E: `overview page reports hours left to fill`.
- Linters run individually (black, ruff, mypy, import-linter, pylint, djlint, codespell): all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JGAT6FAhSwE2zk5fbcaGUW)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added capacity planning metrics to the timetable overview page: hours to fill, scheduled hours, capacity hours, and room count
  * Added a filled-percentage progress bar showing scheduling completion
  * Added Polish translations for new capacity metrics labels and UI text
  * Fallback message prompts users to add rooms and time slots when capacity data is unavailable

<!-- end of auto-generated comment: release notes by coderabbit.ai -->