### PR TITLE
style(button): drop grey ring, unify danger/secondary, fix :active jitter

### DIFF
--- a/src/ludamus/client/src/index.css
+++ b/src/ludamus/client/src/index.css
@@ -378,10 +378,9 @@ button:active {
   .btn {
     --bg: var(--color-primary);
     --y: 2px;
-    /* derived from --color-border, but we're supporting legacy browsers so no color-mix */
+    /* translucent shade derived from --color-border */
     --shade: hsla(30deg, 20.6%, 23%, 0.25);
-    /* top highlight ("scrim") + soft gloss falloff; variants tune these — the
-       filled buttons get a bright highlight, the tonal secondary none */
+    /* top highlight + gloss; variants tune these */
     --hl1: rgba(255, 255, 255, 0.085);
     --hl2: transparent;
 
@@ -395,8 +394,7 @@ button:active {
     font-weight: 500;
     transition: all 0.2s;
     background-color: var(--bg);
-    /* optical vertical centering — trims Outfit's half-leading. Progressive
-       enhancement; older engines ignore it. */
+    /* optical vertical centering (trims Outfit's half-leading) */
     text-box: trim-both cap alphabetic;
     box-shadow:
       inset 0 1px 0 0 var(--hl1),
@@ -411,12 +409,9 @@ button:active {
 
     &:active {
       @apply translate-y-0.5 scale-[99.4%];
-      /* Collapse the 3D lip by driving --y to 0 rather than replacing the whole
-         box-shadow. A box-shadow can only transition smoothly when both states
-         have the same number of layers; swapping a 4-layer resting shadow for a
-         shorter pressed one made the lip snap out of sync with the transform
-         (the "jitter" / vanishing bottom border). Keeping the same layers and
-         only animating the offset lets the lip retract in lockstep. */
+      /* Collapse the lip via --y, not a box-shadow swap: equal layer counts
+         keep box-shadow from snapping a layer in/out, so it stays in sync with
+         the transform (the swap jittered). */
       --y: 0;
     }
 
@@ -452,12 +447,9 @@ button:active {
     cursor: not-allowed;
   }
 
-  /* Filled brand buttons share one recipe: a subtle vertical gradient face
-     (lighter top, deeper bottom; the stops are the brand colour nudged in
-     lightness — no color-mix, legacy support), a white label, the shared 3D lip
-     from .btn, a bright top highlight (the salmon/pink scrim line) and a faint
-     text-shadow. --bg is the gradient's bottom stop so the lip matches. There
-     is no surrounding ring — that read as a grey line on light backgrounds. */
+  /* Filled buttons: vertical gradient face (brand colour, lighter top → deeper
+     bottom), white label, top highlight, text-shadow. --bg is the bottom stop
+     so the shared lip matches. No ring — it read as a grey line on light bg. */
   .btn-primary {
     --bg: #ef4f2d;
     --hl1: rgba(255, 255, 255, 0.3);
@@ -478,10 +470,7 @@ button:active {
     text-shadow: 0 1px 1px rgba(0, 0, 0, 0.16);
   }
 
-  /* Dark mode: a heavier label survives halation (white on a saturated fill
-     against the near-black surround), the text-shadow deepens and the top
-     highlight eases off. The pressed-state flatten lives on the base
-     .btn:active, so the variants need no box-shadow override. */
+  /* Dark: heavier label + deeper text-shadow survive halation; highlight eases off. */
   .dark .btn-primary,
   .dark .btn-danger {
     --hl1: rgba(255, 255, 255, 0.22);
@@ -491,12 +480,8 @@ button:active {
     text-shadow: 0 1px 1px rgba(0, 0, 0, 0.22);
   }
 
-  /* Secondary: a restrained tonal match. Keeps the light fill, dark text and
-     border, but adopts the shared lip, text-box trim and a subtle dimensional
-     gradient — a translucent overlay that lifts the top and darkens the bottom
-     slightly in both themes without re-specifying the token colour. Its own
-     border defines the edge and the dark text needs no top highlight, so the
-     scrim is switched off. */
+  /* Secondary: tonal match — light fill, dark text, border. Subtle translucent
+     gradient (token-linked), no top highlight; its border does the edge. */
   .btn-secondary {
     --bg: var(--color-bg-secondary);
     --shade: hsla(30deg, 20.6%, 35%, 0.25);

--- a/src/ludamus/client/src/index.css
+++ b/src/ludamus/client/src/index.css
@@ -411,10 +411,13 @@ button:active {
 
     &:active {
       @apply translate-y-0.5 scale-[99.4%];
-      box-shadow:
-        inset 0 0 1px 0 rgba(0, 0, 0, 0.1),
-        0 0px 0 0 rgba(0, 0, 0, 0.25),
-        0 0px 0 0 var(--bg);
+      /* Collapse the 3D lip by driving --y to 0 rather than replacing the whole
+         box-shadow. A box-shadow can only transition smoothly when both states
+         have the same number of layers; swapping a 4-layer resting shadow for a
+         shorter pressed one made the lip snap out of sync with the transform
+         (the "jitter" / vanishing bottom border). Keeping the same layers and
+         only animating the offset lets the lip retract in lockstep. */
+      --y: 0;
     }
 
     &:focus {

--- a/src/ludamus/client/src/index.css
+++ b/src/ludamus/client/src/index.css
@@ -380,6 +380,10 @@ button:active {
     --y: 2px;
     /* derived from --color-border, but we're supporting legacy browsers so no color-mix */
     --shade: hsla(30deg, 20.6%, 23%, 0.25);
+    /* top highlight ("scrim") + soft gloss falloff; variants tune these — the
+       filled buttons get a bright highlight, the tonal secondary none */
+    --hl1: rgba(255, 255, 255, 0.085);
+    --hl2: transparent;
 
     position: relative;
     display: inline-flex;
@@ -391,8 +395,12 @@ button:active {
     font-weight: 500;
     transition: all 0.2s;
     background-color: var(--bg);
+    /* optical vertical centering — trims Outfit's half-leading. Progressive
+       enhancement; older engines ignore it. */
+    text-box: trim-both cap alphabetic;
     box-shadow:
-      inset 0 1px 0 0 rgba(255, 255, 255, 0.085),
+      inset 0 1px 0 0 var(--hl1),
+      inset 0 3px 5px -3px var(--hl2),
       0 var(--y) 0 0 var(--shade),
       0 var(--y) 0 0 var(--bg);
 
@@ -441,65 +449,68 @@ button:active {
     cursor: not-allowed;
   }
 
+  /* Filled brand buttons share one recipe: a subtle vertical gradient face
+     (lighter top, deeper bottom; the stops are the brand colour nudged in
+     lightness — no color-mix, legacy support), a white label, the shared 3D lip
+     from .btn, a bright top highlight (the salmon/pink scrim line) and a faint
+     text-shadow. --bg is the gradient's bottom stop so the lip matches. There
+     is no surrounding ring — that read as a grey line on light backgrounds. */
   .btn-primary {
-    /* Bright coral face via a subtle vertical gradient — lighter top, deeper
-       bottom — both stops are --color-primary (#f85a3c) nudged in lightness
-       (no color-mix: legacy support). --bg is the bottom stop so the 3D lip
-       matches the gradient base. The white label keeps the brand's bright coral
-       in both themes; the touches below fix dark-mode halation perceptually
-       rather than by recolouring. */
     --bg: #ef4f2d;
+    --hl1: rgba(255, 255, 255, 0.3);
+    --hl2: rgba(255, 255, 255, 0.22);
     color: white;
     background-image: linear-gradient(180deg, #fb6953, #ef4f2d);
     text-shadow: 0 1px 1px rgba(0, 0, 0, 0.16);
-    /* optical vertical centering — trims Outfit's half-leading. Progressive
-       enhancement; older engines ignore it. */
-    text-box: trim-both cap alphabetic;
-    box-shadow:
-      /* more pronounced top scrim + soft gloss falloff */
-      inset 0 1px 0 0 rgba(255, 255, 255, 0.3),
-      inset 0 3px 5px -3px rgba(255, 255, 255, 0.22),
-      /* hairline definition ring */ 0 0 0 0.5px rgba(61, 55, 50, 0.16),
-      0 var(--y) 0 0 var(--shade),
-      0 var(--y) 0 0 var(--bg);
   }
 
-  .dark .btn-primary {
-    /* heavier label survives the halation; stronger ring separates the button
-       from the near-black surround so the white edges stop blooming. */
+  .btn-danger {
+    --bg: #e23636;
+    --hl1: rgba(255, 255, 255, 0.3);
+    --hl2: rgba(255, 255, 255, 0.22);
+    color: white;
+    background-image: linear-gradient(180deg, #f56363, #e23636);
+    text-shadow: 0 1px 1px rgba(0, 0, 0, 0.16);
+  }
+
+  /* Dark mode: a heavier label survives halation (white on a saturated fill
+     against the near-black surround), the text-shadow deepens and the top
+     highlight eases off. The pressed-state flatten lives on the base
+     .btn:active, so the variants need no box-shadow override. */
+  .dark .btn-primary,
+  .dark .btn-danger {
+    --hl1: rgba(255, 255, 255, 0.22);
+    --hl2: rgba(255, 255, 255, 0.18);
     font-weight: 600;
     text-shadow: 0 1px 1px rgba(0, 0, 0, 0.22);
-    box-shadow:
-      inset 0 1px 0 0 rgba(255, 255, 255, 0.22),
-      inset 0 3px 5px -3px rgba(255, 255, 255, 0.18),
-      0 0 0 0.5px rgba(0, 0, 0, 0.5),
-      0 var(--y) 0 0 var(--shade),
-      0 var(--y) 0 0 var(--bg);
-
-    /* .dark .btn-primary and .btn:active share specificity, so re-assert the
-       pressed-state flatten here or the resting shadow would win on press. */
-    &:active {
-      box-shadow:
-        inset 0 0 1px 0 rgba(0, 0, 0, 0.1),
-        0 0 0 0 rgba(0, 0, 0, 0.25),
-        0 0 0 0 var(--bg);
-    }
   }
 
+  /* Secondary: a restrained tonal match. Keeps the light fill, dark text and
+     border, but adopts the shared lip, text-box trim and a subtle dimensional
+     gradient — a translucent overlay that lifts the top and darkens the bottom
+     slightly in both themes without re-specifying the token colour. Its own
+     border defines the edge and the dark text needs no top highlight, so the
+     scrim is switched off. */
   .btn-secondary {
     --bg: var(--color-bg-secondary);
+    --shade: hsla(30deg, 20.6%, 35%, 0.25);
+    --hl1: transparent;
     border: 1px solid var(--color-border);
     color: var(--color-foreground);
-    --shade: hsla(30deg, 20.6%, 35%, 0.25);
+    background-image: linear-gradient(
+      180deg,
+      rgba(255, 255, 255, 0.5),
+      rgba(0, 0, 0, 0.02)
+    );
   }
 
   .dark .btn-secondary {
     --shade: hsla(30deg, 0%, 28%, 0.35);
-  }
-
-  .btn-danger {
-    --bg: var(--color-danger);
-    color: white;
+    background-image: linear-gradient(
+      180deg,
+      rgba(255, 255, 255, 0.04),
+      rgba(0, 0, 0, 0.06)
+    );
   }
 
   .icon-btn {

--- a/src/ludamus/client/src/index.css
+++ b/src/ludamus/client/src/index.css
@@ -462,6 +462,7 @@ button:active {
     --bg: #ef4f2d;
     --hl1: rgba(255, 255, 255, 0.3);
     --hl2: rgba(255, 255, 255, 0.22);
+
     color: white;
     background-image: linear-gradient(180deg, #fb6953, #ef4f2d);
     text-shadow: 0 1px 1px rgba(0, 0, 0, 0.16);
@@ -471,6 +472,7 @@ button:active {
     --bg: #e23636;
     --hl1: rgba(255, 255, 255, 0.3);
     --hl2: rgba(255, 255, 255, 0.22);
+
     color: white;
     background-image: linear-gradient(180deg, #f56363, #e23636);
     text-shadow: 0 1px 1px rgba(0, 0, 0, 0.16);
@@ -484,6 +486,7 @@ button:active {
   .dark .btn-danger {
     --hl1: rgba(255, 255, 255, 0.22);
     --hl2: rgba(255, 255, 255, 0.18);
+
     font-weight: 600;
     text-shadow: 0 1px 1px rgba(0, 0, 0, 0.22);
   }
@@ -498,6 +501,7 @@ button:active {
     --bg: var(--color-bg-secondary);
     --shade: hsla(30deg, 20.6%, 35%, 0.25);
     --hl1: transparent;
+
     border: 1px solid var(--color-border);
     color: var(--color-foreground);
     background-image: linear-gradient(
@@ -509,6 +513,7 @@ button:active {
 
   .dark .btn-secondary {
     --shade: hsla(30deg, 0%, 28%, 0.35);
+
     background-image: linear-gradient(
       180deg,
       rgba(255, 255, 255, 0.04),


### PR DESCRIPTION
Follow-up to #435.

## What changed

- **Primary:** removed the surrounding hairline ring — `rgba(61,55,50,.16)`, which renders as a grey `#D3D3D4` line on the light page background. **Kept** the bright top highlight (the salmon `#FE9F92` line).
- **Danger:** was a flat solid red. Now the same recipe as Primary in the danger red: vertical gradient, top highlight, faint text-shadow, `text-box` trim, heavier label in dark mode.
- **Secondary:** restrained tonal match — keeps the light fill, dark text and border, gains a subtle dimensional gradient, the lip and `text-box` trim. No top highlight (dark text), no ring (its border does the edge).
- **`:active` jitter fix** *(also fixes current Primary on `main`)* — see below.

## The `:active` jitter

`box-shadow` only interpolates smoothly when both states have the **same number of layers**. The resting shadow had grown to 4 layers (top highlight + gloss + the two 3D-lip layers), while `.btn:active` swapped to a 3-layer shadow. The mismatch made the lip **snap** instead of animating, falling out of sync with the `transform` — so the bottom border appeared to vanish and jitter. The current Primary on `main` is worse, at 5 resting layers.

Fix: collapse the lip by driving `--y` to `0` on `:active` instead of replacing the whole `box-shadow`. The shadow keeps its 4 layers and only the offset animates, so the lip retracts in lockstep with the press — matching how the old flat Danger button (3 layers throughout) felt.

## How

The shared bits (3D lip, the top-highlight as base vars `--hl1`/`--hl2`, and `text-box` trim) live on the base `.btn`, so each variant only sets its colour. No variant overrides the resting box-shadow, so the press fix in `.btn:active` applies uniformly and the dark-mode `:active` specificity hack from #435 is gone.

## Before / after report

https://zen-temple-4vpw.here.now/ — all three variants, before vs after, in dark and light, **plus a forced Default/Hover/Pressed grid** and live hover/`:active` reproducing the real recipe (including the fixed press).

## Notes / QA

- Danger and Secondary gradient stops are hardcoded (no `color-mix`, per the legacy-support constraint), same as Primary in #435.
- `text-box` now applies to every `.btn`; progressive enhancement.
- Verified with `mise run build-frontend` (compiles clean) and `mise run djlint-format` (no changes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N4zhJurWJEb6m9b6mbefkN

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated button visuals for smoother, more consistent 3D and glossy effects.
  * Improved pressed-state behavior so buttons collapse more naturally when clicked.
  * Refined primary, secondary, and danger button themes, including dark mode appearance.
  * Added better text alignment within buttons for a cleaner look.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->