### PR TITLE
ci(deploy): raise SSH command_timeout to 13m

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -99,6 +99,9 @@ jobs:
           username: ${{ secrets.PRODUCTION_USER }}
           key: ${{ secrets.PRODUCTION_DEPLOY_KEY }}
           envs: GITHUB_COMMIT_SHA
+          # Default is 10m; a cold pull + rebuild of the images exceeds it and
+          # drone-ssh kills the command mid-build ("Run Command Timeout").
+          command_timeout: 13m
           script: |
             set -ex
             cd ludamus/

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -176,6 +176,9 @@ jobs:
           username: ${{ secrets.STAGING_USER }}
           key: ${{ secrets.STAGING_DEPLOY_KEY }}
           envs: GITHUB_COMMIT_SHA
+          # Default is 10m; a cold pull + rebuild of the images exceeds it and
+          # drone-ssh kills the command mid-build ("Run Command Timeout").
+          command_timeout: 13m
           script: |
             set -ex
             cd ludamus/


### PR DESCRIPTION
## Why

The deploy step runs `docker compose up --build --pull always` **synchronously over SSH** (`appleboy/ssh-action`). Its default `command_timeout` is **10m**, which a cold pull + rebuild can exceed — drone-ssh then kills the build mid-flight with `Run Command Timeout` (e.g. staging run [`27902604809`](https://github.com/zagrajmy/ludamus/actions/runs/27902604809)).

## Change

Set `command_timeout: 13m` on the `Deploy` step in both `deploy-staging.yml` and `deploy-production.yml`. 13m gives enough headroom for a cold build while still surfacing a genuinely stuck deploy reasonably quickly.

This is a safety margin. The bigger fix already landed in #414 (frontend deps now install via aube in a cached layer — the aube build deployed to staging in ~3.5 min), so cold builds should rarely approach even 10m now; this just prevents a worst-case cold build from being guillotined.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WMPdge7NExTGDuLfGXqx5H)_