### PR TITLE
ci: pull prebuilt GHCR image on prod instead of building on host (step 2)

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -90,17 +90,31 @@ jobs:
           source: .env.local
           target: ludamus/
 
+      - name: Verify the prebuilt image exists in GHCR
+        # Fail fast (before touching prod) if the "Build production image"
+        # workflow hasn't published an image for this commit yet.
+        env:
+          GHCR_TOKEN: ${{ secrets.GHCR_TOKEN }}
+          GHCR_USER: ${{ vars.GHCR_USER }}
+        run: |
+          echo "$GHCR_TOKEN" | docker login ghcr.io -u "$GHCR_USER" --password-stdin
+          docker buildx imagetools inspect \
+            "ghcr.io/${{ github.repository }}:sha-${{ github.sha }}"
+
       - name: Deploy
         uses: appleboy/ssh-action@v1
         env:
           GITHUB_COMMIT_SHA: ${{ github.sha }}
+          APP_IMAGE: ghcr.io/${{ github.repository }}:sha-${{ github.sha }}
+          GHCR_USER: ${{ vars.GHCR_USER }}
+          GHCR_TOKEN: ${{ secrets.GHCR_TOKEN }}
         with:
           host: ${{ secrets.PRODUCTION_HOST }}
           username: ${{ secrets.PRODUCTION_USER }}
           key: ${{ secrets.PRODUCTION_DEPLOY_KEY }}
-          envs: GITHUB_COMMIT_SHA
-          # Default is 10m; a cold pull + rebuild of the images exceeds it and
-          # drone-ssh kills the command mid-build ("Run Command Timeout").
+          envs: GITHUB_COMMIT_SHA,APP_IMAGE,GHCR_USER,GHCR_TOKEN
+          # Default is 10m; a cold pull of the prebuilt images can exceed it and
+          # drone-ssh kills the command mid-pull ("Run Command Timeout").
           command_timeout: 13m
           script: |
             set -ex
@@ -109,8 +123,14 @@ jobs:
             git fetch
             git checkout $GITHUB_COMMIT_SHA
             export GIT_COMMIT_SHA=$(git rev-parse --short HEAD)
+            # Authenticate to GHCR to pull the private prebuilt image, then drop
+            # the credentials again once the images are local.
+            echo "$GHCR_TOKEN" | docker login ghcr.io -u "$GHCR_USER" --password-stdin
             # .env.local was validated by varlock on the CI runner. Here the
             # compose CLI reads it: --env-file feeds ${VAR} interpolation,
             # and prod.yaml's `env_file:` injects it into the containers.
-            docker compose --env-file .env.local -p ludamus -f docker/compose/prod.yaml up --build --pull always -d
+            # APP_IMAGE pins the exact image built for this revision.
+            docker compose --env-file .env.local -p ludamus -f docker/compose/prod.yaml pull
+            docker compose --env-file .env.local -p ludamus -f docker/compose/prod.yaml up -d
+            docker logout ghcr.io
             docker image prune -f

--- a/docker/compose/prod.yaml
+++ b/docker/compose/prod.yaml
@@ -1,15 +1,12 @@
 ---
-x-app-build: &app-build
-  build:
-    context: ../../
-    dockerfile: docker/Dockerfile
-    target: prod
-    args:
-      DJANGO_SETTINGS_MODULE: ${DJANGO_SETTINGS_MODULE}
-      ENV: ${ENV}
+x-app-image: &app-image
+  # Prebuilt by the "Build production image" workflow and pulled from GHCR
+  # instead of built on the host. The deploy exports APP_IMAGE to the exact
+  # ghcr.io/<repo>:sha-<commit> tag it published for this revision.
+  image: ${APP_IMAGE:?APP_IMAGE must point at the prebuilt GHCR image}
 
 x-app-defaults: &app-defaults
-  <<: *app-build
+  <<: *app-image
   # Container env comes from .env.local, materialized on the CI runner from
   # GitHub Environment vars/secrets and scp'd to the host. The deploy
   # validates it with varlock against .env.schema before upload, so the


### PR DESCRIPTION
## Why

Completes the move off on-host builds started in #428. The production deploy currently builds the Docker image **on the prod host** (`docker compose up --build`) — the exact step that failed in deploys #23/#24 when the host's network stalled. This switches prod to **pull** the image CI already publishes to GHCR.

> **Stacked on #428.** Base is `claude/ci-build-images`; this diff shows only the consumer change. Once #428 merges to `main`, I'll retarget this to `main`.

## What

- **`docker/compose/prod.yaml`** — replace the shared `build:` block with `image: ${APP_IMAGE}` for `web` / `migrations` / `collectstatic` (one shared image). `APP_IMAGE` is required (`:?`), so a misconfigured deploy fails loudly instead of silently building.
- **`.github/workflows/deploy-production.yml`**:
  - New **"Verify the prebuilt image exists in GHCR"** step — fails fast *before* touching prod if CI hasn't published `sha-<commit>` yet.
  - **Deploy** step now logs in to the private GHCR package, `docker compose pull`s, and `up -d` **without `--build`**, then `docker logout`. `APP_IMAGE` pins the exact image built for the deployed revision.

## Required setup (private package → prod needs credentials)

Add these to the **`production`** GitHub Environment before the first pull-based deploy:

| Kind | Name | Value |
|------|------|-------|
| Secret | `GHCR_TOKEN` | a token with **`read:packages`** for the private package |
| Variable | `GHCR_USER` | the GitHub account that owns the token |

A fine-grained PAT (read-only, packages) or a classic PAT with `read:packages` both work. Keep the GHCR package **private**.

## Rollout order

1. Merge #428 → `main` so the image-build workflow runs and publishes `sha-<commit>`.
2. Add `GHCR_TOKEN` / `GHCR_USER` to the `production` Environment.
3. Retarget + merge this PR.
4. Dispatch a production deploy — the verify step confirms the image, prod pulls it, no on-host build.

## Follow-up

Mirror the same pull-based flow for **staging** once prod is proven.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HgHmgqSBB6yo2tZtDRVoDZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01HgHmgqSBB6yo2tZtDRVoDZ)_