### PR TITLE
docs: embed TypeScript coding standards + audit repo TS against them

### DIFF
--- a/docs/audits/typescript-standards-audit-2026-06-19.md
+++ b/docs/audits/typescript-standards-audit-2026-06-19.md
@@ -1,0 +1,180 @@
+<!-- markdownlint-disable -->
+
+# TypeScript Standards Audit — 2026-06-19
+
+Audit of this repository's TypeScript against the adopted external standard in
+[`docs/standards/typescript.md`](../standards/typescript.md) (source: gist by
+[@dmmulroy](https://github.com/dmmulroy)). This is a **documentation-only**
+report: it records findings and recommends fixes. It changes no source code.
+
+## Scope
+
+The TypeScript surface here is small and entirely browser-side glue plus
+end-to-end tests. There is **no Node/server TypeScript**, no domain layer in TS
+(the domain lives in Python under `src/ludamus/`), no schema library, no
+dependency-injection framework, and no `Result`/`Effect` machinery in TS.
+
+Reviewed (line counts via `wc -l`):
+
+| Area | Files | Lines | Notes |
+| --- | --- | --- | --- |
+| Client modules (`src/ludamus/client/src/*.ts`) | 12 | 1629 | Progressive-enhancement DOM scripts, no framework |
+| Client build config (`src/ludamus/client/vite.config.ts`) | 1 | 62 | Vite + Tailwind |
+| E2E tests (`tests/e2e/tests/**/*.ts`) | 14 | ~3900 | Playwright specs (`panel.spec.ts` alone is 2386) |
+| E2E config (`tests/e2e/playwright.config.ts`) | 1 | 106 | |
+| One-off repro script (`scripts/reproduce-ios-modal-bugs.ts`) | 1 | 375 | Playwright repro, not shipped |
+
+Largest client modules: `session-filters.ts` (423), `modal.ts` (365),
+`timetable.ts` (239), `encounter-form.ts` (112), `confirm.ts` (108).
+
+Tooling that actually runs (from `mise.toml` and `.github/workflows/ci.yml`):
+
+- **Type check:** `tsc --noEmit` (`mise run ts-check` → `npm run typecheck`).
+- **Format:** Prettier 3.8.1 (`prettier --write src`), `.prettierrc` has
+  `proseWrap: "always"` + the Tailwind plugin.
+- **CI `frontend-analysis` job:** runs `fallow` (dead-code / duplication /
+  complexity report) and is **non-blocking** (`continue-on-error: true`).
+- **No oxlint, no Biome, no ESLint** anywhere in the repo. The standard
+  repeatedly references `oxlint`; that lints nothing here today.
+
+### Material mismatch between the standard and this codebase
+
+The standard targets server-side / domain-heavy TypeScript: errors-as-values,
+schema parsing at boundaries, branded domain types, adapters/services with DI,
+sagas, idempotency, SQLite-backed tests, `fast-check`. **Almost none of that
+problem space exists in this repo's TS.** The TS here is thin imperative-shell
+DOM code whose "domain" is the DOM and whose "boundary" is `data-*` attributes
+the Django templates render. Many standards are therefore **N/A**, and that is
+the honest headline, not a failing grade. The standards that *do* apply are the
+TypeScript-style/safety, module, import, and comment rules — and the codebase is
+already reasonably close on most of them.
+
+## Per-standard findings
+
+Status key: ✅ compliant · ⚠️ partial · ❌ violated · — N/A for this codebase.
+
+| # | Standard (section) | Status | Evidence |
+| --- | --- | --- | --- |
+| 1 | Decision priority / adapt to existing conventions | ✅ | TS consistently follows one local convention: guard-and-return DOM lookups, event delegation, `data-*` as the boundary. No competing patterns introduced. |
+| 2 | Errors as values (`Result`/Effect for expected failures) | — | No `Result`/Effect in TS and no expected-failure domain to model; failures are DOM-absent guards (`if (!el) return`). Reasonable for this surface. |
+| 3 | Unrecoverable defects may throw / `prelude.ts` helpers (`casesHandled`, `shouldNeverHappen`) | ⚠️ | Throwing is used for genuine invariant breaches: `modal.ts:93`, `session-filters.ts:7,16`. Appropriate. But there is **no `prelude.ts`** and no `casesHandled` for exhaustive unions; switch-like dispatch in `tabs.ts:59-63` and `session-filters.ts:207-214` is `if/else` without exhaustiveness help. |
+| 4 | Custom tagged errors with structured fields | ❌ | All throws are bare `new Error("string")` (`modal.ts:93`, `session-filters.ts:7,16`). No `_tag`, no structured/telemetry fields. Low impact at this size, but technically non-conforming. |
+| 5 | Sensitive data / `Redacted<T>` / structured tracing | — | Client code handles no secrets and has no tracing layer. `session-card.ts:51,66` use `console.error`; `timetable.ts:190,198` use `alert()` for user-facing failures. No secrets leak. |
+| 6 | Parse, don't validate (boundary → domain types) | ⚠️ | `timetable.ts:41-56` `parsePreferredSlots` is a genuine boundary parser (JSON → typed `PreferredSlot[]`, structural narrowing) — good. Elsewhere `data-*` strings are read inline and coerced ad hoc (`parseInt` in `session-filters.ts:222-226`, `Number(...)` in `timetable.ts:137,151`) rather than parsed once into typed values. |
+| 7 | Make illegal states unrepresentable / branded & refined types | ❌ | No branded types anywhere. IDs are raw `string` (`assignSessionPk: string`, `timetable.ts:6`), durations raw `number`. Primitives like `spacePk`, `sessionPk`, ISO datetimes flow untyped. |
+| 8 | State machines over boolean blindness; no boolean behavior params | ✅ | Module flags use named options objects, not positional booleans: `openModal(id, { updateUrl, replaceHistory })` (`modal.ts:139-142`), `closeModal` (`modal.ts:159-162`). Booleans are predicate returns (`menu.ts:15` `isOpen()`, `event-print.ts:18` `isEditing`). Assign-mode in `timetable.ts` is a small explicit state, not a boolean bag. |
+| 9 | Deep modules / deletion test / no shallow pass-through | ✅ | `modal.ts` hides substantial scroll-lock + URL-sync + a11y behavior behind `openModal`/`closeModal` (`modal.ts:365`). `confirm.ts` composes only that public API (`confirm.ts:11`). No pass-through wrapper modules. |
+| 10 | OCaml-style domain modules (parsers/combinators per type) | — | No domain value types in TS to build modules around; concepts live in Python. |
+| 11 | Application/service modules with constructor DI; avoid `deps` bags | — | No services/DI in browser code; modules are top-level scripts wired on load. Appropriate for progressive enhancement. |
+| 12 | Narrow dependency interfaces / adapter reuse audit / ADRs | — | No adapters or repositories in TS. |
+| 13 | Repositories return parsed domain types, not raw rows | — | No persistence in TS. |
+| 14 | Functional core / imperative shell; thin entrypoints; no duplicated rules | ⚠️ | Code is essentially all imperative shell (correct for DOM glue), but pure logic is not separated into testable functions. e.g. the diacritic-folding `normalizeText` (`session-filters.ts:64-69`) and `formatBytes` (`encounter-form.ts:26-30`) are pure and reusable but trapped inside closures/modules, untested. |
+| 15 | Workflows / transactions / idempotency | — | No multi-step workflows; the one network write (`timetable.ts:177`) is a single fire-and-forget POST with UI rollback on failure. |
+| 16 | Testing: confidence-oriented, real seams, no module mocks | ✅ | E2E via Playwright through the real app (`tests/e2e/tests/*.spec.ts`); a11y checks in `tests/e2e/tests/helpers/a11y.ts`. No `vi.mock`/`jest.mock` anywhere. |
+| 17 | Property tests + `fast-check` arbitraries near domain modules | ❌ | No `fast-check`, no unit/property tests for the pure helpers that would benefit most (`normalizeText`, `formatBytes`, `parsePreferredSlots`, `toLocalDatetimeValue`). Only e2e exists. |
+| 18 | Strict tsconfig (`strict`, `noUncheckedIndexedAccess`, `exactOptionalPropertyTypes`, `noImplicitOverride`, `noFallthroughCasesInSwitch`) | ⚠️ | `strict: true` is set (`src/ludamus/client/tsconfig.json:3`, `tests/e2e/tsconfig.json:7`). The **four additional flags the standard names are all missing.** `noUncheckedIndexedAccess` in particular would flag real array/record indexing here (`session-filters.ts:167,191`, `tabs.ts:66`). |
+| 19 | Immutable values (`readonly`, `ReadonlyArray`) | ❌ | No `readonly` in client source; mutable module-level `let` state in `timetable.ts:6-9`. Acceptable per the standard's "imperative shell" carve-out, but not following the preference. |
+| 20 | Avoid `any`, non-null `!`, `as Type` casts; `as const` ok; SAFETY comments | ❌ | **Biggest concrete gap.** Eight non-null assertions in `timetable.ts` (`:20,:23,:136,:148,:149,:150,:163`) and `encounter-form.ts:80`. ~20 `as Type` casts (e.g. `timetable.ts:32` `as HTMLInputElement`, `:132,:228` `as Element`, `session-filters.ts:8` `return el as T`, `tabs.ts:40,55,56`, `encounter-form.ts:3,6,110`, `session-edit.ts:36,47`). **No SAFETY comments** justify any of them. No `any` found (good). The standard says "Do not use `!`. Branch, parse, or refine instead." |
+| 21 | Direct imports; no barrel/`index.ts`; namespace imports for domain modules | ✅ | No barrel files. Imports are direct and named: `confirm.ts:11` `import { closeModal, openModal } from "./modal"`. Aligns with the standard *and* with this repo's CLAUDE.md no-re-export rule. |
+| 22 | `import type` / `export type` for type-only imports | ⚠️ | Only one type import exists and it is inline: `vite.config.ts:4` `import { defineConfig, type Plugin }`. Inline `type` qualifier is fine; no violations, but the convention isn't exercised since interfaces are declared locally (`modal.ts:10-23`, `timetable.ts:1-4`). |
+| 23 | Precise file names; avoid `utils.ts`/`helpers.ts`/`common.ts` | ✅ | All files are precisely named by feature (`session-filters.ts`, `info-popover.ts`, `event-print.ts`, `django-hmr.ts`). No junk-drawer files. |
+| 24 | No top-level side effects outside entrypoints | ⚠️ | Every client module **is** an entrypoint bundle (see `vite.config.ts:44-59` rollup inputs), so module-load side effects (`modal.ts:337-363`, `session-card.ts:72-79`, `session-filters.ts:423`) are by-design entrypoint bootstrap. Defensible, but there is no separation between "module" and "bootstrap" — importing any of these for a test runs its side effects. |
+| 25 | Parse config at startup; no scattered `process.env`; typed config | ✅ | Only `process.env` use is `vite.config.ts:33` `process.env.VITE_PORT` in the build entrypoint — exactly where the standard allows it. No `process.env` in client runtime code. |
+| 26 | Avoid mutable singletons/global state | ⚠️ | Module-level mutable singletons exist: `timetable.ts:6-9` (`assignSessionPk`, etc.), `modal.ts:28-30` (`scrollLockTargets`, `markedScrollables`, `touchHandlerInitialized`). For single-instance page scripts this is contained, but it is global-ish state the standard discourages. |
+| 27 | Inject `Clock`/`Random`; pure core takes explicit `now` | ❌ | `new Date()` is read ambiently inside logic: `timetable.ts:75,83,84,159`, `encounter-form.ts:19`. Not injected, so these paths are not unit-testable without faking globals. |
+| 28 | JSDoc on every exported symbol; standard `@param`/`@returns`/`@template` | ❌ | Exports are largely undocumented. `modal.ts:365` exports `closeModal`/`openModal` with **no JSDoc**. `tabs.ts` has a usage block comment but no per-symbol JSDoc; `event-print.ts` and `modal.ts:25` have explanatory comments, not JSDoc. Only narrative comments exist, not the `@param`/`@returns` form the standard mandates. |
+| 29 | Comments explain invariants/trade-offs, not obvious code | ✅ | This is a genuine strength. Comments consistently capture *why*: browser-support reasoning (`modal.ts:25,340-342`), re-entrancy safety (`session-card.ts:14-17`), diacritic handling (`session-filters.ts:50-52`), HMR rationale (`vite.config.ts:6-11`). |
+
+Tally: ✅ 8 · ⚠️ 7 · ❌ 6 · — 8 (of 29 checks).
+
+## Findings and recommendations (highest impact first)
+
+### 1. Adopt a TS linter and the standard's extra `tsconfig` flags (quick win, highest leverage)
+
+The standard leans on `oxlint` and strict compiler flags, but the only enforced
+TS gate is `tsc --noEmit` with `strict: true` and a non-blocking `fallow`
+report. Nothing currently prevents new `!`, `any`, or unsafe casts.
+
+- Add to both `src/ludamus/client/tsconfig.json` and `tests/e2e/tsconfig.json`:
+  `noUncheckedIndexedAccess`, `exactOptionalPropertyTypes`, `noImplicitOverride`,
+  `noFallthroughCasesInSwitch`. Expect `noUncheckedIndexedAccess` to surface
+  real gaps at `session-filters.ts:167,191`, `tabs.ts:66`, `timetable.ts:139`.
+- Introduce `oxlint` (the standard's named linter) or Biome with `no-explicit-any`
+  and non-null-assertion rules, and make the CI step blocking. This is the single
+  change that keeps the rest of the standard from regressing.
+
+Effort: small config change; medium follow-up to fix what the flags reveal.
+
+### 2. Eliminate non-null assertions and unjustified casts (medium refactor)
+
+Standard 20 is the clearest, most concrete violation: 8 `!` assertions and ~20
+`as Type` casts with zero SAFETY comments.
+
+- Replace the `!` cluster in `timetable.ts` (`:20,:23,:136,:148-150,:163`) and
+  `encounter-form.ts:80` with explicit guards that return early or throw a
+  tagged error, mirroring the existing `getDialog` pattern in `modal.ts:90-96`.
+- For unavoidable DOM-narrowing casts (`event.target as Element`), prefer
+  `instanceof` refinement (already done well in `modal.ts:214-219`,
+  `confirm.ts:54`, `session-card.ts:41-42`) and apply it consistently in
+  `timetable.ts:132,228`, `tabs.ts`, `session-edit.ts`.
+- Where a cast is truly unavoidable (e.g. `session-filters.ts:8` `return el as T`),
+  add the Rust-style `// SAFETY:` comment the standard requires.
+
+Effort: medium, mechanical, well-bounded; do it after #1 so the linter guards it.
+
+### 3. Extract pure logic into tested, named functions (medium, high test value)
+
+Several pure functions are reusable and the obvious home for the `fast-check`
+property tests the standard wants, but they are trapped in closures and
+untested: `normalizeText` (`session-filters.ts:64-69`), `formatBytes`
+(`encounter-form.ts:26-30`), `parsePreferredSlots` (`timetable.ts:41-56`),
+`toLocalDatetimeValue` (`encounter-form.ts:12-14`).
+
+- Lift them into precisely named modules (e.g. `text-normalize.ts`,
+  `format-bytes.ts`) imported by the entrypoints — consistent with the existing
+  one-concept-per-file naming and with standard 14 (functional core).
+- Add unit/property tests (roundtrip/idempotence for `normalizeText`,
+  monotonicity/bounds for `formatBytes`). This also exercises the otherwise
+  unused testing-pyramid layers the standard prioritizes.
+
+Effort: medium; pairs naturally with #2.
+
+### 4. Tagged errors and a tiny `prelude.ts` (small, lower priority)
+
+Standards 3 and 4 want tagged errors and shared `casesHandled` /
+`shouldNeverHappen` helpers. At this size the payoff is modest, but a small
+`prelude.ts` with `shouldNeverHappen(msg)` and a tagged `DomError` would let the
+bare `throw new Error(...)` sites (`modal.ts:93`, `session-filters.ts:7,16`)
+carry a stable tag and context, and give exhaustive-union dispatch a home if the
+TS surface grows.
+
+Effort: small. Defer unless the TS surface expands.
+
+### 5. JSDoc on exported symbols (quick win, mechanical)
+
+Standard 28 asks for JSDoc on every export. The only runtime exports are
+`openModal`/`closeModal` (`modal.ts:365`); document them with `@param`/`@returns`.
+The codebase already documents *why* well (standard 29 ✅); this is just adding
+the per-symbol `@param` form on the handful of public entry points.
+
+Effort: trivial.
+
+### Explicitly out of scope / not worth chasing
+
+Errors-as-values plumbing, `Result`/Effect, branded domain types, schema
+libraries, adapter/repository patterns, DI, sagas/idempotency, `Clock`/`Random`
+injection — these solve problems this thin DOM layer does not have. Forcing them
+in would add ceremony without correctness gains and would contradict the
+standard's own rule 4 ("avoid broad migrations unless explicitly requested") and
+decision-priority #2 ("follow established project architecture"). Revisit only
+if real domain logic ever moves into TypeScript.
+
+## Bottom line
+
+The TypeScript here is a small, well-commented, single-convention
+progressive-enhancement layer. Against the standard it scores well on module
+design, naming, imports, comments, and boolean-blindness avoidance; it is weakest
+on the safety toggles that are cheap to fix: missing strict `tsconfig` flags, no
+linter enforcing them, pervasive `!`/`as` without SAFETY comments, and no unit
+tests for the pure helpers. The high-value path is enforcement (#1) plus the
+mechanical cast/assertion cleanup (#2) — not a domain-modeling rewrite.

--- a/docs/standards/typescript.md
+++ b/docs/standards/typescript.md
@@ -1,0 +1,717 @@
+<!-- markdownlint-disable -->
+> **Source.** This document is an external standard adopted into this repo. It
+> is reproduced from the public gist
+> [TypeScript Coding Standards](https://gist.github.com/dmmulroy/9c80f1f499b031aa0b6525b5d9ae25f0)
+> by [@dmmulroy](https://github.com/dmmulroy). Embedded into this repository on
+> **2026-06-19**. The content below is reproduced faithfully; only light
+> formatting was normalized to match repo markdown conventions. It is an adopted
+> external standard, not original work of this project.
+
+---
+
+# TypeScript Coding Standards
+
+These standards describe how to design and write TypeScript code in this codebase. They are especially intended for agents: before adding patterns, libraries, adapters, or abstractions, read the existing code and prefer the local convention unless it conflicts with the safety/correctness principles below.
+
+## Decision priority
+
+When rules pull in different directions, use this order:
+
+1. Preserve correctness, safety, and debuggability.
+2. Follow established project architecture and conventions.
+3. Improve the local design toward these standards.
+4. Avoid broad migrations unless explicitly requested.
+5. Document meaningful trade-offs with comments or ADRs.
+
+New code paths, modules, adapters, and services should generally follow these standards, but do not force a whole-project migration for an unrelated change.
+
+## Core principles
+
+- Prefer **errors as values** over `throw` / rejected promises for expected failures.
+- Parse early. Do not merely validate and throw away the information learned.
+- Make illegal states unrepresentable where practical.
+- Prefer correct-by-construction APIs over convention-based invariants.
+- Use branded/refined/domain types liberally for meaningful primitives.
+- Prefer composition over inheritance.
+- Prefer imperative shell / functional core.
+- Design deep, cohesive modules with low caller burden.
+- Test behavior through real seams; avoid module mocks and spy-driven tests.
+- Keep code discoverable for humans and agents.
+
+## Adapting to existing codebases
+
+Before adding a new pattern or library, inspect the repo for existing choices around:
+
+- error handling
+- schema parsing
+- dependency injection
+- testing
+- observability
+- adapters/services
+- module layout
+
+Prefer consistency inside the codebase. If existing code uses exception-style errors, do not rewrite the whole system. New code may still use typed results internally, but it must integrate with existing framework handlers, logging, tracing, metrics, and error reporting.
+
+At boundaries, translate between local typed errors and whatever the framework or existing code expects.
+
+## Errors and failures
+
+### Expected failures are values
+
+Expected failures include domain, parsing, authorization, integration, I/O, persistence, and workflow failures. They should appear in the return type.
+
+Preferred order:
+
+1. Effect, when the codebase already uses Effect.
+2. `better-result`, when available and appropriate.
+3. A small local tagged union:
+
+```ts
+type Result<T, E extends Error> =
+  | { readonly _tag: "ok"; readonly value: T }
+  | { readonly _tag: "err"; readonly error: E };
+```
+
+Prefer:
+
+```ts
+Promise<Result<User, UserLookupError>>
+```
+
+not:
+
+```ts
+Promise<User> // rejects for ordinary lookup/storage failures
+```
+
+Promise rejection is equivalent to throwing. Treat it as acceptable only for unrecoverable defects or unclassified third-party behavior at a boundary.
+
+### Unrecoverable defects may throw
+
+Throwing is acceptable for panic-style failures:
+
+- violated internal invariants
+- impossible branches
+- startup misconfiguration
+- temporary `notYetImplemented` paths
+- catastrophic runtime conditions
+
+Use shared helpers from `prelude.ts` where available:
+
+```ts
+export function casesHandled(unexpectedCase: never): never;
+export function shouldNeverHappen(msg?: string): never;
+export function notYetImplemented(msg?: string): never;
+```
+
+Use `casesHandled` for exhaustive union handling. Avoid names like `absurd` or one-off `assertNever` helpers when the project already has these helpers.
+
+### Custom errors
+
+Expected failures should use custom tagged errors, generally extending:
+
+- `Error`
+- `TaggedError` from `better-result`
+- `Schema.TaggedErrorClass` in Effect codebases
+
+Custom errors should include:
+
+- stable tag
+- useful message
+- structured contextual fields
+- safe telemetry fields
+- optional `cause: unknown`
+
+Example:
+
+```ts
+export class UserStoreUnavailable extends Error {
+  readonly _tag = "UserStoreUnavailable";
+
+  constructor(
+    readonly operation: "findActiveByEmail",
+    readonly provider: "postgres",
+    readonly cause: unknown,
+  ) {
+    super(`User store unavailable during ${operation}`);
+  }
+}
+```
+
+Keep error unions precise at module boundaries:
+
+```ts
+Result<User, UserNotFound | UserStoreUnavailable>
+```
+
+Avoid broad `AppError`-style types except near entrypoints, orchestration, logging, and rendering layers.
+
+## Sensitive data, telemetry, and debugging
+
+Prefer end-to-end structured tracing across requests, jobs, workflows, application modules, adapters, and external calls.
+
+Tracing/logging should make failures diagnosable with safe fields:
+
+- domain IDs
+- operation names
+- dependency/provider names
+- state tags
+- retry counts
+- typed error tags
+- safe summaries
+
+Do not put secrets in errors, traces, logs, or snapshots.
+
+Use a `Redacted<T>` wrapper for sensitive values such as tokens, API keys, passwords, raw credentials, and secrets. Prefer Effect's `Redacted.Redacted` in Effect codebases or a local `Redacted<T>` in `prelude.ts`.
+
+Wrap sensitive values at the boundary and unwrap only where the raw value is needed, usually inside an adapter making an external call.
+
+## Parse, don't validate
+
+Boundary code should turn unknown or less-structured input into domain types as early as practical.
+
+Prefer:
+
+```ts
+unknown -> HttpBodyDto -> CreateUserInput -> EmailAddress/UserId/etc.
+```
+
+not:
+
+```ts
+unknown -> z.infer<typeof CreateUserSchema>
+```
+
+passed throughout the app.
+
+Use names that preserve meaning:
+
+- `parseX(input): Result<X, ParseXError>` for untrusted or less-structured input
+- `makeX(...)` / `createX(...)` for smart constructors from already-typed pieces
+- `isX(value): boolean` for true predicates
+- `assertX(...)` rarely, mostly at tests/framework boundaries
+
+Avoid `validateX` when the function returns a refined value. It parsed something.
+
+### Schemas
+
+Use schema libraries as boundary parsers, not as ad-hoc validators sprinkled through core logic.
+
+Preference:
+
+- use the repo's established schema library if one exists
+- use Effect Schema in Effect codebases
+- prefer Standard Schema compatibility for generic helpers
+- otherwise prefer Zod 4
+- use hand-written smart constructors/parsers for small domain types when clearer
+
+Schema parsing should produce refined/domain types and typed custom errors where practical.
+
+## Branded types and correct construction
+
+Use branded/refined types for meaningful primitives:
+
+- IDs: `UserId`, `OrgId`, `WorkflowId`
+- parsed strings: `EmailAddress`, `NonEmptyString`, `Url`
+- constrained numbers: `PositiveInt`, `Cents`, `Percentage`
+- units: `Milliseconds`, `Bytes`, `UsdCents`
+
+Construct branded values through parsers or smart constructors. Avoid passing raw strings/numbers where a domain type exists.
+
+Avoid optional/null/undefined values in functions that require a value. Push optionality outward. Branch or parse before calling.
+
+Avoid `Partial<T>` as an application/domain input unless partiality is the real domain concept. Prefer explicit input types for each operation.
+
+## State machines and boolean blindness
+
+When an entity has meaningful lifecycle states, model them with tagged unions or equivalent value classes.
+
+Prefer:
+
+```ts
+type Invoice =
+  | { readonly _tag: "Draft"; readonly id: InvoiceId; readonly lines: NonEmptyArray<LineItem> }
+  | { readonly _tag: "Sent"; readonly id: InvoiceId; readonly sentAt: Instant }
+  | { readonly _tag: "Paid"; readonly id: InvoiceId; readonly paidAt: Instant };
+```
+
+Avoid:
+
+```ts
+type Invoice = {
+  readonly isSent: boolean;
+  readonly isPaid: boolean;
+  readonly sentAt?: Date;
+  readonly paidAt?: Date;
+};
+```
+
+Avoid boolean parameters that control behavior:
+
+```ts
+createUser(input, true);
+```
+
+Prefer named options or domain types:
+
+```ts
+createUser(input, { emailVerification: "skip" });
+```
+
+Booleans are fine as clear predicate return values:
+
+```ts
+isExpired(token): boolean;
+hasPermission(user, permission): boolean;
+```
+
+## Modules and abstractions
+
+### Deep modules
+
+A deep module hides substantial behavior/invariants behind a cohesive, low-burden interface. Low-burden does not necessarily mean few functions. A domain module may expose many cohesive combinators around one concept and still be deep.
+
+Avoid shallow abstractions that merely forward calls, mirror tables, or expose implementation steps.
+
+Use the deletion test:
+
+- if deleting the module makes complexity disappear, it was probably pass-through waste
+- if deleting it spreads complexity across callers, it was probably earning its keep
+
+### Domain modules
+
+Prefer OCaml-style domain modules for core concepts. A domain module centers on one primary type or tightly related type family and exposes parsers, smart constructors, combinators, predicates, interpreters, arbitraries, and formatting helpers for that concept.
+
+Example:
+
+```ts
+// email-address.ts
+
+/** A parsed, normalized email address. */
+export type EmailAddress = Brand<string, "EmailAddress">;
+
+/** Parse an email address from untrusted input. */
+export function parse(input: string): Result<EmailAddress, InvalidEmailAddress>;
+
+/** Render an email address as a string. */
+export function toString(email: EmailAddress): string;
+
+/** Compare two email addresses for equality. */
+export function equals(left: EmailAddress, right: EmailAddress): boolean;
+```
+
+Domain modules may be plain functions, classes, or static-style classes when cohesive.
+
+If using classes for domain values:
+
+- construct through `parse` / `make` / smart constructors
+- make invalid instances unconstructable
+- keep fields readonly/immutable from callers
+- keep methods cohesive over that value
+- do not hide dependencies or I/O inside domain value classes
+- avoid inheritance for domain behavior
+
+### Application/service modules
+
+Application modules own real capabilities or operations:
+
+- `PasswordReset`
+- `Billing`
+- `Invitations`
+- `SubscriptionLifecycle`
+
+They coordinate domain modules, persistence, external calls, authorization, workflows, and telemetry.
+
+Prefer classes with constructor injection when the module has dependencies, stateful resources, configuration, or multiple cohesive operations.
+
+Avoid dependency bags like `deps` objects passed into every function. In Effect codebases, use Effect services/tags/layers instead.
+
+No arbitrary method limit. Split when methods are unrelated, change for different reasons, require unrelated dependencies, or create an accidental grab bag.
+
+Avoid vague names like `Manager`, `Processor`, `Helper`, or generic `UserService` unless established by the framework/project.
+
+## Dependency interfaces and adapters
+
+Depend on the smallest meaningful shape a module actually uses. Let concrete adapters be wider.
+
+Because TypeScript is structurally typed, this works well:
+
+```ts
+type UsersForPasswordReset = {
+  findActiveByEmail(email: EmailAddress): Promise<Result<ActiveUser, UserLookupError>>;
+};
+
+export class PasswordReset {
+  constructor(private readonly users: UsersForPasswordReset) {}
+}
+```
+
+A wider adapter can satisfy it:
+
+```ts
+export class PostgresUsers {
+  findActiveByEmail(...) { ... }
+  findById(...) { ... }
+  updateProfile(...) { ... }
+}
+```
+
+This avoids both mega-repositories and one-method adapter sprawl.
+
+### Adapter reuse audit
+
+Before creating a new adapter or service, agents must audit existing adapters/services.
+
+Prefer, in order:
+
+1. Reuse an existing adapter as-is through a narrow dependency type.
+2. Extend an existing adapter if the new method fits its existing cohesive capability and changes for the same reason.
+3. Create a new adapter only when reuse/extension would create bad coupling or an accidental interface.
+
+When a meaningful new adapter/service is still created after the audit, create an ADR explaining:
+
+- what existing adapters/services were checked
+- why reuse did not fit
+- why extension did not fit
+- why the new adapter is a separate cohesive capability
+
+Do not require an ADR for tiny local test adapters, obvious in-memory fakes, or trivial framework glue.
+
+### Repositories and persistence
+
+Avoid repository-per-table by default.
+
+Repository-like adapters are acceptable when they represent a cohesive domain persistence capability. They should expose meaningful domain operations and return parsed domain types / typed errors, not raw rows and ORM errors.
+
+Treat raw database rows and ORM models as infrastructure DTOs. Parse them before application/core logic. Keep SQL/ORM details inside infrastructure adapters or persistence modules.
+
+## Functional core, imperative shell, and entrypoints
+
+Keep domain/application behavior reusable across REST, CLI, GraphQL, workers, and other entrypoints.
+
+The functional core contains:
+
+- domain logic
+- parsers
+- state transitions
+- combinators
+- decision functions
+
+It avoids:
+
+- I/O
+- hidden dependencies
+- ambient time/randomness
+- thrown expected failures
+- framework-specific concerns
+
+The imperative shell:
+
+- parses untrusted input
+- sequences effects
+- calls the core with refined values
+- classifies external failures into typed errors
+- handles I/O, persistence, HTTP, queues, telemetry, time, randomness
+
+Entrypoint adapters should be thin protocol translation layers. They parse protocol-specific input, invoke shared modules, and render protocol-specific output. Do not duplicate business rules in controllers/resolvers/CLI handlers.
+
+Authorization belongs in shared application/domain policy, not duplicated in controllers. Entrypoints may authenticate and parse users/sessions/credentials, but shared modules should receive a domain-specific parsed authorization input such as `AdminUser`, `Session`, `Principal`, `DeployCredential`, or `CommandActor`.
+
+## Workflows, transactions, and idempotency
+
+Use ordinary function calls or database transactions for simple single-boundary operations.
+
+Use a saga/durable workflow when the process needs:
+
+- retries
+- compensation
+- idempotency
+- resumability
+- timers
+- human approval
+- cross-service coordination
+- multiple transaction boundaries
+
+Do not hold database transactions open across network calls or long-running operations.
+
+Any command, job, or workflow step that may be retried needs an explicit idempotency strategy:
+
+- idempotency key
+- natural unique constraint
+- deduplication record
+- state-machine transition guard
+- transactional outbox/inbox
+
+Retrying should not rely on “probably safe” side effects.
+
+## Testing
+
+Prefer confidence-oriented tests:
+
+1. e2e for critical user flows
+2. integration tests through real seams
+3. focused/property tests for pure domain modules
+4. unit tests when they test meaningful behavior, not implementation details
+
+Never use `vi.mock` or `jest.mock` for module mocking. Use real seams:
+
+- constructor-injected interfaces/classes
+- Effect services/layers
+- local database substitutes such as SQLite
+- in-memory adapters when behavior is simple
+- fake external adapters when needed
+
+Prefer tests that assert observable input/output behavior:
+
+- returned value/error
+- persisted state
+- emitted event/message
+- rendered response
+- sent email record in a fake/local adapter
+
+Avoid spy-driven tests like `expect(sendEmail).toHaveBeenCalledWith(...)` unless the interaction itself is the only observable behavior.
+
+For persistence behavior, prefer SQLite/local DB-backed tests over hand-rolled in-memory fakes when SQL/schema/transaction behavior matters.
+
+### Property tests and arbitraries
+
+Use `fast-check` where properties are clearer than examples, especially for:
+
+- parsers/smart constructors
+- branded/refined types
+- state machines
+- serialization roundtrips
+- normalization/idempotence
+- lawful combinators
+
+Use arbitraries for mock/test data generation. Prefer exporting arbitraries near the domain module they support:
+
+```txt
+src/billing/
+  invoice-number.ts
+  invoice-number.test.ts
+  invoice-number.arbitrary.ts
+```
+
+Tests should not bypass parsers, smart constructors, or invariants.
+
+## TypeScript style and safety
+
+Use strict TypeScript settings where practical:
+
+- `strict: true`
+- `noUncheckedIndexedAccess: true`
+- `exactOptionalPropertyTypes: true`
+- `noImplicitOverride: true`
+- `noFallthroughCasesInSwitch: true`
+
+Prefer immutable values:
+
+```ts
+type CreateUserInput = {
+  readonly email: EmailAddress;
+  readonly roles: ReadonlyArray<Role>;
+};
+```
+
+Mutation is acceptable inside localized imperative shell code, performance-sensitive internals, builders, or adapters when hidden behind a precise interface.
+
+### Casts, `any`, and non-null assertions
+
+Avoid:
+
+- `any`
+- non-null assertions (`!`)
+- casts with `as Type`
+
+`as const` is fine.
+
+Rare exceptions are allowed for highly generic helpers, branding internals, interop boundaries, or combinators where TypeScript cannot express the invariant.
+
+Any non-`as const` cast requires a Rust-like safety comment:
+
+```ts
+// SAFETY: TypeScript cannot express the brand. parseEmailAddress checked the normalized string before branding. Callers cannot construct EmailAddress except through this parser.
+return normalized as EmailAddress;
+```
+
+Rare `any` also requires a targeted oxlint ignore and justification:
+
+```ts
+// oxlint-disable-next-line no-explicit-any -- SAFETY: This helper preserves arbitrary function parameters; TypeScript cannot express this variadic constraint without any.
+type Fn = (...args: any[]) => unknown;
+```
+
+Do not use `!`. Branch, parse, or refine instead.
+
+## Imports, exports, and files
+
+Prefer direct imports from the file that owns the abstraction. Avoid barrel files / `index.ts` re-export layers by default.
+
+For domain modules, namespace imports often preserve the module shape:
+
+```ts
+import * as EmailAddress from "./email-address";
+
+EmailAddress.parse(input);
+```
+
+Use named imports for classes, prelude helpers, and focused shared helpers:
+
+```ts
+import { casesHandled } from "./prelude";
+import { PasswordReset } from "./password-reset";
+```
+
+Use `import type` / `export type` for type-only imports and exports.
+
+Export only what callers should use. Keep internal helpers unexported unless intentionally shared. Do not export internals just for tests.
+
+Avoid TypeScript `namespace` unless there is a compelling interop reason.
+
+Avoid vague files:
+
+```txt
+utils.ts
+helpers.ts
+common.ts
+misc.ts
+```
+
+Use precise names:
+
+```txt
+email-address.ts
+billing-period.ts
+string-case.ts
+array.ts
+prelude.ts
+```
+
+`prelude.ts` is allowed for tiny ubiquitous generic helpers/types such as:
+
+- `casesHandled`
+- `shouldNeverHappen`
+- `notYetImplemented`
+- `Redacted`
+- common `Result` helpers
+- broad type utilities
+
+Do not put domain/application policy in `prelude.ts`.
+
+No arbitrary file-size limits. Prefer cohesion and discoverability over small files for their own sake. Split when a file has multiple unrelated reasons to change or callers must understand unrelated concepts.
+
+## Comments and JSDoc
+
+Comments should explain invariants, trade-offs, non-obvious domain rules, and safety justifications. Avoid comments that narrate obvious code.
+
+Every exported function, class, method, constant, and usually exported type should have JSDoc.
+
+Use standard JSDoc syntax:
+
+```ts
+/**
+ * Parse an email address from untrusted input.
+ *
+ * @param input - The untrusted string to parse.
+ * @returns A parsed email address, or `InvalidEmailAddress` when the input is invalid.
+ */
+export function parse(input: string): Result<EmailAddress, InvalidEmailAddress>;
+```
+
+For generics:
+
+```ts
+/**
+ * Map the success value of a result.
+ *
+ * @template T - The original success type.
+ * @template U - The mapped success type.
+ * @template E - The error type.
+ * @param result - The result to map.
+ * @param fn - The function applied to the success value.
+ * @returns A result with the mapped success value, or the original error.
+ */
+export function map<T, U, E>(result: Result<T, E>, fn: (value: T) => U): Result<U, E>;
+```
+
+Use `@throws` only for unrecoverable defects, framework-required behavior, or temporary `notYetImplemented` paths. Do not document expected typed errors as throws.
+
+For complex exported object types, document fields when helpful:
+
+```ts
+/** Input required to create a user. */
+export type CreateUserInput = {
+  /** The actor creating the user. */
+  readonly actor: AdminUser;
+
+  /** The parsed email address for the new user. */
+  readonly email: EmailAddress;
+};
+```
+
+## Configuration and resources
+
+Parse environment/config at startup or the earliest boundary into typed config with branded/redacted values where appropriate.
+
+Do not read `process.env` throughout the app. Missing/invalid config is a startup failure with useful context.
+
+Avoid top-level side effects except in true entrypoint/bootstrap files. Modules should not start servers, open connections, read env, register handlers, or perform I/O at import time.
+
+Resource creation and cleanup should be explicit and owned by bootstrap/imperative shell code or Effect layers when using Effect.
+
+Avoid mutable singletons/global state. Constants and pure lookup tables are fine. If a singleton is required by a framework/runtime, isolate it at the boundary.
+
+Inject `Clock` / `Random` services into dependency-bearing modules. Pure domain functions may accept explicit `now` / random values.
+
+## Quick agent checklist
+
+Before coding:
+
+- Read existing conventions for errors, schemas, tests, adapters, telemetry, and module layout.
+- Look for existing domain modules/types before creating new ones.
+- Look for existing adapters/services before creating a new one.
+- Parse inputs at the edge and use domain types internally.
+- Avoid raw DTOs, raw IDs, nullable bags, and `Partial<T>` in core/application logic.
+- Prefer typed errors as values for new expected failures.
+- Preserve existing observability/error mechanics.
+- Test through public interfaces and real seams.
+- Use `fast-check` arbitraries for generated test data when practical.
+- Add JSDoc for exported symbols.
+- Add ADRs for meaningful new adapters/services created after an adapter reuse audit.
+
+## Handoff / continuation topics
+
+This draft intentionally stops before going deep on these areas. Cover them in a future grilling session:
+
+1. **Cloudflare development patterns**
+   - Durable Objects
+   - Durable Workflows
+   - Workers/Hono request boundaries
+   - D1/R2/KV/Queues patterns
+   - local testing strategy
+   - where Cloudflare-specific code should live relative to domain/application modules
+
+2. **Effect development patterns**
+   - services/tags/layers
+   - `Effect` error modeling
+   - `Schema.TaggedErrorClass`
+   - `Redacted.Redacted`
+   - resource management/scopes
+   - testing Effect services
+   - when and how project code should structure Effect modules
+
+3. **More concrete examples**
+   - bad/good parse-don't-validate examples
+   - custom error examples
+   - branded type examples
+   - service/application module examples
+   - adapter reuse audit examples
+   - testing examples with SQLite and `fast-check`
+
+4. **Tooling details**
+   - exact oxlint rules
+   - exact tsconfig baseline
+   - formatting/import rules
+   - test runner conventions
+   - JSDoc linting/enforcement


### PR DESCRIPTION
## What

Two documentation-only additions on one branch:

- **`docs/standards/typescript.md`** — embeds the external TypeScript Coding Standards from [@dmmulroy's gist](https://gist.github.com/dmmulroy/9c80f1f499b031aa0b6525b5d9ae25f0), reproduced faithfully with a source header (link + author + embed date 2026-06-19). Adopted external standard, not original work.
- **`docs/audits/typescript-standards-audit-2026-06-19.md`** — a rigorous, point-by-point audit of the repo's TypeScript against that standard.

No source code is changed; the audit recommends, a future PR acts.

## Scope of the TS audited

Browser-only surface: 12 client modules (`src/ludamus/client/src/*.ts`, ~1.6k lines), Vite config, and Playwright e2e tests. Type-checked by `tsc --noEmit`, formatted by Prettier; CI's `frontend-analysis` runs `fallow` non-blocking. **No oxlint/Biome/ESLint exists today.**

## Audit headlines

Result: ✅ 8 · ⚠️ 7 · ❌ 6 · — 8 (of 29 checks). Much of the standard targets server/domain TS that doesn't exist here (errors-as-values, branded types, adapters/DI, schemas) — hence many N/A.

**Strong:** deep modules (`modal.ts`), named-option params over boolean blindness, direct/no-barrel imports, precise file names, why-focused comments, real-seam e2e tests (no module mocks).

**Gaps (highest impact first):**
1. No linter + 4 missing strict tsconfig flags → nothing prevents new `!`/`any`/casts.
2. 8 non-null assertions + ~20 `as` casts with **no** SAFETY comments.
3. Pure helpers (`normalizeText`, `formatBytes`, `parsePreferredSlots`) untested — no unit/property tests, no `fast-check`.
4. Bare `throw new Error` instead of tagged errors; no JSDoc on exports.

Full evidence with `path:line` citations in the audit doc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JGAT6FAhSwE2zk5fbcaGUW)_