### PR TITLE
Optically align navbar right-side items

### DIFF
--- a/src/ludamus/templates/components/navbar.html
+++ b/src/ludamus/templates/components/navbar.html
@@ -28,7 +28,7 @@
                     {% endif %}
                 {% endif %}
             </div>
-            <div class="flex items-center gap-2">
+            <div class="flex items-center gap-2 -translate-y-px">
                 {% if request.user.is_authenticated %}
                     {% include "components/notifications.html" %}
                     <!-- User dropdown menu -->
@@ -75,7 +75,7 @@
                         </div>
                     </div>
                 {% else %}
-                    {% include "components/login_button.html" with next=request.build_absolute_uri extra_class="text-sm" show_icon="" text="" %}
+                    {% include "components/login_button.html" with next=request.build_absolute_uri extra_class="text-sm -translate-y-[.5px]" show_icon="" text="" %}
                 {% endif %}
             </div>
         </div>


### PR DESCRIPTION
Nudge the navbar's right-side items up for optical alignment with the left-side logo/nav.

- Authenticated group (notifications + avatar) → `-translate-y-px`
- Login button → `-translate-y-[.5px]`

Moved separately rather than via the shared container so each gets its own offset.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Adjusted the vertical alignment of the navigation area for signed-in users.
  * Fine-tuned the login button position for signed-out users to improve visual consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->