### PR TITLE
Make navbar notification button a minimal icon button

### DIFF
--- a/src/ludamus/templates/components/notifications.html
+++ b/src/ludamus/templates/components/notifications.html
@@ -5,7 +5,7 @@
             data-menu-button
             aria-controls="navbar-notifications-panel"
             aria-expanded="false"
-            class="relative w-9 h-9 rounded-full bg-neutral-800 flex items-center justify-center cursor-pointer transition-all duration-150 ring-2 ring-transparent hover:ring-coral-500/30 focus:outline-none focus:ring-coral-500/50 text-foreground-secondary"
+            class="relative w-9 h-9 rounded-full flex items-center justify-center cursor-pointer transition-colors duration-150 hover:bg-bg-tertiary focus:outline-none focus-visible:bg-bg-tertiary text-foreground-secondary hover:text-foreground-primary"
             aria-label="{% translate "Notifications" %}{% if navbar_notifications.unread_count %} ({{ navbar_notifications.unread_count }} {% translate "unread" %}){% endif %}">
         {% icon "bell" class="w-5 h-5" %}
         {% if navbar_notifications.unread_count %}


### PR DESCRIPTION
## Summary

The notification bell button in the navbar was wrongly styled in light mode (it had a hardcoded dark `bg-neutral-800` background) and felt heavy. This makes it a minimal icon button:

- **No background, border, or ring by default** — just the icon.
- **On hover** — renders only a subtle background (`bg-bg-tertiary`), no border, and the icon color brightens to `text-foreground-primary`.
- Keeps keyboard accessibility via `focus-visible:bg-bg-tertiary`.

### Before / After (classes)

```diff
- relative w-9 h-9 rounded-full bg-neutral-800 ... ring-2 ring-transparent hover:ring-coral-500/30 focus:ring-coral-500/50 text-foreground-secondary
+ relative w-9 h-9 rounded-full ... hover:bg-bg-tertiary focus-visible:bg-bg-tertiary text-foreground-secondary hover:text-foreground-primary
```

The unread-count badge is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014sWzA1k2Hva5SVACPJ4mFG

---
_Generated by [Claude Code](https://claude.ai/code/session_014sWzA1k2Hva5SVACPJ4mFG)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Style
* Updated the visual styling of the notification menu button.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->