### PR TITLE
fix(button): track focus ring to the 3D lip via --y

### DIFF
--- a/src/ludamus/client/src/index.css
+++ b/src/ludamus/client/src/index.css
@@ -412,7 +412,7 @@ button:active {
       /* Collapse the lip via --y, not a box-shadow swap: equal layer counts
          keep box-shadow from snapping a layer in/out, so it stays in sync with
          the transform (the swap jittered). */
-      --y: 0;
+      --y: 0px; /* 0px, not 0, so the focus-ring calc() below stays valid */
     }
 
     &:focus {
@@ -424,17 +424,11 @@ button:active {
       content: "";
       position: absolute;
       inset: -2px;
-      bottom: -4px;
+      /* track the 3D lip via --y so the ring follows it in every state
+         (incl. hover-while-pressed), no per-state overrides */
+      bottom: calc(-2px - var(--y));
       border: 1px solid var(--color-primary);
       border-radius: 18px;
-    }
-
-    &:hover:focus-visible:after {
-      bottom: -3px;
-    }
-
-    &:active:focus-visible:after {
-      bottom: -2px;
     }
   }
 


### PR DESCRIPTION
Follow-up to #442.

The button's `:focus-visible` ring (a 1px coral `::after`) sits below the 3D lip by hardcoding its `bottom` offset per state:

```css
&:focus-visible:after        { bottom: -4px; }  /* rest,  lip = --y 2px */
&:hover:focus-visible:after  { bottom: -3px; }  /* hover, lip = --y 1px */
&:active:focus-visible:after { bottom: -2px; }  /* active, lip = --y 0  */
```

Enumerating states like this breaks on combinations — e.g. **hovering while pressed** — and needs an extra rule per state. Since the lip's height *is* `--y`, derive the ring from it instead:

```css
&:focus-visible:after { bottom: calc(-2px - var(--y)); }
```

That yields the exact same values (rest −4, hover −3, active −2) but now the ring follows the lip in **every** state and combination, with the two override rules deleted. Net −6 lines.

One small detail: `:active` now sets `--y: 0px` instead of `0`, because CSS `calc()` can't subtract a unitless `0` from a length. The box-shadow lip is unaffected (`0px` and `0` render identically there).

Keeps the current focus style as-is (no switch to `outline` — the current ring is good once it tracks correctly).

Verified `mise run build-frontend` compiles clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N4zhJurWJEb6m9b6mbefkN

---
_Generated by [Claude Code](https://claude.ai/code/session_01N4zhJurWJEb6m9b6mbefkN)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved button active and focus-visible states so pressed and keyboard-focused buttons render more consistently.
  * Fixed the focus ring position to better track the button’s visual offset across hover and active interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->