### PR TITLE
ci: build prod image in CI and push to GHCR (step 1 of off-host builds)

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -1,0 +1,56 @@
+name: Build production image
+
+# First step of moving image builds off the production host: CI builds the
+# prod image and pushes it to GHCR. The deploy still builds on the host for
+# now; a follow-up switches prod.yaml/deploy to pull this prebuilt image.
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  build:
+    name: Build and push prod image to GHCR
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Image metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/${{ github.repository }}
+          # `sha-<full-sha>` is the deploy-addressable tag; `latest` tracks main.
+          tags: |
+            type=sha,format=long
+            type=raw,value=latest,enable={{is_default_branch}}
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: docker/Dockerfile
+          target: prod
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          # Build-only values; runtime config comes from .env.local on the host.
+          build-args: |
+            ENV=production
+            DJANGO_SETTINGS_MODULE=ludamus.edges.settings
+          cache-from: type=gha
+          cache-to: type=gha,mode=max


### PR DESCRIPTION
## Why

Production deploys build the Docker image **on the production host** (`docker compose up --build --pull always` over SSH). That on-host build is exactly what failed in deploys **#23** and **#24** — `aube install` stalled pulling packages over the prod host's flaky network and killed the deploy. PR #427 hardens that install, but the durable fix is to **stop building on prod**: build once in CI (on fast, reliable runners) and have prod pull a prebuilt image.

This is the **first, non-breaking step** in that direction.

## What

New workflow `.github/workflows/build-image.yml`:

- On push to `main` (and `workflow_dispatch`), builds the `prod` target of `docker/Dockerfile` and pushes it to **`ghcr.io/zagrajmy/ludamus`**.
- Tags: `sha-<full-commit>` (deploy-addressable) and `latest` (tracks main).
- Auths with the built-in `GITHUB_TOKEN` + `packages: write` — **no new secrets**.
- Uses GitHub Actions layer cache (`cache-from/to: gha`) to keep builds fast.

The live deploy is **unchanged** — prod still builds on the host for now — so this carries zero deploy risk while it proves out the build-and-publish half.

## Next steps (separate follow-up PR)

To flip prod over to pulling the prebuilt image:

1. **GHCR auth on the prod host** — either make the package public, or add a read-only pull token as a GitHub Environment secret and `docker login ghcr.io` in the deploy script. *(needs your call / a secret you create)*
2. **`docker/compose/prod.yaml`** — replace the `x-app-build` `build:` block with `image: ghcr.io/zagrajmy/ludamus:sha-${GIT_COMMIT_SHA_FULL}` for `web` / `migrations` / `collectstatic` (they share one image).
3. **`deploy-production.yml`** — drop `--build`, gate the deploy on this workflow having published the image for the target SHA, and `docker compose pull && up -d`.
4. Mirror the same for **staging** once prod is proven.

## Verification

CI build runs on this PR's push; I'll confirm the image publishes to GHCR. (The image won't be consumed by prod until the follow-up.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HgHmgqSBB6yo2tZtDRVoDZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01HgHmgqSBB6yo2tZtDRVoDZ)_