### PR TITLE
refactor(pacts): carve user-identity contracts into pacts/crowd.py

### DIFF
--- a/src/ludamus/adapters/db/django/migrations/0025_alter_user_user_type.py
+++ b/src/ludamus/adapters/db/django/migrations/0025_alter_user_user_type.py
@@ -2,7 +2,7 @@
 
 from django.db import migrations, models
 
-import ludamus.pacts
+import ludamus.pacts.crowd
 
 
 class Migration(migrations.Migration):
@@ -19,7 +19,7 @@ class Migration(migrations.Migration):
                     ("connected", "CONNECTED"),
                     ("anonymous", "ANONYMOUS"),
                 ],
-                default=ludamus.pacts.UserType["ACTIVE"],
+                default=ludamus.pacts.crowd.UserType["ACTIVE"],
                 max_length=255,
             ),
         )

--- a/src/ludamus/adapters/db/django/models.py
+++ b/src/ludamus/adapters/db/django/models.py
@@ -22,16 +22,17 @@ from ludamus.pacts import (
     SessionParticipationStatus,
     SessionStatus,
     SpherePage,
-    UserType,
     VirtualEnrollmentConfig,
 )
+from ludamus.pacts.crowd import UserType
 from ludamus.pacts.discounts import DiscountKind
 from ludamus.pacts.submissions import ImportLogStatus
 
 if TYPE_CHECKING:
     from collections.abc import Collection, Iterator
 
-    from ludamus.pacts import EventDTO, UserDTO
+    from ludamus.pacts import EventDTO
+    from ludamus.pacts.crowd import UserDTO
 
 
 MAX_SLUG_RETRIES = 10

--- a/src/ludamus/adapters/web/django/entities.py
+++ b/src/ludamus/adapters/web/django/entities.py
@@ -15,8 +15,8 @@ if TYPE_CHECKING:
         LocationData,
         SessionDTO,
         SessionFieldValueDTO,
-        UserDTO,
     )
+    from ludamus.pacts.crowd import UserDTO
 
 
 @dataclass

--- a/src/ludamus/adapters/web/django/forms.py
+++ b/src/ludamus/adapters/web/django/forms.py
@@ -25,11 +25,9 @@ from ludamus.pacts import (
     EnrollmentConfigRepositoryProtocol,
     EventDTO,
     TicketAPIProtocol,
-    UserData,
-    UserDTO,
-    UserType,
     VirtualEnrollmentConfig,
 )
+from ludamus.pacts.crowd import UserData, UserDTO, UserType
 
 if TYPE_CHECKING:
     from collections.abc import Callable, Iterable

--- a/src/ludamus/adapters/web/django/views.py
+++ b/src/ludamus/adapters/web/django/views.py
@@ -76,9 +76,8 @@ from ludamus.pacts import (
     SessionRepositoryProtocol,
     SessionStatus,
     SpherePage,
-    UserData,
-    UserDTO,
 )
