### PR TITLE
fix(chronology): close TOCTOU in session soft-delete/restore with row locks

### DIFF
--- a/src/ludamus/links/db/django/repositories.py
+++ b/src/ludamus/links/db/django/repositories.py
@@ -357,8 +357,10 @@ class SessionRepository(SessionRepositoryProtocol):  # noqa: PLR0904
         # Scope + existence in one query: a soft-deleted session in this event.
         # (The alive-manager service check can't see deleted rows, so event
         # scoping lives here.) Missing / wrong-event / already-alive -> NotFound.
+        # `select_for_update` locks the row so concurrent restores serialize
+        # (caller runs inside a transaction); the second sees it already alive.
         try:
-            session = Session.all_objects.get(
+            session = Session.all_objects.select_for_update().get(
                 id=pk, category__event_id=event_pk, deleted_at__isnull=False
             )
         except Session.DoesNotExist as exception:

--- a/src/ludamus/mills/chronology.py
+++ b/src/ludamus/mills/chronology.py
@@ -492,8 +492,13 @@ class SessionDeletionService:
     def soft_delete(
         self, event_pk: int, session_pk: int, user_pk: int | None = None
     ) -> None:
-        require_session_in_event(self._sessions, session_pk, event_pk)
         with self._transaction.atomic():
+            # Lock the session row first, then re-check event membership while
+            # holding the lock: a concurrent request can no longer move the
+            # session to another event (or delete it) between the check and the
+            # mutation (TOCTOU). `lock` raises NotFound for missing/already-dead.
+            self._sessions.lock(session_pk)
+            require_session_in_event(self._sessions, session_pk, event_pk)
             # Free the timetable slot through the existing unschedule path:
             # drop the agenda item, return the session to PENDING, and record
             # the unassignment in the schedule activity log.

--- a/tests/integration/web/panel/test_proposal_delete_action.py
+++ b/tests/integration/web/panel/test_proposal_delete_action.py
@@ -1,9 +1,14 @@
 """Integration tests for /panel/event/<slug>/proposals/<proposal_id>/do/delete."""
 
+import threading
+from concurrent.futures import ThreadPoolExecutor
 from datetime import UTC, datetime, timedelta
 from http import HTTPStatus
 
+import pytest
 from django.contrib import messages
+from django.db import connection
+from django.test import Client
 from django.urls import reverse
 
 from ludamus.adapters.db.django.models import (
@@ -127,6 +132,49 @@ class TestProposalDeleteActionView:
         log = ScheduleChangeLog.objects.get(session_id=session.pk)
         assert log.action == ScheduleChangeAction.UNASSIGN
         assert log.user_id == active_user.pk
+
+    @pytest.mark.postgres
+    @pytest.mark.django_db(transaction=True)
+    def test_concurrent_delete_frees_slot_exactly_once(
+        self, active_user, sphere, event
+    ):
+        # Two managers delete the same scheduled session at once. The row lock
+        # serializes them: the slot is freed once, so exactly one UNASSIGN log is
+        # written. Without locking both requests would log the unassignment.
+        sphere.managers.add(active_user)
+        session = _make_session(event, sphere)
+        _schedule(session, event)
+        url = self.get_url(event, session.pk)
+
+        clients = []
+        for _ in range(2):
+            client = Client()
+            client.force_login(active_user)
+            clients.append(client)
+
+        barrier = threading.Barrier(len(clients))
+
+        def delete(client):
+            barrier.wait()
+            try:
+                return client.post(url)
+            finally:
+                connection.close()
+
+        with ThreadPoolExecutor(max_workers=len(clients)) as pool:
+            responses = [
+                future.result()
+                for future in [pool.submit(delete, client) for client in clients]
+            ]
+
+        assert all(r.status_code == HTTPStatus.FOUND for r in responses)
+        assert Session.all_objects.get(pk=session.pk).deleted_at is not None
+        assert (
+            ScheduleChangeLog.objects.filter(
+                session_id=session.pk, action=ScheduleChangeAction.UNASSIGN
+            ).count()
+            == 1
+        )
 
     def test_post_excludes_soft_deleted_from_listing(
         self, authenticated_client, active_user, sphere, event


### PR DESCRIPTION
soft_delete validated event membership outside the transaction and took no
lock, so a concurrent request could move the session to another event (or
delete it) between the check and the mutation. Lock the session row first
(self._sessions.lock) and re-check membership while holding the lock, inside
atomic(). restore now takes select_for_update on its scoped query so concurrent
restores serialize. Adds a Postgres concurrency test proving two racing deletes
free the slot exactly once (one UNASSIGN log).

Closes #419.

Co-authored-by: hasparus <hasparus@gmail.com>