### PR TITLE
chore(hook): drop racy screenshot self-check

### DIFF
--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -28,25 +28,10 @@ mise trust
 mise install
 mise run bootstrap
 
-# Playwright (needed by the e2e suite) also backs `aubx agent-browser`
-# screenshots: agent-browser's own Chrome installer hits a network-blocked CDN.
-# Provision via the canonical task; agent-browser then finds the same Chromium
-# through $PLAYWRIGHT_BROWSERS_PATH, so e2e and screenshots share one browser.
+# Playwright backs the e2e suite and `aubx agent-browser` screenshots; both
+# share the Chromium it provisions.
 mise run install:playwright \
   || echo "WARN: Playwright install failed; agent-browser screenshots unavailable"
-
-# Self-check: surface screenshot-tooling readiness early rather than at capture
-# time (see issue #379). Probe with a real launch — the only signal that proves
-# agent-browser can actually find and start the browser, unlike a bare on-disk
-# binary check which can pass while discovery still fails (it false-reported OK
-# in PR #397 because install:playwright runs async and Chromium wasn't ready).
-if command -v aubx >/dev/null 2>&1 \
-  && aubx agent-browser open about:blank >/dev/null 2>&1; then
-  aubx agent-browser close --all >/dev/null 2>&1 || true
-  echo "OK: screenshots ready (aubx agent-browser launched Chromium)"
-else
-  echo "WARN: screenshot tooling not ready (agent-browser could not launch); see CLAUDE.md"
-fi
 
 if ! grep -q '^## Commits$' CLAUDE.local.md 2>/dev/null; then
   # Credit whoever is driving this session, not Claude/Anthropic. The trailer

--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -31,7 +31,7 @@ mise run bootstrap
 # Playwright backs the e2e suite and `aubx agent-browser` screenshots; both
 # share the Chromium it provisions.
 mise run install:playwright \
-  || echo "WARN: Playwright install failed; agent-browser screenshots unavailable"
+  || echo "WARN: Playwright install failed; e2e suite and agent-browser screenshots unavailable"
 
 if ! grep -q '^## Commits$' CLAUDE.local.md 2>/dev/null; then
   # Credit whoever is driving this session, not Claude/Anthropic. The trailer


### PR DESCRIPTION
## What this changes

Follow-up to #403. Removes the screenshot-readiness self-check from the
session-start hook and trims its comments.

## Why

Verified in a live remote session that `aubx agent-browser` resolves
Playwright's Chromium via `$PLAYWRIGHT_BROWSERS_PATH` on its own — cold, with
no filesystem shim:

- 3× cold `aubx agent-browser open about:blank` → all OK
- `mise run shots -- /` against a live server → valid 1280×577 PNG

The earlier "Chrome not found" failures were a **race**, not a discovery
regression: the first `aubx agent-browser` invocation lazily npm-installs
`agent-browser@0.28.0`, and browser resolution fails until that settles. Once
installed it works.

Because the self-check is a **single-shot** probe, it runs inside that install
window and prints a spurious `WARN` even though capture works seconds later — so
it misleads more than it helps. The `install:playwright` step keeps its own
WARN-on-failure, which is the signal that actually matters.

Net: −15 lines, `bash -n` clean.

## Notes

- Tooling-only change; no UI pages affected, so no screenshots.

🤖 Generated with [Claude Code](https://claude.com/claude-code)