### PR TITLE
fix(navbar,btn): login button hover press + symmetric hover-out

### DIFF
--- a/src/ludamus/client/src/index.css
+++ b/src/ludamus/client/src/index.css
@@ -374,10 +374,14 @@ button:active {
     border-radius: 1rem;
     padding: 0.625rem 1rem;
     font-weight: 500;
-    /* Only transform (press) and box-shadow (depth via --y) animate on state. */
+    /* translate + scale (press) and box-shadow (depth via --y) animate on state.
+       These are the properties the :hover / :active rules actually set, so they
+       must all be listed here for the base (hover-out, release) transition to
+       animate symmetrically with hover-in — not snap. */
     transition:
-      transform 0.2s,
-      box-shadow 0.2s;
+      translate 0.15s,
+      scale 0.15s,
+      box-shadow 0.15s;
     background-color: var(--bg);
     /* optical vertical centering (trims Outfit's half-leading) */
     text-box: trim-both cap alphabetic;
@@ -388,7 +392,7 @@ button:active {
       0 var(--y) 0 0 var(--bg);
 
     &:hover {
-      @apply translate-y-px transition duration-150;
+      @apply translate-y-px;
       --y: 1px;
     }
 

--- a/src/ludamus/templates/components/navbar.html
+++ b/src/ludamus/templates/components/navbar.html
@@ -75,7 +75,9 @@
                         </div>
                     </div>
                 {% else %}
-                    {% include "components/login_button.html" with next=request.build_absolute_uri extra_class="text-sm -translate-y-[.5px]" show_icon="" text="" %}
+                    <span class="inline-flex -translate-y-[.5px]">
+                        {% include "components/login_button.html" with next=request.build_absolute_uri extra_class="text-sm" show_icon="" text="" %}
+                    </span>
                 {% endif %}
             </div>
         </div>


### PR DESCRIPTION
## What

The navbar login button didn't behave like the "propose session" button on hover. Two distinct bugs, both fixed here:

1. **It never shifted down on hover** — only the shadow changed.
2. **The press animated asymmetrically** — even once shifting was restored, hover-*out* snapped back instantly while the shadow eased.

## Why

**Bug 1 — pinned transform (navbar.html).** The login button uses the same `btn btn-primary` classes as "propose session", but the navbar passed an extra alignment utility directly on the `<a>`:

```django
extra_class="text-sm -translate-y-[.5px]"
```

That `-translate-y-[.5px]` is a Tailwind **utility** (utilities layer). The `.btn:hover` press-down lives in `@layer components`. In Tailwind v4's cascade layers, utilities always beat components regardless of specificity — so the button's `translate` was pinned in every state. Only the shadow changed on hover, because that's driven by the `--y` custom property in `.btn:hover`.

**Bug 2 — asymmetric transition (index.css).** The `.btn` base transition only listed `transform` and `box-shadow`, but `:hover`/`:active` press the button with `translate` and `scale` (Tailwind v4 emits these as separate properties, not `transform`). Hover-*in* animated because the `:hover` rule pulled in `@apply transition` (whose list covers `translate`/`scale`); hover-*out* fell back to the base transition, which omitted them — so position/scale snapped while the shadow eased.

## How

- **navbar.html:** move the `-.5px` alignment nudge onto an `inline-flex` wrapper span, leaving the button's own `transform` free for the hover/active press. Visual alignment is unchanged.
- **index.css:** list the properties that actually animate (`translate`, `scale`, `box-shadow`) in the base transition and drop the now-redundant `transition duration-150` override on `:hover`, so press in/out and release all animate at the same 150ms.

## Verification

Built the frontend, seeded the e2e DB, ran the app, and checked the live login button with a headless browser:

```
IDLE   translate=none      transition-property="translate, scale, box-shadow"  duration="0.15s, 0.15s, 0.15s"
HOVER  translate=0px 1px   transition-property="translate, scale, box-shadow"  duration="0.15s, 0.15s, 0.15s"
```

- Button now moves on hover (`none` → `0px 1px`) — navbar fix.
- Base transition lists `translate`/`scale`/`box-shadow`, so hover-out animates symmetrically — CSS fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)