### PR TITLE
fix(infra): drop dead synckit trust exclusion

### DIFF
--- a/aube-workspace.yaml
+++ b/aube-workspace.yaml
@@ -1,12 +1,4 @@
 paranoid: true
-# synckit@0.9.3 (pulled transitively via eslint-plugin-mdx@3.2.0, itself from
-# fallow) has no provenance while 0.11.13 does, so paranoid mode rejects it as a
-# trust downgrade and `aube install` / `aubr varlock` fail. Exclude just that one
-# package so installs succeed; every other package keeps the strict
-# no-downgrade policy. Remove once the eslint→mdx→synckit chain is gone
-# (e.g. migrating frontend lint to oxlint).
-trustPolicyExclude:
-  - synckit
 allowBuilds:
   fallow: true
 packages:

--- a/aube-workspace.yaml
+++ b/aube-workspace.yaml
@@ -1,8 +1,14 @@
 paranoid: true
+# synckit@0.9.3 (pulled transitively via eslint-plugin-mdx@3.2.0, itself from
+# fallow) has no provenance while 0.11.13 does, so paranoid mode rejects it as a
+# trust downgrade and `aube install` / `aubr varlock` fail. Exclude just that one
+# package so installs succeed; every other package keeps the strict
+# no-downgrade policy. Remove once the eslint→mdx→synckit chain is gone
+# (e.g. migrating frontend lint to oxlint).
+trustPolicyExclude:
+  - synckit
 allowBuilds:
   fallow: true
 packages:
   - "./src/ludamus/client"
   - "./tests/e2e"
-trustPolicyExclude:
-  - synckit@0.9.3


### PR DESCRIPTION
## What
Removes the `trustPolicyExclude: synckit@0.9.3` block from `aube-workspace.yaml`. Net −2 lines vs main.

## Why
The exclusion is dead config. The `pnpm.overrides` pin to `synckit@0.11.13` in `package.json` (29917a2) removed `synckit@0.9.3` from `aube-lock.yaml` entirely — the only resolved version is 0.11.13, which has provenance attestation — so the paranoid no-downgrade check has nothing left to reject and the exclusion names a coordinate that can no longer resolve.

## History of this PR
The original diff here chased an `ERR_AUBE_TRUST_DOWNGRADE` for `synckit@0.9.3` that was reproduced in a **stale worktree** (pre-override lockfile) and — worse — replaced main's version-scoped `synckit@0.9.3` exclusion with a bare `synckit`, exempting every future synckit version from the trust policy. Review caught both; this is the corrected, narrower-than-main version.

## Verification
On a clean checkout of main with this file:
- `aube install` → 725 packages installed, no trust errors
- `aubr varlock --version` → runs fine

## Note for feature branches
Branches with pre-override lockfiles (e.g. the party branch) will still hit `ERR_AUBE_TRUST_DOWNGRADE` locally until they merge main — the fix there is updating the branch, not re-adding the exclusion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_017YQfLmJnXQuqYWoHN49pyo)_