### PR TITLE
fix(deploy): harden frontend-deps install against registry stalls

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -14,6 +14,8 @@
 !aube-workspace.yaml
 !aube-lock.yaml
 !tests/e2e/package.json
+# npmrc carries fetch-retry settings that harden the frontend install
+!.npmrc
 
 # But still ignore these even if they're in allowed directories
 **/__pycache__/

--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,8 @@
 min-release-age=7
+
+# Survive flaky registry connections during installs. Prod deploy builds pull
+# packages over the host's network, which has stalled mid-stream ("error
+# decoding response body"); retry fetches with a generous per-request timeout.
+fetch-retries=5
+fetch-retry-maxtimeout=120000
+fetch-timeout=120000

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -52,7 +52,16 @@ RUN mise trust && mise install
 COPY --chown=appuser:appuser aube-workspace.yaml aube-lock.yaml package.json ./
 COPY --chown=appuser:appuser tests/e2e/package.json ./tests/e2e/
 COPY --chown=appuser:appuser src/ludamus/client/package.json ./src/ludamus/client/
-RUN mise run frontend-deps
+# Retry to ride out transient registry stream errors: this install pulls from
+# the npm registry over the host's network, which occasionally stalls mid-stream
+# ("error decoding response body") and fails the whole deploy. aube caches what
+# it already fetched, so each retry resumes near where the last attempt stopped.
+RUN n=1; until mise run frontend-deps; do \
+        if [ "$n" -ge 5 ]; then echo "frontend-deps failed after $n attempts" >&2; exit 1; fi; \
+        echo "frontend-deps attempt $n failed; retrying in $((n * 10))s" >&2; \
+        sleep "$((n * 10))"; \
+        n=$((n + 1)); \
+    done
 
 # Development stage with dev dependencies
 FROM base AS dev

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -49,7 +49,7 @@ RUN mise trust && mise install
 # for the frozen-lockfile workspace integrity check even though --filter +
 # --no-optional keep its (Playwright) deps out of the image. Independent of the
 # Python deps, so it lives in base and is built once for both stages.
-COPY --chown=appuser:appuser aube-workspace.yaml aube-lock.yaml package.json ./
+COPY --chown=appuser:appuser .npmrc aube-workspace.yaml aube-lock.yaml package.json ./
 COPY --chown=appuser:appuser tests/e2e/package.json ./tests/e2e/
 COPY --chown=appuser:appuser src/ludamus/client/package.json ./src/ludamus/client/
 # Retry to ride out transient registry stream errors: this install pulls from


### PR DESCRIPTION
## Why

The last two production deploys (runs **#23** and **#24**) both failed at the same Docker build step:

```
Dockerfile:55  >>> RUN mise run frontend-deps
× stream error for typescript@5.9.3: HTTP error: error decoding response body   (#23)
× stream error for prettier@3.8.1:   HTTP error: error decoding response body   (#24)
```

The deploy SSHes into the prod host and runs `docker compose up --build`. The frontend dependency install (`aube install`) pulls packages from the npm registry over the prod host's network, which stalled mid-download (throughput collapsed to ~20 kB/s) and then dropped the stream — taking the whole deploy down. This is a flaky-network failure, not a code regression, but it's now recurring on every deploy.

## What

Two layers of resilience around the `frontend-deps` install:

1. **`fetch-retries` via `.npmrc`** — `aube` honors pnpm-style config, so `fetch-retries=5` + generous `fetch-timeout`/`fetch-retry-maxtimeout` make it retry individual failed package fetches in-process. The root `.npmrc` was not previously in the build context, so this also required allowlisting it in `.dockerignore` and copying it into the image.
2. **Bounded retry loop** in the Dockerfile as a whole-install backstop (up to 5 attempts, 10s→40s backoff). `aube` caches already-fetched packages, so each retry resumes near where the previous attempt stalled (#23 reached 604/730, #24 reached 629/730).

## Files

- `.npmrc` — add `fetch-retries` / `fetch-timeout` / `fetch-retry-maxtimeout`
- `.dockerignore` — allowlist `.npmrc` so it reaches the build context
- `docker/Dockerfile` — copy `.npmrc` into the image; wrap `mise run frontend-deps` in a retry-with-backoff loop

## Follow-up

This makes the build *resilient* to transient stalls, but the more durable fix is to **build images in CI and have prod pull a prebuilt image** instead of building (and hitting the registry) live on the production host. Tracked as a separate workstream.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HgHmgqSBB6yo2tZtDRVoDZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01HgHmgqSBB6yo2tZtDRVoDZ)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced Docker build resilience with automatic retry logic for frontend dependency installation
  * Updated npm configuration with retry and timeout settings for package fetches
  * Modified Docker build setup to include npm configuration files in the build context

<!-- end of auto-generated comment: release notes by coderabbit.ai -->