### PR TITLE
Attach the RSVP copy-collapse observer once at init, not per click

### DIFF
--- a/src/ludamus/templates/notice_board/detail.html
+++ b/src/ludamus/templates/notice_board/detail.html
@@ -340,20 +340,17 @@
             // Copying is handled by copy.ts, which reveals the popover only on a
             // successful write and hides it again when the feedback is done.
             // Collapse the save prompt at that hide — so never on a failed copy,
-            // and without duplicating copy.ts's timing here.
-            document.addEventListener('click', function(e) {
-                var btn = e.target.closest('.rsvp-save-prompt [data-copy]');
-                if (!btn) return;
-                var popover = btn.querySelector('[data-copy-popover]');
-                if (!popover) return;
-                var card = btn.closest('.card');
-                var observer = new MutationObserver(function() {
+            // and without duplicating copy.ts's timing here. One observer per
+            // popover, attached up front like the other prompt wiring, so
+            // repeated clicks can't stack observers (#476). data-show only ever
+            // mutates on success, and its removal marks the feedback's end.
+            document.querySelectorAll('.rsvp-save-prompt [data-copy] [data-copy-popover]').forEach(function(popover) {
+                var card = popover.closest('.card');
+                new MutationObserver(function() {
                     if (popover.dataset.show === undefined) {
-                        observer.disconnect();
                         collapseSavePrompt(card);
                     }
-                });
-                observer.observe(popover, { attributes: true, attributeFilter: ['data-show'] });
+                }).observe(popover, { attributes: true, attributeFilter: ['data-show'] });
             });
             document.querySelectorAll('.calendar-menu a').forEach(function(link) {
                 link.addEventListener('click', function() {


### PR DESCRIPTION
Closes #476 — follow-up to #471 (the final review's remaining nit).

## What & why

Every click on the RSVP save-prompt copy button in `notice_board/detail.html` created a fresh `MutationObserver` on the button's confirmation popover. On success the stack self-healed (all observers fired, disconnected, called the idempotent collapse), but when copies **permanently fail** (plain-HTTP deploy — `data-show` never mutates) each click leaked one live observer, unbounded.

## How

Delete the per-click mechanism instead of guarding it: attach **one observer per popover at init**, like the rest of the save-prompt wiring in the same script block (the prompt content is static on this page). `data-show` only ever mutates on a *successful* copy, and its removal (feedback done) is the collapse signal.

Behaviour is unchanged:
- failed/unavailable copies never collapse the prompt,
- a successful copy shows "Copied!" first and collapses to "Saved" only after the feedback ends,
- a restored prompt collapses again on the next successful copy (the observer no longer disconnects — it doesn't need to).

No visual change (behaviour-only JS in an existing script block).

## Verification

- Simulated both paths in Chromium against the real compiled `copy.ts`: 3 repeated **rejected** copies → prompt stays visible (and no observers can stack); **successful** copy → popover shows "Copied!" mid-feedback with the prompt still visible, then the prompt collapses and "Saved" appears.
- `djlint` clean; 60 notice-board/encounter integration tests pass; the copy-flow e2e (`notice-board.auth.spec.ts`) covers the shared handler.

Not folded in: the duplicated `copy_lines` payload nit from the same review (two uses; rule-of-three — tracked in #476's notes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01QqAtjTzvrQ9cEZxpTz2deb)_