### PR TITLE
refactor(links): move user repositories into links/db/django/crowd.py

### DIFF
--- a/src/ludamus/links/db/django/crowd.py
+++ b/src/ludamus/links/db/django/crowd.py
@@ -1,0 +1,106 @@
+from typing import TYPE_CHECKING
+
+from ludamus.pacts import (
+    ConnectedUserRepositoryProtocol,
+    NotFoundError,
+    UserData,
+    UserDTO,
+    UserRepositoryProtocol,
+    UserType,
+)
+
+if TYPE_CHECKING:
+    from ludamus.adapters.db.django.models import User
+else:
+    from django.contrib.auth import get_user_model
+
+    User = get_user_model()
+
+
+class UserRepository(UserRepositoryProtocol):
+    def __init__(self, user_type: UserType) -> None:
+        self._user_type = user_type
+
+    @staticmethod
+    def create(user_data: UserData) -> None:
+        User.objects.create(**user_data)
+
+    def read(self, slug: str) -> UserDTO:
+        try:
+            user = User.objects.get(slug=slug, user_type=self._user_type)
+        except User.DoesNotExist as exception:
+            raise NotFoundError from exception
+
+        return UserDTO.model_validate(user)
+
+    def read_by_id(self, pk: int) -> UserDTO:
+        try:
+            user = User.objects.get(pk=pk, user_type=self._user_type)
+        except User.DoesNotExist as exception:
+            raise NotFoundError from exception
+        return UserDTO.model_validate(user)
+
+    def read_by_username(self, username: str) -> UserDTO:
+        try:
+            user = User.objects.get(username=username, user_type=self._user_type)
+        except User.DoesNotExist as exception:
+            raise NotFoundError from exception
+        return UserDTO.model_validate(user)
+
+    @staticmethod
+    def update(user_slug: str, user_data: UserData) -> None:
+        User.objects.filter(slug=user_slug).update(**user_data)
+
+    @staticmethod
+    def email_exists(email: str, exclude_slug: str | None = None) -> bool:
+        if not email:
+            return False
+
+        query = User.objects.filter(email__iexact=email)
+        if exclude_slug:
+            query = query.exclude(slug=exclude_slug)
+
+        return query.exists()
+
+
+class ConnectedUserRepository(ConnectedUserRepositoryProtocol):
+    @staticmethod
+    def read_all(manager_slug: str) -> list[UserDTO]:
+        try:
+            manager = User.objects.get(user_type=UserType.ACTIVE, slug=manager_slug)
+        except User.DoesNotExist as exception:
+            raise NotFoundError from exception
+
+        return [
+            UserDTO.model_validate(connected_user)
+            for connected_user in manager.connected.all()
+        ]
+
+    @staticmethod
+    def create(manager_slug: str, user_data: UserData) -> None:
+        manager = User.objects.get(user_type=UserType.ACTIVE, slug=manager_slug)
+        User.objects.create(manager=manager, **user_data)
+
+    @staticmethod
+    def read(manager_slug: str, user_slug: str) -> UserDTO:
+        try:
+            connected_user = User.objects.get(
+                slug=user_slug, manager__slug=manager_slug
+            )
+        except User.DoesNotExist as exception:
+            raise NotFoundError from exception
+        return UserDTO.model_validate(connected_user)
+
+    @staticmethod
+    def update(manager_slug: str, user_slug: str, user_data: UserData) -> None:
+        User.objects.filter(slug=user_slug, manager__slug=manager_slug).update(
+            **user_data
+        )
+
+    @staticmethod
+    def delete(manager_slug: str, user_slug: str) -> None:
+        try:
+            user = User.objects.get(slug=user_slug, manager__slug=manager_slug)
+        except User.DoesNotExist as exception:
+            raise NotFoundError from exception
+        user.delete()

