### PR TITLE
perf(docker): cache frontend install in its own layer, via aube

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -9,6 +9,11 @@
 !scripts/**
 !src/
 !tasks.toml
+# aube workspace manifests + lockfile for reproducible frontend installs
+!package.json
+!aube-workspace.yaml
+!aube-lock.yaml
+!tests/e2e/package.json
 
 # But still ignore these even if they're in allowed directories
 **/__pycache__/

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -46,6 +46,16 @@ USER appuser
 # Install toolchain and Python dependencies (cached independently of src changes)
 RUN mise trust && mise install && mise run p install
 
+# Install frontend deps reproducibly from the aube workspace lockfile, scoped to
+# the client package. Copy only the manifests + lockfile first so a source-only
+# change reuses this cached node_modules layer. tests/e2e/package.json is needed
+# for the frozen-lockfile workspace integrity check even though --filter +
+# --no-optional keep its (Playwright) deps out of the image.
+COPY --chown=appuser:appuser aube-workspace.yaml aube-lock.yaml package.json ./
+COPY --chown=appuser:appuser tests/e2e/package.json ./tests/e2e/
+COPY --chown=appuser:appuser src/ludamus/client/package.json ./src/ludamus/client/
+RUN mise run frontend-deps
+
 # Copy application code
 COPY --chown=appuser:appuser src ./src
 
@@ -67,6 +77,16 @@ USER appuser
 
 # Install toolchain and production Python dependencies (cached independently of src changes)
 RUN mise trust && mise install && mise run p install --only main
+
+# Install frontend deps reproducibly from the aube workspace lockfile, scoped to
+# the client package. Copy only the manifests + lockfile first so a source-only
+# change reuses this cached node_modules layer. tests/e2e/package.json is needed
+# for the frozen-lockfile workspace integrity check even though --filter +
+# --no-optional keep its (Playwright) deps out of the image.
+COPY --chown=appuser:appuser aube-workspace.yaml aube-lock.yaml package.json ./
+COPY --chown=appuser:appuser tests/e2e/package.json ./tests/e2e/
+COPY --chown=appuser:appuser src/ludamus/client/package.json ./src/ludamus/client/
+RUN mise run frontend-deps
 
 # Copy application code
 COPY --chown=appuser:appuser src ./src

--- a/docker/mise.toml
+++ b/docker/mise.toml
@@ -6,6 +6,7 @@ jobs = 1
 python = "3.14"
 node = "v25.6.1"
 poetry = { version = "2.3.2", pyproject = "/app/pyproject.toml" }
+"github:endevco/aube" = "1.22.0"
 
 [env]
 # Mise creates and activates this virtualenv automatically
@@ -24,8 +25,11 @@ run = "django-admin"
 [tasks.start]
 run = "honcho start -e /dev/null -f Procfile.dev"
 
+[tasks.frontend-deps]
+run = "aube install --filter ./src/ludamus/client --frozen-lockfile --no-optional"
+
 [tasks.build-frontend]
-run = "cd src/ludamus/client && npm install && npm run build"
+run = "aubr -C src/ludamus/client build"
 
 [tasks.gunicorn]
 run = """


### PR DESCRIPTION
## Goal

Improve docker image build time (and therefore staging deploy time), following the timeout investigation in the staging-deploy-separation PR.

## Problem

The staging/production deploy builds the images **on the host, synchronously, over SSH**. In the Dockerfile, frontend deps were installed in the same step as the build, *after* `COPY src`:

```dockerfile
COPY --chown=appuser:appuser src ./src
RUN mise run build-frontend   # = cd src/ludamus/client && npm install && npm run build
```

Because the `COPY src` layer is invalidated by **any** source change, every deploy re-ran a full `npm install` even when no frontend dependency changed. Pure recurring cost on the slow, timed host build. It was also still using raw `npm` (with no lockfile), unlike the rest of the repo which uses **aube**.

## Change

Split the work so frontend deps are cached independently of source, and route it through aube:

- **`docker/mise.toml`**: add the `github:endevco/aube` tool (pinned to `1.22.0`, matching the file's pin-everything convention); split `build-frontend` into
  - `frontend-deps` → `aube install --filter ./src/ludamus/client --frozen-lockfile --no-optional`
  - `build-frontend` → `aubr -C src/ludamus/client build`
- **`docker/Dockerfile`** (dev + prod): copy the aube workspace manifests + lockfile and run `frontend-deps` **before** `COPY src`.
- **`.dockerignore`**: allow the workspace manifests + lockfile into the build context.

Frontend deps now reinstall only when a manifest/lockfile changes; source-only changes reuse the cached `node_modules` layer (excluded from `COPY src` by `.dockerignore`). Using the committed `aube-lock.yaml` with `--frozen-lockfile` also makes the install **reproducible** — the old `npm install` had no lockfile.

`--filter` + `--no-optional` keep `tests/e2e`'s Playwright deps out of the image; `tests/e2e/package.json` is copied only because the frozen-lockfile workspace integrity check requires every workspace member's manifest to be present.

## Validation

Ran the exact task commands against the real source tree in the session sandbox (no Docker daemon available, so the full image build itself wasn't run):

- `aube install --filter ./src/ludamus/client --frozen-lockfile --no-optional` → installs only client deps, no `playwright-core`. ✓
- `aubr -C src/ludamus/client build` → `vite build` ✓ (`✓ built in 389ms`).

⚠️ The Docker **image build is not exercised by CI** — it only runs during an actual deploy. Please label this PR `staging` to validate end-to-end before merging.

## Possible follow-ups (not in this PR)

- BuildKit cache mounts for the mise/poetry/pip + aube store, to speed even cold installs.
- Reconsider `--pull always` on the deploy command (re-validates base images every deploy) vs. the security benefit of always-fresh base images.

🤖 Generated with [Claude Code](https://claude.com/claude-code)