### PR TITLE
Enlarge avatar menu button hitbox to 44px touch target

### DIFF
--- a/src/ludamus/templates/components/navbar.html
+++ b/src/ludamus/templates/components/navbar.html
@@ -39,7 +39,7 @@
                                 aria-controls="navbar-profile-panel"
                                 aria-expanded="false"
                                 aria-label="{% translate "Account menu" %}"
-                                class="w-9 h-9 rounded-full bg-neutral-800 flex items-center justify-center cursor-pointer transition-shadow duration-150 ring-2 ring-transparent hover:ring-coral-500/30 focus:outline-none focus:ring-coral-500/50">
+                                class="relative w-9 h-9 rounded-full bg-neutral-800 flex items-center justify-center cursor-pointer transition-shadow duration-150 ring-2 ring-transparent hover:ring-coral-500/30 focus:outline-none focus:ring-coral-500/50 before:absolute before:-inset-1 before:content-['']">
                             {% include "components/avatar.html" with user=current_user_info size="size-10" %}
                         </button>
                         <!-- Dropdown panel -->


### PR DESCRIPTION
The avatar menu trigger is `w-9 h-9` (36px), below the 44px touch-target minimum. Add a transparent `before:-inset-1` layer that extends the tappable area to ~44px without changing the visual size.

`relative` anchors the absolute pseudo; `before:content-['']` is required or Tailwind won't emit the pseudo-element.

Pre-existing a11y issue surfaced during the navbar-nudge review (#449).