### PR TITLE
fix(propose): correct "A 👁" to "An 👁" in personal details hint

### DIFF
--- a/src/ludamus/locale/pl/LC_MESSAGES/django.po
+++ b/src/ludamus/locale/pl/LC_MESSAGES/django.po
@@ -3428,7 +3428,7 @@ msgid "Your Information"
 msgstr "Twoje dane"
 
 #: src/ludamus/templates/chronology/propose/parts/personal.html
-msgid "Your details — private by default. A 👁 marks what attendees will see."
+msgid "Your details — private by default. An 👁 marks what attendees will see."
 msgstr ""
 "Twoje dane — domyślnie prywatne. 👁 oznacza pola widoczne dla uczestników."
 

--- a/src/ludamus/templates/chronology/propose/parts/personal.html
+++ b/src/ludamus/templates/chronology/propose/parts/personal.html
@@ -6,7 +6,7 @@
     {% include "chronology/propose/parts/_login_nudge.html" %}
     <h2 class="text-lg font-semibold mb-1">{% translate "Your Information" %}</h2>
     <p class="text-sm text-foreground-muted mb-5">
-        {% blocktranslate %}Your details — private by default. A 👁 marks what attendees will see.{% endblocktranslate %}
+        {% blocktranslate %}Your details — private by default. An 👁 marks what attendees will see.{% endblocktranslate %}
     </p>
     <form method="post"
           hx-post="{% url 'web:chronology:session-propose-personal' event_slug=event.slug %}"


### PR DESCRIPTION
## What

Grammar fix in the personal-details step of the session-propose wizard: "A 👁 marks what attendees will see." → "An 👁 marks what attendees will see."

Updated both the template and the matching `msgid` in the Polish `.po` catalog so the translation entry stays linked (the Polish `msgstr` is unaffected — it doesn't carry the article).

## Files

- `src/ludamus/templates/chronology/propose/parts/personal.html`
- `src/ludamus/locale/pl/LC_MESSAGES/django.po`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01KnFk93abhkHCvxwgn9MkyS)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved grammatical accuracy in the "Your Information" step description for better clarity when describing privacy settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->