### PR TITLE
fix(modal): stop window scroll jumping to the top on close (Mobile Safari)

### DIFF
--- a/scripts/reproduce-ios-modal-bugs.ts
+++ b/scripts/reproduce-ios-modal-bugs.ts
@@ -340,12 +340,19 @@ await openUrl(initialUrl.toString(), udid);
 
 await client.command.wait({ ...deviceOptions, durationMs: 3000 });
 
+// Captured just before opening so the close path can assert the page returned
+// to the same scroll position (see the scroll-preservation check after close).
+let preOpenTriggerLabel: string | null = null;
+let preOpenTriggerY: number | null = null;
+
 if (openViaScrolledPage) {
   console.log(`Opening ${targetTitle} from a scrolled page...`);
   console.log(`Pre-scrolling the page (${preOpenScrollSteps} steps) before opening...`);
   await forcePreOpenScroll();
   const trigger = await scrollUntilTriggerInViewport();
   console.log(`Activating modal trigger: ${describeNode(trigger)}`);
+  preOpenTriggerLabel = trigger.label ?? null;
+  preOpenTriggerY = trigger.rect?.y ?? null;
   await clickNodeReference(trigger);
   if (!(await waitForLabel("Close", 5000))) {
     console.warn("The trigger reference did not open the modal; tapping its center.");
@@ -383,6 +390,34 @@ await client.command.wait({ ...deviceOptions, durationMs: 1000 });
 
 if (await hasVisibleText("Close")) {
   failures.push("The modal X / Close button did not close the modal.");
+}
+
+// Scroll-preservation guard. While the modal is open the page is scroll-locked
+// by pinning <body> with `position: fixed; top: -scrollY` (needed so the iOS
+// top-layer Close button stays tappable over a scrolled page). The close must
+// hand the document back to that same offset; if it restores late or to the
+// wrong place, the page jumps — most visibly to the top and back on Mobile
+// Safari. Re-find the trigger we opened from and assert it settled back to the
+// viewport position it held before opening.
+if (openViaScrolledPage && preOpenTriggerLabel && preOpenTriggerY !== null) {
+  await client.command.wait({ ...deviceOptions, durationMs: 600 });
+  const settledSnapshot = await takeSnapshot();
+  const settledTrigger = settledSnapshot.nodes.find(
+    (node) => node.label === preOpenTriggerLabel && !isHiddenDialogLabel(node),
+  );
+  const settledY = settledTrigger?.rect?.y ?? null;
+  if (settledY === null) {
+    failures.push(
+      `After closing, "${preOpenTriggerLabel}" was no longer in the viewport, ` +
+        "so the page did not return to its pre-open scroll position.",
+    );
+  } else if (Math.abs(settledY - preOpenTriggerY) > 200) {
+    failures.push(
+      `The page scroll jumped on close: "${preOpenTriggerLabel}" moved from ` +
+        `y=${Math.round(preOpenTriggerY)} to y=${Math.round(settledY)} ` +
+        "(>200px), so the scroll position was not preserved.",
+    );
+  }
 }
 
 if (failures.length > 0) {

--- a/src/ludamus/client/src/modal.ts
+++ b/src/ludamus/client/src/modal.ts
@@ -88,9 +88,12 @@ const unlockPage = (): void => {
   style.right = "";
   style.width = "";
   bodyPinned = false;
-  // Restore styles first, then scroll on the next frame (Vaul pattern) so the
-  // un-pin doesn't flash.
-  requestAnimationFrame(() => window.scrollTo(0, pinnedScrollY));
+  // Removing the fixed pin drops the document back to scroll offset 0; restore
+  // the prior offset synchronously, in the same task, so the page paints once at
+  // the right place. Deferring this to rAF lets Safari paint a frame (or several,
+  // when the unlock trails a closing View Transition) at the top first — the
+  // visible "jump to the top and back" on modal close.
+  window.scrollTo(0, pinnedScrollY);
 };
 
 const getScrollableElements = (dialog: HTMLDialogElement): HTMLElement[] => {


### PR DESCRIPTION
## The bug

On Mobile Safari, closing a modal makes the page **jump to the very top and then snap back down** to where you were. It's the thing in the screen recording that "looks terrible." It lives in the same body-pin machinery that was originally added because **the modal couldn't be closed at all on Mobile Safari** (the Close button was dead over a scrolled page).

![Mobile Safari: scroll jumps to the top on modal close, then snaps back](https://github.com/zagrajmy/ludamus/blob/assets/modal-scroll-close-evidence/evidence/before-scroll-jump-mobile-safari.png?raw=true)

*Real-device frames, one modal close, left→right: (1) modal open while the list is scrolled, (2) closing → background jumps to the top, (3) still at the top for ~200 ms, (4) snaps back down.*

### Why it happens

iOS Safari ignores `overflow: hidden` on a scrolled `<body>`, so we lock the page by pinning the body with `position: fixed; top: -scrollY` (`needsBodyPin()` in `modal.ts`). That pin is what keeps the top-layer Close button tappable — **this PR does not touch it**. The problem was the **unlock**:

```ts
// before
style.position = ""; style.top = ""; /* … */
requestAnimationFrame(() => window.scrollTo(0, pinnedScrollY));
```

Removing the fixed pin drops the document back to scroll offset `0`. The prior offset was then restored a frame later inside `requestAnimationFrame`. That extra frame is the bug:

- Safari paints the page **at the top** before the rAF callback runs.
- In the session-card morph path, `unlockPage()` runs only *after* the ~300 ms closing View Transition `finished` — so the page sits unpinned at the top for several frames before the rAF restore snaps it back down.

The comment credited this rAF to "the Vaul pattern", but Vaul actually restores the scroll **synchronously** — so the rAF was both a misattribution and the cause.

### The fix

Restore the scroll offset synchronously, in the same task that removes the pin, so the page paints once at the correct position and never flashes the top:

```ts
// after
style.position = ""; style.top = ""; /* … */
window.scrollTo(0, pinnedScrollY);
```

One line changes behaviour; the rest is the corrected comment. The pin (and therefore the original Mobile-Safari "can't close the modal" fix) is untouched.

## Regression coverage

The `ios-regressions` job (`agent-device` driving a real iOS Simulator, `mobile.yml`) already opens a session modal from a scrolled page and asserts the Close button works. This PR extends `scripts/reproduce-ios-modal-bugs.ts` to also assert **scroll preservation**: it records the trigger's viewport offset before opening and, after closing, asserts it settled back within 200 px. A close that leaves the document at the top now fails the regression instead of only showing up in a screen recording.

## Why no Chromium before/after

This is an iOS/Safari-only paint-timing quirk — the body-pin path is UA-gated to real iOS/Safari (`needsBodyPin()`), and **Chromium does not reproduce the flash even with the old rAF code** (verified with a deterministic harness: the first painted frame reads `scrollY = 1800` in both the rAF and sync variants). So a headless Chromium screenshot can't show it; the real-device recording above is the authoritative evidence, and the iOS Simulator regression is the automated guard.

## Testing

- `npm run typecheck` ✅
- `npm run lint` (eslint, `--max-warnings 0`) ✅
- `bun build scripts/reproduce-ios-modal-bugs.ts` transpiles clean ✅
- `ios-regressions` (`mobile.yml`) exercises the scrolled-open → close → scroll-preserved path on a real iOS Simulator.

## Follow-up

This removes the symptom with a minimal change. The thread also asked *why a modal on a scrollable page has cost this many hours* — the body-pin + noscroll + View-Transition-suspend machinery in `modal.ts` exists almost entirely to serve this one iOS quirk. Happy to write up the "stop locking the page at all" / "pure-CSS `overflow:hidden` lock" / "app-shell scroll container" alternatives if we want to retire the machinery rather than keep patching it.

> Note: evidence images live on the throwaway `assets/modal-scroll-close-evidence` branch (kept off this PR's diff); delete it after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)