### PR TITLE
Animate modal backdrop blur instead of snapping it in

### DIFF
--- a/src/ludamus/client/src/modal.css
+++ b/src/ludamus/client/src/modal.css
@@ -47,10 +47,12 @@
 
   .modal::backdrop {
     background-color: transparent;
+    backdrop-filter: blur(0);
     transition:
       display 0.2s allow-discrete,
       overlay 0.2s allow-discrete,
-      background-color 0.2s var(--ease-out);
+      background-color 0.2s var(--ease-out),
+      backdrop-filter 0.2s var(--ease-out);
   }
 
   .modal[open]::backdrop {
@@ -61,6 +63,7 @@
   @starting-style {
     .modal[open]::backdrop {
       background-color: transparent;
+      backdrop-filter: blur(0);
     }
   }
 }

--- a/src/ludamus/client/src/modal.css
+++ b/src/ludamus/client/src/modal.css
@@ -168,6 +168,9 @@
   animation: page-blur-out var(--vt-morph-exit-duration) var(--vt-morph-ease) both;
 }
 
+/* These keyframes replace the UA default root cross-fade (the opacity rule
+   above), so they re-supply the opacity fade themselves — editing opacity here
+   drives the page cross-fade, not just the blur, now on the morph's timing. */
 @keyframes page-blur-in {
   from {
     opacity: 0;

--- a/src/ludamus/client/src/modal.css
+++ b/src/ludamus/client/src/modal.css
@@ -1,3 +1,10 @@
+:root {
+  /* Single source of truth: the live ::backdrop blur and the morph's
+     root-snapshot blur must match so the hand-off at the end of the view
+     transition is seamless. */
+  --modal-backdrop-blur: 4px;
+}
+
 @layer components {
   .modal {
     position: fixed;
@@ -57,7 +64,7 @@
 
   .modal[open]::backdrop {
     background-color: color-mix(in srgb, var(--color-background) 50%, transparent);
-    backdrop-filter: blur(4px);
+    backdrop-filter: blur(var(--modal-backdrop-blur));
   }
 
   @starting-style {
@@ -143,6 +150,46 @@
 ::view-transition-new(root) {
   animation-duration: 0.2s;
   animation-timing-function: var(--ease-out);
+}
+
+/* Drive the background-page blur as part of the card<->modal morph so it grows
+   from the tap instead of snapping in once the morph settles. Safari doesn't
+   rasterise the ::backdrop's backdrop-filter into the view-transition snapshot,
+   so the live blur only appears after the transition; simulate it here by
+   blurring the root snapshot (the page behind), which is painted below the
+   morphing modal group and so leaves the modal itself crisp. The end state
+   matches the live ::backdrop blur, so the hand-off when the transition ends is
+   seamless. modal.ts toggles these classes on <html> for the morph's lifetime. */
+:root.session-morph-open::view-transition-new(root) {
+  animation: page-blur-in var(--vt-morph-duration) var(--vt-morph-ease) both;
+}
+
+:root.session-morph-close::view-transition-old(root) {
+  animation: page-blur-out var(--vt-morph-exit-duration) var(--vt-morph-ease) both;
+}
+
+@keyframes page-blur-in {
+  from {
+    opacity: 0;
+    filter: blur(0);
+  }
+
+  to {
+    opacity: 1;
+    filter: blur(var(--modal-backdrop-blur));
+  }
+}
+
+@keyframes page-blur-out {
+  from {
+    opacity: 1;
+    filter: blur(var(--modal-backdrop-blur));
+  }
+
+  to {
+    opacity: 0;
+    filter: blur(0);
+  }
 }
 
 @media (prefers-reduced-motion: reduce) {

--- a/src/ludamus/client/src/modal.ts
+++ b/src/ludamus/client/src/modal.ts
@@ -98,6 +98,10 @@ const ignoreSkippedTransition = (error: unknown): void => {
 
 const MORPH_NAME = "session-morph";
 const CARD_SUPPRESSED = "session-card-suppressed";
+// <html> classes that scope the page-blur keyframes to a morph's lifetime (see
+// modal.css). Derived from MORPH_NAME so the prefix relationship is explicit.
+const ROOT_MORPH_OPEN = `${MORPH_NAME}-open`;
+const ROOT_MORPH_CLOSE = `${MORPH_NAME}-close`;
 
 const sessionCardForModal = (id: string): HTMLElement | null => {
   if (!id.startsWith("session-")) return null;
@@ -133,6 +137,10 @@ const setContainerMorph = (root: HTMLElement, active: boolean): void => {
 const setMorph = (root: HTMLElement, active: boolean): void => {
   setContainerMorph(root, active);
   setSubMorph(root, active);
+};
+
+const setRootMorph = (className: string, active: boolean): void => {
+  document.documentElement.classList.toggle(className, active);
 };
 
 const morphTransition = (steps: {
@@ -178,11 +186,11 @@ const openModal = async (
       openingModals.add(id);
       morphPromise = morphTransition({
         before: () => {
-          document.documentElement.classList.add("session-morph-open");
+          setRootMorph(ROOT_MORPH_OPEN, true);
           setMorph(card, true);
         },
         settle: () => {
-          document.documentElement.classList.remove("session-morph-open");
+          setRootMorph(ROOT_MORPH_OPEN, false);
           openingModals.delete(id);
           setMorph(dialog, false);
           card.style.transition = "";
@@ -223,11 +231,11 @@ const closeModal = (
     if (animate && canMorph(card)) {
       morphTransition({
         before: () => {
-          document.documentElement.classList.add("session-morph-close");
+          setRootMorph(ROOT_MORPH_CLOSE, true);
           setContainerMorph(dialog, true);
         },
         settle: () => {
-          document.documentElement.classList.remove("session-morph-close");
+          setRootMorph(ROOT_MORPH_CLOSE, false);
           setContainerMorph(card, false);
         },
         swap: () => {

--- a/src/ludamus/client/src/modal.ts
+++ b/src/ludamus/client/src/modal.ts
@@ -177,8 +177,12 @@ const openModal = async (
     if (animate && canMorph(card)) {
       openingModals.add(id);
       morphPromise = morphTransition({
-        before: () => setMorph(card, true),
+        before: () => {
+          document.documentElement.classList.add("session-morph-open");
+          setMorph(card, true);
+        },
         settle: () => {
+          document.documentElement.classList.remove("session-morph-open");
           openingModals.delete(id);
           setMorph(dialog, false);
           card.style.transition = "";
@@ -218,8 +222,12 @@ const closeModal = (
     const card = sessionCardForModal(id);
     if (animate && canMorph(card)) {
       morphTransition({
-        before: () => setContainerMorph(dialog, true),
+        before: () => {
+          document.documentElement.classList.add("session-morph-close");
+          setContainerMorph(dialog, true);
+        },
         settle: () => {
+          document.documentElement.classList.remove("session-morph-close");
           setContainerMorph(card, false);
         },
         swap: () => {


### PR DESCRIPTION
The ::backdrop only transitioned background-color, so backdrop-filter had
no duration, no resting blur(0), and no @starting-style value — the blur
jumped straight to blur(4px) the instant the dialog opened. For session
modals (opened inside a view-transition morph) the snapped blur only
became visible once the morph settled, reading as "blur appears after the
modal opens" — most obvious on mobile Safari.

Add backdrop-filter to the transition with a blur(0) resting and
@starting-style value so it tweens clear -> blurred on open and back on
close, alongside the existing background-color fade.

Co-authored-by: hasparus <hasparus@gmail.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Modal open/close transitions now feel smoother and more consistent.
  * Background blur is now applied more evenly during modal and session transition animations.

* **Bug Fixes**
  * Improved the handoff between opening and closing states so the backdrop blur no longer snaps unexpectedly.
  * Background page blur during transitions now better matches the modal’s final appearance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->