+from ludamus.pacts.crowd import UserData, UserDTO
 
 from .design_fixtures import (
     mock_event_info,

--- a/src/ludamus/gates/web/django/chronology/panel/views/tracks.py
+++ b/src/ludamus/gates/web/django/chronology/panel/views/tracks.py
@@ -23,7 +23,8 @@ from ludamus.pacts import NotFoundError, TrackCreateData, TrackUpdateData
 if TYPE_CHECKING:
     from django.http import HttpResponse
 
-    from ludamus.pacts import SpaceDTO, UserDTO
+    from ludamus.pacts import SpaceDTO
+    from ludamus.pacts.crowd import UserDTO
 
 
 def _track_get_choices(

--- a/src/ludamus/gates/web/django/context_processors.py
+++ b/src/ludamus/gates/web/django/context_processors.py
@@ -10,7 +10,8 @@ if TYPE_CHECKING:
     from django.http import HttpRequest
 
     from ludamus.adapters.web.django.middlewares import RootRepositoryRequest
-    from ludamus.pacts import SiteDTO, SphereDTO, UserDTO
+    from ludamus.pacts import SiteDTO, SphereDTO
+    from ludamus.pacts.crowd import UserDTO
     from ludamus.pacts.enrollment import NavbarNotificationsDTO
 
 

--- a/src/ludamus/gates/web/django/entities.py
+++ b/src/ludamus/gates/web/django/entities.py
@@ -12,8 +12,8 @@ if TYPE_CHECKING:
         AuthenticatedRequestContext,
         DependencyInjectorProtocol,
         RequestContext,
-        UserDTO,
     )
+    from ludamus.pacts.crowd import UserDTO
     from ludamus.pacts.services import ServicesProtocol
 
 

--- a/src/ludamus/links/db/django/crowd.py
+++ b/src/ludamus/links/db/django/crowd.py
@@ -1,8 +1,8 @@
 from typing import TYPE_CHECKING
 
-from ludamus.pacts import (
+from ludamus.pacts import NotFoundError
+from ludamus.pacts.crowd import (
     ConnectedUserRepositoryProtocol,
-    NotFoundError,
     UserData,
     UserDTO,
     UserRepositoryProtocol,

--- a/src/ludamus/links/db/django/enrollment.py
+++ b/src/ludamus/links/db/django/enrollment.py
@@ -20,7 +20,8 @@ from ludamus.adapters.db.django.models import (
     UserEnrollmentConfig,
     get_used_slots,
 )
-from ludamus.pacts import EventDTO, UserDTO
+from ludamus.pacts import EventDTO
+from ludamus.pacts.crowd import UserDTO
 from ludamus.pacts.enrollment import (
     UNLIMITED_SLOTS,
     OfferDTO,

--- a/src/ludamus/links/db/django/repositories.py
+++ b/src/ludamus/links/db/django/repositories.py
@@ -56,7 +56,6 @@ from ludamus.adapters.db.django.models import (
 from ludamus.pacts import (
     UNSCHEDULED_LIST_LIMIT,
     CategoryStats,
-    ConnectedUserRepositoryProtocol,
     DomainEnrollmentConfigDTO,
     EncounterData,
     EncounterDTO,
@@ -124,12 +123,8 @@ from ludamus.pacts import (
     TrackRepositoryProtocol,
     TrackUpdateData,
     UnscheduledSessionDTO,
-    UserData,
-    UserDTO,
     UserEnrollmentConfigData,
     UserEnrollmentConfigDTO,
-    UserRepositoryProtocol,
-    UserType,
 )
 from ludamus.pacts.chronology import (
     EventIntegrationCreateData,
@@ -138,6 +133,13 @@ from ludamus.pacts.chronology import (
     EventIntegrationUpdateData,
     IntegrationImplementationId,
     IntegrationKind,
+)
+from ludamus.pacts.crowd import (
+    ConnectedUserRepositoryProtocol,
+    UserData,
+    UserDTO,
+    UserRepositoryProtocol,
+    UserType,
 )
 from ludamus.pacts.discounts import (
     DiscountData,

--- a/src/ludamus/links/db/django/repositories.py
+++ b/src/ludamus/links/db/django/repositories.py
@@ -134,13 +134,7 @@ from ludamus.pacts.chronology import (
     IntegrationImplementationId,
     IntegrationKind,
 )
-from ludamus.pacts.crowd import (
-    ConnectedUserRepositoryProtocol,
-    UserData,
-    UserDTO,
-    UserRepositoryProtocol,
-    UserType,
-)
+from ludamus.pacts.crowd import UserDTO
 from ludamus.pacts.discounts import (
     DiscountData,
     DiscountDTO,

--- a/src/ludamus/links/db/django/safety.py
+++ b/src/ludamus/links/db/django/safety.py
@@ -10,7 +10,8 @@ from ludamus.adapters.db.django.models import (
     EventBan,
     Shadowban,
 )
-from ludamus.pacts import NotFoundError, SessionParticipationStatus, UserDTO
+from ludamus.pacts import NotFoundError, SessionParticipationStatus
+from ludamus.pacts.crowd import UserDTO
 from ludamus.pacts.safety import (
     EventBanDTO,
     EventBanRepositoryProtocol,

--- a/src/ludamus/links/db/django/uow.py
+++ b/src/ludamus/links/db/django/uow.py
@@ -8,7 +8,8 @@ from ludamus.adapters.db.django.models import User
 from ludamus.links.db.django import repositories
 from ludamus.links.db.django.agenda_item import AgendaItemRepository
 from ludamus.links.db.django.schedule_change_log import ScheduleChangeLogRepository
-from ludamus.pacts import UnitOfWorkProtocol, UserType
+from ludamus.pacts import UnitOfWorkProtocol
+from ludamus.pacts.crowd import UserType
 
 if TYPE_CHECKING:
     from contextlib import AbstractContextManager

--- a/src/ludamus/mills/enrollment.py
+++ b/src/ludamus/mills/enrollment.py
@@ -15,12 +15,10 @@ from typing import TYPE_CHECKING
 
 from ludamus.pacts import (
     MembershipAPIError,
-    UserData,
-    UserDTO,
     UserEnrollmentConfigData,
-    UserType,
     VirtualEnrollmentConfig,
 )
+from ludamus.pacts.crowd import UserData, UserDTO, UserType
 from ludamus.pacts.enrollment import (
     ClaimResult,
     NavbarNotificationsDTO,
@@ -38,8 +36,8 @@ if TYPE_CHECKING:
         EventDTO,
         TicketAPIProtocol,
         UserEnrollmentConfigDTO,
-        UserRepositoryProtocol,
     )
+    from ludamus.pacts.crowd import UserRepositoryProtocol
     from ludamus.pacts.enrollment import (
         NotificationReadRepositoryProtocol,
         OfferDTO,

--- a/src/ludamus/mills/legacy.py
+++ b/src/ludamus/mills/legacy.py
@@ -44,14 +44,16 @@ from ludamus.pacts import (
     TrackDTO,
     UnitOfWorkProtocol,
     UploadedFileProtocol,
-    UserData,
-    UserDTO,
     UserEnrollmentConfigData,
     UserEnrollmentConfigDTO,
-    UserRepositoryProtocol,
-    UserType,
     VirtualEnrollmentConfig,
     WizardData,
+)
+from ludamus.pacts.crowd import (
+    UserData,
+    UserDTO,
+    UserRepositoryProtocol,
+    UserType,
 )
 from ludamus.specs.encounter import ENCOUNTER_DEFAULT_DURATION
 from ludamus.specs.proposal import PROPOSAL_RATE_LIMIT_SECONDS

--- a/src/ludamus/mills/legacy.py
+++ b/src/ludamus/mills/legacy.py
@@ -49,12 +49,7 @@ from ludamus.pacts import (
     VirtualEnrollmentConfig,
     WizardData,
 )
-from ludamus.pacts.crowd import (
-    UserData,
-    UserDTO,
-    UserRepositoryProtocol,
-    UserType,
-)
+from ludamus.pacts.crowd import UserData, UserDTO, UserRepositoryProtocol, UserType
 from ludamus.specs.encounter import ENCOUNTER_DEFAULT_DURATION
 from ludamus.specs.proposal import PROPOSAL_RATE_LIMIT_SECONDS
 

--- a/src/ludamus/mills/legacy.py
+++ b/src/ludamus/mills/legacy.py
@@ -41,7 +41,6 @@ from ludamus.pacts import (
     UploadedFileProtocol,
     WizardData,
 )
-from ludamus.pacts.crowd import UserData, UserDTO, UserRepositoryProtocol, UserType
 from ludamus.specs.encounter import ENCOUNTER_DEFAULT_DURATION
 from ludamus.specs.proposal import PROPOSAL_RATE_LIMIT_SECONDS
 

--- a/src/ludamus/pacts/crowd.py
+++ b/src/ludamus/pacts/crowd.py
@@ -1,0 +1,72 @@
+"""Crowd (user-identity) contracts: user DTOs, data, and repository protocols."""
+
+from datetime import datetime
+from enum import StrEnum
+from typing import Protocol, TypedDict
+
+from pydantic import BaseModel, ConfigDict
+
+
+class UserType(StrEnum):
+    ACTIVE = "active"
+    CONNECTED = "connected"
+    ANONYMOUS = "anonymous"
+
+
+class UserDTO(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    avatar_url: str
+    date_joined: datetime
+    discord_username: str
+    email: str
+    full_name: str
+    is_active: bool
+    is_authenticated: bool
+    is_staff: bool
+    is_superuser: bool
+    manager_id: int | None = None
+    name: str
+    pk: int
+    slug: str
+    use_gravatar: bool
+    user_type: UserType
+    username: str
+
+
+class UserData(TypedDict, total=False):
+    avatar_url: str
+    discord_username: str
+    email: str
+    is_active: bool
+    name: str
+    password: str
+    slug: str
+    use_gravatar: bool
+    user_type: UserType
+    username: str
+
+
+class UserRepositoryProtocol(Protocol):
+    @staticmethod
+    def create(user_data: UserData) -> None: ...
+    def read(self, slug: str) -> UserDTO: ...
+    def read_by_id(self, pk: int) -> UserDTO: ...
+    def read_by_username(self, username: str) -> UserDTO: ...
+    @staticmethod
+    def update(user_slug: str, user_data: UserData) -> None: ...
+    @staticmethod
+    def email_exists(email: str, exclude_slug: str | None = None) -> bool: ...
+
+
+class ConnectedUserRepositoryProtocol(Protocol):
+    @staticmethod
+    def create(manager_slug: str, user_data: UserData) -> None: ...
+    @staticmethod
+    def read_all(manager_slug: str) -> list[UserDTO]: ...
+    @staticmethod
+    def read(manager_slug: str, user_slug: str) -> UserDTO: ...
+    @staticmethod
+    def delete(manager_slug: str, user_slug: str) -> None: ...
+    @staticmethod
+    def update(manager_slug: str, user_slug: str, user_data: UserData) -> None: ...

--- a/src/ludamus/pacts/legacy.py
+++ b/src/ludamus/pacts/legacy.py
@@ -13,6 +13,12 @@ from typing import (
 
 from pydantic import BaseModel, ConfigDict, field_validator
 
+from ludamus.pacts.crowd import (
+    ConnectedUserRepositoryProtocol,
+    UserDTO,
+    UserRepositoryProtocol,
+)
+
 if TYPE_CHECKING:
     from collections.abc import Iterable
     from contextlib import AbstractContextManager
@@ -420,33 +426,6 @@ class AgendaItemUpdateData(TypedDict, total=False):
     start_time: datetime
 
 
-class UserType(StrEnum):
-    ACTIVE = "active"
-    CONNECTED = "connected"
-    ANONYMOUS = "anonymous"
-
-
-class UserDTO(BaseModel):
-    model_config = ConfigDict(from_attributes=True)
-
-    avatar_url: str
-    date_joined: datetime
-    discord_username: str
-    email: str
-    full_name: str
-    is_active: bool
-    is_authenticated: bool
-    is_staff: bool
-    is_superuser: bool
-    manager_id: int | None = None
-    name: str
-    pk: int
-    slug: str
-    use_gravatar: bool
-    user_type: UserType
-    username: str
-
-
 class SiteDTO(BaseModel):
     model_config = ConfigDict(from_attributes=True)
 
@@ -618,19 +597,6 @@ class EnrollmentConfigDTO(BaseModel):
     pk: int
     restrict_to_configured_users: bool
     start_time: datetime
-
-
-class UserData(TypedDict, total=False):
-    avatar_url: str
-    discord_username: str
-    email: str
-    is_active: bool
-    name: str
-    password: str
-    slug: str
-    use_gravatar: bool
-    user_type: UserType
-    username: str
 
 
 class ProposalCategoryData(TypedDict, total=False):
@@ -880,18 +846,6 @@ class SphereRepositoryProtocol(Protocol):
     def update(sphere_id: int, data: SphereUpdateData) -> None: ...
 
 
-class UserRepositoryProtocol(Protocol):
-    @staticmethod
-    def create(user_data: UserData) -> None: ...
-    def read(self, slug: str) -> UserDTO: ...
-    def read_by_id(self, pk: int) -> UserDTO: ...
-    def read_by_username(self, username: str) -> UserDTO: ...
-    @staticmethod
-    def update(user_slug: str, user_data: UserData) -> None: ...
-    @staticmethod
-    def email_exists(email: str, exclude_slug: str | None = None) -> bool: ...
-
-
 class SessionRepositoryProtocol(Protocol):  # noqa: PLR0904
     @staticmethod
     def create(
@@ -1058,19 +1012,6 @@ class AgendaItemRepositoryProtocol(Protocol):
     def confirm_all_by_track(track_pk: int) -> None: ...
     @staticmethod
     def delete(pk: int) -> None: ...
-
-
-class ConnectedUserRepositoryProtocol(Protocol):
-    @staticmethod
-    def create(manager_slug: str, user_data: UserData) -> None: ...
-    @staticmethod
-    def read_all(manager_slug: str) -> list[UserDTO]: ...
-    @staticmethod
-    def read(manager_slug: str, user_slug: str) -> UserDTO: ...
-    @staticmethod
-    def delete(manager_slug: str, user_slug: str) -> None: ...
-    @staticmethod
-    def update(manager_slug: str, user_slug: str, user_data: UserData) -> None: ...
 
 
 class EventRepositoryProtocol(Protocol):

--- a/src/ludamus/pacts/safety.py
+++ b/src/ludamus/pacts/safety.py
@@ -3,7 +3,7 @@ from typing import Protocol
 
 from pydantic import BaseModel, ConfigDict
 
-from ludamus.pacts.legacy import UserDTO
+from ludamus.pacts.crowd import UserDTO
 
 
 class ShadowbanCandidateDTO(BaseModel):

--- a/tests/integration/factories.py
+++ b/tests/integration/factories.py
@@ -3,7 +3,7 @@ from django.contrib.auth.hashers import make_password
 from factory.django import DjangoModelFactory
 
 from ludamus.adapters.db.django.models import User
-from ludamus.pacts import UserType
+from ludamus.pacts.crowd import UserType
 
 
 class CompleteUserFactory(DjangoModelFactory):

--- a/tests/integration/web/chronology/test_event_anonymous_activate_action.py
+++ b/tests/integration/web/chronology/test_event_anonymous_activate_action.py
@@ -4,7 +4,7 @@ from django.contrib import messages
 from django.urls import reverse
 
 from ludamus.adapters.db.django.models import User
-from ludamus.pacts import UserType
+from ludamus.pacts.crowd import UserType
 from tests.integration.utils import assert_response
 
 

--- a/tests/integration/web/chronology/test_event_page.py
+++ b/tests/integration/web/chronology/test_event_page.py
@@ -36,9 +36,9 @@ from ludamus.pacts import (
     PendingSessionDTO,
     SessionDTO,
     SessionFieldValueDTO,
-    UserDTO,
     VirtualEnrollmentConfig,
 )
+from ludamus.pacts.crowd import UserDTO
 from tests.integration.conftest import (
     AgendaItemFactory,
     EventFactory,

--- a/tests/integration/web/chronology/test_proposal_accept_page.py
+++ b/tests/integration/web/chronology/test_proposal_accept_page.py
@@ -22,8 +22,8 @@ from ludamus.pacts import (
     SessionFieldValueDTO,
     SpaceDTO,
     TimeSlotDTO,
-    UserDTO,
 )
+from ludamus.pacts.crowd import UserDTO
 from tests.integration.utils import assert_response
 
 

--- a/tests/integration/web/chronology/test_session_enroll_page.py
+++ b/tests/integration/web/chronology/test_session_enroll_page.py
@@ -19,7 +19,7 @@ from ludamus.adapters.db.django.models import (
     UserEnrollmentConfig,
 )
 from ludamus.adapters.web.django.entities import SessionUserParticipationData
-from ludamus.pacts import UserDTO
+from ludamus.pacts.crowd import UserDTO
 from ludamus.pacts.legacy import NotificationKind
 from tests.integration.conftest import (
     AgendaItemFactory,

--- a/tests/integration/web/chronology/test_session_enrollment_anonymous_page.py
+++ b/tests/integration/web/chronology/test_session_enrollment_anonymous_page.py
@@ -14,7 +14,7 @@ from ludamus.adapters.db.django.models import (
     SessionParticipationStatus,
     User,
 )
-from ludamus.pacts import UserDTO
+from ludamus.pacts.crowd import UserDTO
 from ludamus.pacts.legacy import NotificationKind
 from tests.integration.conftest import AgendaItemFactory, EventFactory, SessionFactory
 from tests.integration.utils import assert_response

--- a/tests/integration/web/crowd/test_profile_avatar_page.py
+++ b/tests/integration/web/crowd/test_profile_avatar_page.py
@@ -5,7 +5,7 @@ from django.urls import reverse
 
 from ludamus.adapters.db.django.models import User
 from ludamus.links.gravatar import gravatar_url
-from ludamus.pacts import UserDTO
+from ludamus.pacts.crowd import UserDTO
 from tests.integration.utils import assert_response
 
 

--- a/tests/integration/web/crowd/test_profile_connected_users_page.py
+++ b/tests/integration/web/crowd/test_profile_connected_users_page.py
@@ -5,7 +5,7 @@ from django.contrib import messages
 from django.urls import reverse
 
 from ludamus.adapters.db.django.models import MAX_CONNECTED_USERS, User
-from ludamus.pacts import UserDTO, UserType
+from ludamus.pacts.crowd import UserDTO, UserType
 from tests.integration.utils import assert_response
 
 

--- a/tests/integration/web/crowd/test_profile_connected_users_update_action.py
+++ b/tests/integration/web/crowd/test_profile_connected_users_update_action.py
@@ -5,7 +5,7 @@ from django.contrib import messages
 from django.urls import reverse
 
 from ludamus.adapters.db.django.models import MAX_CONNECTED_USERS, User
-from ludamus.pacts import UserDTO, UserType
+from ludamus.pacts.crowd import UserDTO, UserType
 from tests.integration.utils import assert_response
 
 

--- a/tests/integration/web/crowd/test_profile_page.py
+++ b/tests/integration/web/crowd/test_profile_page.py
@@ -5,7 +5,7 @@ from django.contrib import messages
 from django.urls import reverse
 
 from ludamus.adapters.db.django.models import User
-from ludamus.pacts import UserDTO, UserType
+from ludamus.pacts.crowd import UserDTO, UserType
 from tests.integration.utils import assert_response
 
 

--- a/tests/integration/web/panel/test_proposals_page.py
+++ b/tests/integration/web/panel/test_proposals_page.py
@@ -18,8 +18,8 @@ from ludamus.pacts import (
     SessionListItemDTO,
     SessionStatus,
     TrackDTO,
-    UserDTO,
 )
+from ludamus.pacts.crowd import UserDTO
 from tests.integration.conftest import UserFactory
 from tests.integration.utils import assert_response
 

--- a/tests/integration/web/panel/test_track_create_page.py
+++ b/tests/integration/web/panel/test_track_create_page.py
@@ -7,7 +7,8 @@ from django.contrib import messages
 from django.urls import reverse
 
 from ludamus.adapters.db.django.models import Space, Track
-from ludamus.pacts import EventDTO, UserDTO
+from ludamus.pacts import EventDTO
+from ludamus.pacts.crowd import UserDTO
 from tests.integration.conftest import SpaceFactory, UserFactory
 from tests.integration.utils import assert_response
 

--- a/tests/integration/web/panel/test_track_edit_page.py
+++ b/tests/integration/web/panel/test_track_edit_page.py
@@ -7,7 +7,8 @@ from django.contrib import messages
 from django.urls import reverse
 
 from ludamus.adapters.db.django.models import Track
-from ludamus.pacts import EventDTO, TrackDTO, UserDTO
+from ludamus.pacts import EventDTO, TrackDTO
+from ludamus.pacts.crowd import UserDTO
 from tests.integration.conftest import SpaceFactory, UserFactory
 from tests.integration.utils import assert_response
 

--- a/tests/unit/adapters/web/django/test_views.py
+++ b/tests/unit/adapters/web/django/test_views.py
@@ -3,7 +3,7 @@ from datetime import UTC, datetime
 from ludamus.adapters.web.django.views import Auth0UserInfo
 from ludamus.gates.web.django.entities import UserInfo
 from ludamus.links.gravatar import gravatar_url
-from ludamus.pacts import UserDTO, UserType
+from ludamus.pacts.crowd import UserDTO, UserType
 
 
 def _make_user_dto(**overrides) -> UserDTO:


### PR DESCRIPTION
Part of #457 (PR-1). Behavior-preserving GLIMPSE strangler move.

## What
Carves the Crowd user-identity cluster out of the catch-all `pacts/legacy.py` into a new `pacts/crowd.py`:
- `UserType`, `UserDTO`, `UserData`, `UserRepositoryProtocol`, `ConnectedUserRepositoryProtocol` (a closed cluster — they only depend on each other + stdlib/pydantic).
- All **26 import sites** (14 src + 12 tests) updated to import the moved names directly from `ludamus.pacts.crowd`; no re-exports added to `pacts/__init__.py` (direct imports are the project convention).

## Why
Unblocks the Party membership feature (its DTOs get a home next to the user contracts) and advances Refactor 3 (retire the `legacy.py` facades). `pacts` stays the bottom layer.

## Verification
- `lint-imports`: 7 contracts kept, 0 broken
- `pytest --collect-only`: 2315 tests, no import errors
- `ruff` + `mypy` on changed files: clean
- `pytest tests/unit`: 515 passed
- No `noqa`/type-ignore added.

## Merge note
Interacts with **PR-2** (#467, moves the user repos into `links/db/django/crowd.py`): whichever merges second needs a one-line rebase so `links/crowd.py` sources the user contracts from `ludamus.pacts.crowd`. Also note the Party branch (#433) adds its own `pacts/crowd.py` (claim contracts) — the two additions combine cleanly on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_017YQfLmJnXQuqYWoHN49pyo)_