--- a/src/ludamus/links/db/django/repositories.py
+++ b/src/ludamus/links/db/django/repositories.py
@@ -56,7 +56,6 @@ from ludamus.adapters.db.django.models import (
 from ludamus.pacts import (
     UNSCHEDULED_LIST_LIMIT,
     CategoryStats,
-    ConnectedUserRepositoryProtocol,
     DomainEnrollmentConfigDTO,
     EncounterData,
     EncounterDTO,
@@ -124,12 +123,9 @@ from ludamus.pacts import (
     TrackRepositoryProtocol,
     TrackUpdateData,
     UnscheduledSessionDTO,
-    UserData,
     UserDTO,
     UserEnrollmentConfigData,
     UserEnrollmentConfigDTO,
-    UserRepositoryProtocol,
-    UserType,
 )
 from ludamus.pacts.chronology import (
     EventIntegrationCreateData,
@@ -240,52 +236,6 @@ class SphereRepository(SphereRepositoryProtocol):
         for key, value in data.items():
             setattr(sphere, key, value)
         sphere.save(update_fields=list(data.keys()))
-
-
-class UserRepository(UserRepositoryProtocol):
-    def __init__(self, user_type: UserType) -> None:
-        self._user_type = user_type
-
-    @staticmethod
-    def create(user_data: UserData) -> None:
-        User.objects.create(**user_data)
-
-    def read(self, slug: str) -> UserDTO:
-        try:
-            user = User.objects.get(slug=slug, user_type=self._user_type)
-        except User.DoesNotExist as exception:
-            raise NotFoundError from exception
-
-        return UserDTO.model_validate(user)
-
-    def read_by_id(self, pk: int) -> UserDTO:
-        try:
-            user = User.objects.get(pk=pk, user_type=self._user_type)
-        except User.DoesNotExist as exception:
-            raise NotFoundError from exception
-        return UserDTO.model_validate(user)
-
-    def read_by_username(self, username: str) -> UserDTO:
-        try:
-            user = User.objects.get(username=username, user_type=self._user_type)
-        except User.DoesNotExist as exception:
-            raise NotFoundError from exception
-        return UserDTO.model_validate(user)
-
-    @staticmethod
-    def update(user_slug: str, user_data: UserData) -> None:
-        User.objects.filter(slug=user_slug).update(**user_data)
-
-    @staticmethod
-    def email_exists(email: str, exclude_slug: str | None = None) -> bool:
-        if not email:
-            return False
-
-        query = User.objects.filter(email__iexact=email)
-        if exclude_slug:
-            query = query.exclude(slug=exclude_slug)
-
-        return query.exists()
 
 
 class SessionRepository(SessionRepositoryProtocol):  # noqa: PLR0904
@@ -755,49 +705,6 @@ class SessionRepository(SessionRepositoryProtocol):  # noqa: PLR0904
                 )
             )
         return results, has_more
-
-
-class ConnectedUserRepository(ConnectedUserRepositoryProtocol):
-    @staticmethod
-    def read_all(manager_slug: str) -> list[UserDTO]:
-        try:
-            manager = User.objects.get(user_type=UserType.ACTIVE, slug=manager_slug)
-        except User.DoesNotExist as exception:
-            raise NotFoundError from exception
-
-        return [
-            UserDTO.model_validate(connected_user)
-            for connected_user in manager.connected.all()
-        ]
-
-    @staticmethod
-    def create(manager_slug: str, user_data: UserData) -> None:
-        manager = User.objects.get(user_type=UserType.ACTIVE, slug=manager_slug)
-        User.objects.create(manager=manager, **user_data)
-
-    @staticmethod
-    def read(manager_slug: str, user_slug: str) -> UserDTO:
-        try:
-            connected_user = User.objects.get(
-                slug=user_slug, manager__slug=manager_slug
-            )
-        except User.DoesNotExist as exception:
-            raise NotFoundError from exception
-        return UserDTO.model_validate(connected_user)
-
-    @staticmethod
-    def update(manager_slug: str, user_slug: str, user_data: UserData) -> None:
-        User.objects.filter(slug=user_slug, manager__slug=manager_slug).update(
-            **user_data
-        )
-
-    @staticmethod
-    def delete(manager_slug: str, user_slug: str) -> None:
-        try:
-            user = User.objects.get(slug=user_slug, manager__slug=manager_slug)
-        except User.DoesNotExist as exception:
-            raise NotFoundError from exception
-        user.delete()
 
 
 def _event_dto(event: Event) -> EventDTO:

--- a/src/ludamus/links/db/django/uow.py
+++ b/src/ludamus/links/db/django/uow.py
@@ -5,7 +5,7 @@ from django.contrib.auth import login as django_login
 from django.db import transaction
 
 from ludamus.adapters.db.django.models import User
-from ludamus.links.db.django import repositories
+from ludamus.links.db.django import crowd, repositories
 from ludamus.links.db.django.agenda_item import AgendaItemRepository
 from ludamus.links.db.django.schedule_change_log import ScheduleChangeLogRepository
 from ludamus.pacts import UnitOfWorkProtocol, UserType
@@ -27,20 +27,20 @@ class UnitOfWork(UnitOfWorkProtocol):  # noqa: PLR0904
         django_login(request, user)
 
     @cached_property
-    def active_users(self) -> repositories.UserRepository:
-        return repositories.UserRepository(user_type=UserType.ACTIVE)
+    def active_users(self) -> crowd.UserRepository:
+        return crowd.UserRepository(user_type=UserType.ACTIVE)
 
     @cached_property
     def agenda_items(self) -> AgendaItemRepository:
         return AgendaItemRepository()
 
     @cached_property
-    def anonymous_users(self) -> repositories.UserRepository:
-        return repositories.UserRepository(user_type=UserType.ANONYMOUS)
+    def anonymous_users(self) -> crowd.UserRepository:
+        return crowd.UserRepository(user_type=UserType.ANONYMOUS)
 
     @cached_property
-    def connected_users(self) -> repositories.ConnectedUserRepository:
-        return repositories.ConnectedUserRepository()
+    def connected_users(self) -> crowd.ConnectedUserRepository:
+        return crowd.ConnectedUserRepository()
 
     @cached_property
     def event_proposal_settings(self) -> repositories.EventProposalSettingsRepository:

--- a/tests/integration/links/test_repositories_not_found.py
+++ b/tests/integration/links/test_repositories_not_found.py
@@ -12,8 +12,8 @@ from ludamus.adapters.db.django.models import (
     Session,
     SessionField,
 )
+from ludamus.links.db.django.crowd import ConnectedUserRepository
 from ludamus.links.db.django.repositories import (
-    ConnectedUserRepository,
     EventRepository,
     ProposalCategoryRepository,
     SessionRepository,


### PR DESCRIPTION
Part of #457 (PR-2). Behavior-preserving GLIMPSE strangler move.

## What
Moves `UserRepository` and `ConnectedUserRepository` out of the ~3,200-line `links/db/django/repositories.py` into a new `links/db/django/crowd.py`, co-locating Crowd persistence and shrinking the fat repository module.

- Both classes moved verbatim; each still declares its Protocol as a base class.
- `links/db/django/uow.py` now builds `crowd.UserRepository` / `crowd.ConnectedUserRepository` for `active_users` / `anonymous_users` / `connected_users`.
- Dropped the now-unused imports from `repositories.py` (kept the ones other repos still use).
- One test import updated (`test_repositories_not_found.py`).

## Why
Unblocks the Party membership feature (party persistence lands next to the user repos) and advances Refactor 4 (split the fat `repositories.py`).

## Verification
- `lint-imports`: 7 contracts kept, 0 broken
- `pytest --collect-only`: 2315 tests, no errors
- `ruff` + `mypy` on changed files: clean
- `pytest tests/integration/web/crowd tests/unit/links`: 93 passed

## Merge note
Independent of the other #457 PRs, but interacts with **PR-1** (`refactor(pacts): carve user contracts into pacts/crowd.py`): whichever merges second needs a one-line rebase so the new `crowd.py` imports the user contracts from `ludamus.pacts.crowd` instead of the `ludamus.pacts` facade. Also note the Party feature branch (#433) adds a `links/db/django/crowd.py` of its own (ClaimRepository) — the two additions combine cleanly on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_017YQfLmJnXQuqYWoHN49pyo)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for managing user profiles and connected users through the app’s backend, including creating, viewing, updating, and deleting these records.
  * Improved lookup options so users can be found by ID, username, or slug.

* **Bug Fixes**
  * Missing users, managers, or connected users now return clear “not found” results instead of failing unexpectedly.
  * Repository access was aligned so user-related actions use the updated backend path consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->