### PR TITLE
refactor(mills): move enrollment logic out of mills/legacy.py

### DIFF
--- a/src/ludamus/adapters/web/django/forms.py
+++ b/src/ludamus/adapters/web/django/forms.py
@@ -20,7 +20,7 @@ from ludamus.adapters.db.django.models import (
     get_used_slots,
     get_vc_available_slots,
 )
-from ludamus.mills import get_user_enrollment_config
+from ludamus.mills.enrollment import get_user_enrollment_config
 from ludamus.pacts import (
     EnrollmentConfigRepositoryProtocol,
     EventDTO,

--- a/src/ludamus/adapters/web/django/views.py
+++ b/src/ludamus/adapters/web/django/views.py
@@ -58,8 +58,8 @@ from ludamus.gates.web.django.entities import (
     UserInfo,
 )
 from ludamus.gates.web.django.helpers import placeholder_cover_url
-from ludamus.mills import (
-    AcceptProposalService,
+from ludamus.mills import AcceptProposalService
+from ludamus.mills.enrollment import (
     AnonymousEnrollmentService,
     get_user_enrollment_config,
 )

--- a/src/ludamus/mills/enrollment.py
+++ b/src/ludamus/mills/enrollment.py
@@ -9,9 +9,18 @@ logic stays unit-testable with fakes.
 from __future__ import annotations
 
 import secrets
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
+from secrets import token_urlsafe
 from typing import TYPE_CHECKING
 
+from ludamus.pacts import (
+    MembershipAPIError,
+    UserData,
+    UserDTO,
+    UserEnrollmentConfigData,
+    UserType,
+    VirtualEnrollmentConfig,
+)
 from ludamus.pacts.enrollment import (
     ClaimResult,
     NavbarNotificationsDTO,
@@ -23,6 +32,14 @@ from ludamus.pacts.legacy import PromotionMode
 from ludamus.specs.enrollment import select_promotable_parties
 
 if TYPE_CHECKING:
+    from ludamus.pacts import (
+        EnrollmentConfigDTO,
+        EnrollmentConfigRepositoryProtocol,
+        EventDTO,
+        TicketAPIProtocol,
+        UserEnrollmentConfigDTO,
+        UserRepositoryProtocol,
+    )
     from ludamus.pacts.enrollment import (
         NotificationReadRepositoryProtocol,
         OfferDTO,
@@ -207,3 +224,159 @@ class NotificationsService:
     def mark_all_read(self, user_id: int) -> None:
         with self._transaction.atomic():
             self._notifications.mark_all_read(user_id)
+
+
+class AnonymousEnrollmentService:
+    SLUG_TEMPLATE = "code_{code}"
+
+    def __init__(self, user_repository: UserRepositoryProtocol) -> None:
+        self._user_repository = user_repository
+
+    def get_user_by_code(self, code: str) -> UserDTO:
+        slug = self.SLUG_TEMPLATE.format(code=code)
+        user = self._user_repository.read(slug)
+        return UserDTO.model_validate(user)
+
+    def build_user(self, code: str) -> UserData:
+        return UserData(
+            username=f"anon_{token_urlsafe(8).lower()}",
+            slug=self.SLUG_TEMPLATE.format(code=code),
+            user_type=UserType.ANONYMOUS,
+            is_active=False,
+        )
+
+
+def _refresh_user_config_from_api(
+    *,
+    user_config: UserEnrollmentConfigDTO,
+    ticket_api: TicketAPIProtocol,
+    enrollment_config_repo: EnrollmentConfigRepositoryProtocol,
+) -> UserEnrollmentConfigDTO | None:
+    try:
+        membership_count = ticket_api.fetch_membership_count(user_config.user_email)
+    except MembershipAPIError:
+        return user_config
+
+    current_time = datetime.now(tz=UTC)
+
+    if membership_count == 0:
+        user_config.allowed_slots = 0
+        user_config.last_check = current_time
+        enrollment_config_repo.update_user_config(user_config)
+        return None
+
+    user_config.allowed_slots = membership_count
+    user_config.last_check = current_time
+    enrollment_config_repo.update_user_config(user_config)
+    return user_config
+
+
+def _create_user_config_from_api(
+    *,
+    enrollment_config: EnrollmentConfigDTO,
+    user_email: str,
+    ticket_api: TicketAPIProtocol,
+    enrollment_config_repo: EnrollmentConfigRepositoryProtocol,
+) -> UserEnrollmentConfigDTO | None:
+
+    try:
+        membership_count = ticket_api.fetch_membership_count(user_email)
+    except MembershipAPIError:
+        return None
+
+    current_time = datetime.now(tz=UTC)
+    return enrollment_config_repo.create_user_config(
+        UserEnrollmentConfigData(
+            enrollment_config_id=enrollment_config.pk,
+            user_email=user_email,
+            allowed_slots=membership_count,
+            fetched_from_api=True,
+            last_check=current_time,
+        )
+    )
+
+
+def get_or_create_user_enrollment_config(  # noqa: PLR0913
+    *,
+    enrollment_config: EnrollmentConfigDTO,
+    user_email: str,
+    ticket_api: TicketAPIProtocol,
+    check_interval_minutes: int,
+    existing_user_config: UserEnrollmentConfigDTO | None,
+    enrollment_config_repo: EnrollmentConfigRepositoryProtocol,
+) -> UserEnrollmentConfigDTO | None:
+    if existing_user_config:
+        if existing_user_config.allowed_slots > 0:
+            return existing_user_config
+
+        time_threshold = datetime.now(tz=UTC) - timedelta(
+            minutes=check_interval_minutes
+        )
+
+        if (
+            not existing_user_config.last_check
+            or existing_user_config.last_check < time_threshold
+        ):
+            return _refresh_user_config_from_api(
+                user_config=existing_user_config,
+                ticket_api=ticket_api,
+                enrollment_config_repo=enrollment_config_repo,
+            )
+
+        return None
+
+    return _create_user_config_from_api(
+        enrollment_config=enrollment_config,
+        user_email=user_email,
+        ticket_api=ticket_api,
+        enrollment_config_repo=enrollment_config_repo,
+    )
+
+
+def get_user_enrollment_config(
+    *,
+    event: EventDTO,
+    user_email: str,
+    enrollment_config_repo: EnrollmentConfigRepositoryProtocol,
+    ticket_api: TicketAPIProtocol,
+    check_interval_minutes: int,
+) -> VirtualEnrollmentConfig | None:
+    virtual_config = VirtualEnrollmentConfig()
+
+    now = datetime.now(tz=UTC)
+    for config in enrollment_config_repo.read_list(
+        event.pk, max_start_time=now, min_end_time=now
+    ):
+        existing_user_config = enrollment_config_repo.read_user_config(
+            config, user_email
+        )
+        if api_user_config := get_or_create_user_enrollment_config(
+            enrollment_config=config,
+            user_email=user_email,
+            ticket_api=ticket_api,
+            check_interval_minutes=check_interval_minutes,
+            existing_user_config=existing_user_config,
+            enrollment_config_repo=enrollment_config_repo,
+        ):
+            virtual_config.allowed_slots += api_user_config.allowed_slots
+            virtual_config.has_user_config = True
+        elif existing_user_config:
+            virtual_config.allowed_slots += existing_user_config.allowed_slots
+            virtual_config.has_user_config = True
+
+        email_domain = (
+            user_email.split("@")[1] if (user_email and "@" in user_email) else ""
+        )
+        if email_domain and (
+            domain_config := enrollment_config_repo.read_domain_config(
+                config, email_domain
+            )
+        ):
+            virtual_config.allowed_slots += domain_config.allowed_slots_per_user
+            virtual_config.has_domain_config = True
+
+    return (
+        virtual_config
+        if (virtual_config.has_user_config or virtual_config.has_domain_config)
+        else None
+    )

--- a/src/ludamus/mills/legacy.py
+++ b/src/ludamus/mills/legacy.py
@@ -1,7 +1,6 @@
 import string
-from datetime import UTC, datetime, timedelta
+from datetime import UTC, datetime
 from secrets import choice as _secret_choice
-from secrets import token_urlsafe
 from typing import TYPE_CHECKING
 from urllib.parse import urlencode
 
@@ -18,15 +17,12 @@ from ludamus.pacts import (
     EncounterDTO,
     EncounterIndexItem,
     EncounterIndexResult,
-    EnrollmentConfigDTO,
-    EnrollmentConfigRepositoryProtocol,
     EventDTO,
     EventStatsData,
     FacilitatorData,
     FacilitatorDTO,
     FacilitatorMergeError,
     HostPersonalDataEntry,
-    MembershipAPIError,
     NotFoundError,
     PanelStatsDTO,
     PersonalFieldRequirementDTO,
@@ -39,18 +35,10 @@ from ludamus.pacts import (
     SessionFieldValueData,
     SessionStatus,
     SessionUpdateData,
-    TicketAPIProtocol,
     TimeSlotRequirementDTO,
     TrackDTO,
     UnitOfWorkProtocol,
     UploadedFileProtocol,
-    UserData,
-    UserDTO,
-    UserEnrollmentConfigData,
-    UserEnrollmentConfigDTO,
-    UserRepositoryProtocol,
-    UserType,
-    VirtualEnrollmentConfig,
     WizardData,
 )
 from ludamus.specs.encounter import ENCOUNTER_DEFAULT_DURATION
@@ -485,26 +473,6 @@ def check_proposal_rate_limit(cache: CacheProtocol, ip: str, event_id: int) -> b
     return True
 
 
-class AnonymousEnrollmentService:
-    SLUG_TEMPLATE = "code_{code}"
-
-    def __init__(self, user_repository: UserRepositoryProtocol) -> None:
-        self._user_repository = user_repository
-
-    def get_user_by_code(self, code: str) -> UserDTO:
-        slug = self.SLUG_TEMPLATE.format(code=code)
-        user = self._user_repository.read(slug)
-        return UserDTO.model_validate(user)
-
-    def build_user(self, code: str) -> UserData:
-        return UserData(
-            username=f"anon_{token_urlsafe(8).lower()}",
-            slug=self.SLUG_TEMPLATE.format(code=code),
-            user_type=UserType.ANONYMOUS,
-            is_active=False,
-        )
-
-
 class AcceptProposalService:
     def __init__(
         self, uow: UnitOfWorkProtocol, context: AuthenticatedRequestContext
@@ -638,142 +606,6 @@ class PanelService:
                 break
 
         return errors
-
-
-def _refresh_user_config_from_api(
-    *,
-    user_config: UserEnrollmentConfigDTO,
-    ticket_api: TicketAPIProtocol,
-    enrollment_config_repo: EnrollmentConfigRepositoryProtocol,
-) -> UserEnrollmentConfigDTO | None:
-    try:
-        membership_count = ticket_api.fetch_membership_count(user_config.user_email)
-    except MembershipAPIError:
-        return user_config
-
-    current_time = datetime.now(tz=UTC)
-
-    if membership_count == 0:
-        user_config.allowed_slots = 0
-        user_config.last_check = current_time
-        enrollment_config_repo.update_user_config(user_config)
-        return None
-
-    user_config.allowed_slots = membership_count
-    user_config.last_check = current_time
-    enrollment_config_repo.update_user_config(user_config)
-    return user_config
-
-
-def _create_user_config_from_api(
-    *,
-    enrollment_config: EnrollmentConfigDTO,
-    user_email: str,
-    ticket_api: TicketAPIProtocol,
-    enrollment_config_repo: EnrollmentConfigRepositoryProtocol,
-) -> UserEnrollmentConfigDTO | None:
-
-    try:
-        membership_count = ticket_api.fetch_membership_count(user_email)
-    except MembershipAPIError:
-        return None
-
-    current_time = datetime.now(tz=UTC)
-    return enrollment_config_repo.create_user_config(
-        UserEnrollmentConfigData(
-            enrollment_config_id=enrollment_config.pk,
-            user_email=user_email,
-            allowed_slots=membership_count,
-            fetched_from_api=True,
-            last_check=current_time,
-        )
-    )
-
-
-def get_or_create_user_enrollment_config(  # noqa: PLR0913
-    *,
-    enrollment_config: EnrollmentConfigDTO,
-    user_email: str,
-    ticket_api: TicketAPIProtocol,
-    check_interval_minutes: int,
-    existing_user_config: UserEnrollmentConfigDTO | None,
-    enrollment_config_repo: EnrollmentConfigRepositoryProtocol,
-) -> UserEnrollmentConfigDTO | None:
-    if existing_user_config:
-        if existing_user_config.allowed_slots > 0:
-            return existing_user_config
-
-        time_threshold = datetime.now(tz=UTC) - timedelta(
-            minutes=check_interval_minutes
-        )
-
-        if (
-            not existing_user_config.last_check
-            or existing_user_config.last_check < time_threshold
-        ):
-            return _refresh_user_config_from_api(
-                user_config=existing_user_config,
-                ticket_api=ticket_api,
-                enrollment_config_repo=enrollment_config_repo,
-            )
-
-        return None
-
-    return _create_user_config_from_api(
-        enrollment_config=enrollment_config,
-        user_email=user_email,
-        ticket_api=ticket_api,
-        enrollment_config_repo=enrollment_config_repo,
-    )
-
-
-def get_user_enrollment_config(
-    *,
-    event: EventDTO,
-    user_email: str,
-    enrollment_config_repo: EnrollmentConfigRepositoryProtocol,
-    ticket_api: TicketAPIProtocol,
-    check_interval_minutes: int,
-) -> VirtualEnrollmentConfig | None:
-    virtual_config = VirtualEnrollmentConfig()
-
-    now = datetime.now(tz=UTC)
-    for config in enrollment_config_repo.read_list(
-        event.pk, max_start_time=now, min_end_time=now
-    ):
-        existing_user_config = enrollment_config_repo.read_user_config(
-            config, user_email
-        )
-        if api_user_config := get_or_create_user_enrollment_config(
-            enrollment_config=config,
-            user_email=user_email,
-            ticket_api=ticket_api,
-            check_interval_minutes=check_interval_minutes,
-            existing_user_config=existing_user_config,
-            enrollment_config_repo=enrollment_config_repo,
-        ):
-            virtual_config.allowed_slots += api_user_config.allowed_slots
-            virtual_config.has_user_config = True
-        elif existing_user_config:
-            virtual_config.allowed_slots += existing_user_config.allowed_slots
-            virtual_config.has_user_config = True
-
-        email_domain = (
-            user_email.split("@")[1] if (user_email and "@" in user_email) else ""
-        )
-        if email_domain and (
-            domain_config := enrollment_config_repo.read_domain_config(
-                config, email_domain
-            )
-        ):
-            virtual_config.allowed_slots += domain_config.allowed_slots_per_user
-            virtual_config.has_domain_config = True
-
-    return (
-        virtual_config
-        if (virtual_config.has_user_config or virtual_config.has_domain_config)
-        else None
-    )
 
 
 class FacilitatorMergeService:


### PR DESCRIPTION
Part of #457 (PR-6). Behavior-preserving GLIMPSE strangler move.

## What
Moves enrollment-related business logic out of the catch-all `mills/legacy.py` into the existing `mills/enrollment.py`:
- `AnonymousEnrollmentService`
- `get_or_create_user_enrollment_config`, `get_user_enrollment_config`
- their private helpers `_refresh_user_config_from_api`, `_create_user_config_from_api`

Runtime imports vs annotation-only imports split correctly (the latter under `TYPE_CHECKING`) to satisfy ruff. Dead imports removed from `legacy.py` (verified each was only used by the moved code; `EventDTO` stays — still used by `PanelService`). Two import sites updated (`adapters/web/django/views.py`, `forms.py`); no re-exports added to `mills/__init__.py`. `mills` stays Django-free / pacts+specs-only.

## Why
Puts enrollment-config logic in its canonical module so the Party step-2 slot-accounting rewrite is a local edit rather than surgery on the legacy grab-bag. Advances Refactor 3.

## Verification
- `lint-imports`: 7 contracts kept, 0 broken
- `pytest --collect-only`: 2315 tests, no import errors
- `ruff` + `mypy` on changed files: clean
- `pytest tests/unit -k "enroll or anonymous or mills"`: 222 passed
- `pytest tests/integration -k "anonymous or enroll"`: 212 passed, 3 skipped

Independent of PR-1/PR-2; no expected merge interaction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_017YQfLmJnXQuqYWoHN49pyo)_