### PR TITLE
refactor(docker): hoist shared toolchain + frontend install into base stage

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -35,26 +35,32 @@ RUN mkdir -p staticfiles media logs \
     && chown -R appuser:appuser /app \
     && chown -R appuser:appuser /mise
 
-# Development stage with dev dependencies
-FROM base AS dev
-
-COPY docker/Procfile.dev /app/
-
-# Switch to non-root user
+# Switch to non-root user for the remaining build steps
 USER appuser
 
-# Install toolchain and Python dependencies (cached independently of src changes)
-RUN mise trust && mise install && mise run p install
+# Install the toolchain (python/node/poetry/aube). Shared by dev and prod; the
+# Python *dependencies* are installed per-stage below because they differ
+# (dev installs all groups, prod only main).
+RUN mise trust && mise install
 
 # Install frontend deps reproducibly from the aube workspace lockfile, scoped to
 # the client package. Copy only the manifests + lockfile first so a source-only
 # change reuses this cached node_modules layer. tests/e2e/package.json is needed
 # for the frozen-lockfile workspace integrity check even though --filter +
-# --no-optional keep its (Playwright) deps out of the image.
+# --no-optional keep its (Playwright) deps out of the image. Independent of the
+# Python deps, so it lives in base and is built once for both stages.
 COPY --chown=appuser:appuser aube-workspace.yaml aube-lock.yaml package.json ./
 COPY --chown=appuser:appuser tests/e2e/package.json ./tests/e2e/
 COPY --chown=appuser:appuser src/ludamus/client/package.json ./src/ludamus/client/
 RUN mise run frontend-deps
+
+# Development stage with dev dependencies
+FROM base AS dev
+
+COPY docker/Procfile.dev /app/
+
+# Install Python dependencies (all groups)
+RUN mise run p install
 
 # Copy application code
 COPY --chown=appuser:appuser src ./src
@@ -72,21 +78,8 @@ CMD ["run", "start"]
 # Production stage without dev dependencies
 FROM base AS prod
 
-# Switch to non-root user
-USER appuser
-
-# Install toolchain and production Python dependencies (cached independently of src changes)
-RUN mise trust && mise install && mise run p install --only main
-
-# Install frontend deps reproducibly from the aube workspace lockfile, scoped to
-# the client package. Copy only the manifests + lockfile first so a source-only
-# change reuses this cached node_modules layer. tests/e2e/package.json is needed
-# for the frozen-lockfile workspace integrity check even though --filter +
-# --no-optional keep its (Playwright) deps out of the image.
-COPY --chown=appuser:appuser aube-workspace.yaml aube-lock.yaml package.json ./
-COPY --chown=appuser:appuser tests/e2e/package.json ./tests/e2e/
-COPY --chown=appuser:appuser src/ludamus/client/package.json ./src/ludamus/client/
-RUN mise run frontend-deps
+# Install production Python dependencies only
+RUN mise run p install --only main
 
 # Copy application code
 COPY --chown=appuser:appuser src ./src


### PR DESCRIPTION
## Why

Follow-up to #414 (flagged in its review): the `dev` and `prod` stages duplicated the toolchain install and the **entire** frontend-deps block (manifest COPYs + `mise run frontend-deps`). This hoists the identical parts into `base`.

## Change

Moved into `base` (built once, shared by both stages):
- `USER appuser` + `mise trust && mise install` (toolchain only — python/node/poetry/aube)
- the aube manifest COPYs + `mise run frontend-deps`

Each stage now carries only what genuinely differs:
- `RUN mise run p install` — dev: all groups; prod: `--only main`
- `CMD`

Net **−7 lines**, and the dev/prod stages go from ~12 near-identical lines each to 4.

## Behavior & caching preserved

- `mise install` is split from `mise run p install` (toolchain in base, Python deps per-stage). `mise trust` runs once in base; the trust record lives in `appuser`'s home and is inherited by both stages.
- `frontend-deps` stays its own layer keyed on the JS manifests — a **source-only** change still rebuilds just `build-frontend` + `compilemessages`, exactly as after #414.
- `frontend-deps` now runs *before* `p install`, which is fine — it only needs node/aube (from `mise install`), not the Python deps.

## Validation

⚠️ No Docker daemon in the session and **CI doesn't build the image** — this is a Dockerfile-structure change, so it needs a real build to confirm. Please add the `staging` label to run it through a staging deploy before merging (same as #414).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WMPdge7NExTGDuLfGXqx5H)_