### PR TITLE
fix(enrollment): let a selected companion be deselected before submitting

### DIFF
--- a/src/ludamus/locale/pl/LC_MESSAGES/django.po
+++ b/src/ludamus/locale/pl/LC_MESSAGES/django.po
@@ -563,6 +563,7 @@ msgstr ""
 "być Twoim prawdziwym imieniem."
 
 #: src/ludamus/adapters/web/django/forms.py
+#: src/ludamus/templates/chronology/enroll_select.html
 msgid "No change"
 msgstr "Bez zmian"
 

--- a/src/ludamus/templates/chronology/enroll_select.html
+++ b/src/ludamus/templates/chronology/enroll_select.html
@@ -98,6 +98,7 @@
                                     <tr class="border-b border-border bg-bg-tertiary">
                                         <th class="text-left px-3 py-2 font-medium">{% translate "User" %}</th>
                                         <th class="text-left px-3 py-2 font-medium">{% translate "Current Status" %}</th>
+                                        <th class="text-center px-3 py-2 font-medium">{% translate "No change" %}</th>
                                         <th class="text-center px-3 py-2 font-medium">{% translate "Enroll" %}</th>
                                         <th class="text-center px-3 py-2 font-medium">{% translate "Join Waiting List" %}</th>
                                         <th class="text-center px-3 py-2 font-medium">{% translate "Cancel" %}</th>
@@ -127,6 +128,15 @@
                                                 {% else %}
                                                     <span class="inline-flex items-center rounded-full bg-bg-tertiary px-2.5 py-0.5 text-xs font-medium">{% translate "Available" %}</span>
                                                 {% endif %}
+                                            </td>
+                                            <td class="px-3 py-2.5 text-center">
+                                                <input type="radio"
+                                                       class="accent-foreground-muted"
+                                                       name="user_{{ user_data.user.pk }}"
+                                                       id="user_{{ user_data.user.pk }}_no_change"
+                                                       aria-label="{% translate "No change" %}: {{ user_data.user.full_name }}"
+                                                       value=""
+                                                       checked>
                                             </td>
                                             <td class="px-3 py-2.5 text-center">
                                                 {% if not user_data.user_enrolled and not user_data.user_waiting %}
@@ -172,7 +182,7 @@
                                     {% endfor %}
                                     {% if user_data|length == 1 %}
                                         <tr>
-                                            <td colspan="5" class="text-center text-foreground-muted py-4 text-sm">
+                                            <td colspan="6" class="text-center text-foreground-muted py-4 text-sm">
                                                 {% translate "No connected users available. You can add connected users in your" %}
                                                 <a href="{% url 'web:crowd:profile-connected-users' %}"
                                                    class="text-primary hover:underline">{% translate "profile settings" %}</a>.

--- a/tests/integration/web/chronology/test_session_enroll_page.py
+++ b/tests/integration/web/chronology/test_session_enroll_page.py
@@ -65,6 +65,73 @@ class TestSessionEnrollPageView:
             template_name="chronology/enroll_select.html",
         )
 
+    def test_get_renders_default_checked_no_change_radio_per_row(
+        self, active_user, connected_user, authenticated_client, agenda_item
+    ):
+        connected_user.name = "Connected Person"
+        connected_user.save()
+        SessionParticipation.objects.create(
+            user=connected_user,
+            session=agenda_item.session,
+            status=SessionParticipationStatus.CONFIRMED,
+        )
+
+        response = authenticated_client.get(
+            self._get_url(agenda_item.session.pk, agenda_item.session.event.slug)
+        )
+
+        assert_response(
+            response,
+            HTTPStatus.OK,
+            context_data={
+                "connected_users": [UserDTO.model_validate(connected_user)],
+                "event": agenda_item.space.event,
+                "form": ANY,
+                "session": agenda_item.session,
+                "shadowban_warnings": [],
+                "user_data": [
+                    SessionUserParticipationData(
+                        user=UserDTO.model_validate(active_user),
+                        user_enrolled=False,
+                        user_waiting=False,
+                        has_time_conflict=False,
+                    ),
+                    SessionUserParticipationData(
+                        user=UserDTO.model_validate(connected_user),
+                        user_enrolled=True,
+                        user_waiting=False,
+                        has_time_conflict=False,
+                    ),
+                ],
+            },
+            template_name="chronology/enroll_select.html",
+        )
+        content = " ".join(response.content.decode().split())
+        for user in (active_user, connected_user):
+            assert (
+                f'name="user_{user.pk}" id="user_{user.pk}_no_change" '
+                f'aria-label="No change: {user.full_name}" value="" checked' in content
+            )
+
+    @pytest.mark.usefixtures("enrollment_config")
+    def test_post_no_change_value_leaves_user_unenrolled(
+        self, connected_user, agenda_item, authenticated_client
+    ):
+        response = authenticated_client.post(
+            self._get_url(agenda_item.session.pk, agenda_item.session.event.slug),
+            data={f"user_{connected_user.id}": ""},
+        )
+
+        assert_response(
+            response,
+            HTTPStatus.FOUND,
+            messages=[(messages.WARNING, "Please select at least one user to enroll.")],
+            url=self._get_url(agenda_item.session.pk, agenda_item.session.event.slug),
+        )
+        assert not SessionParticipation.objects.filter(
+            user=connected_user, session=agenda_item.session
+        ).exists()
+
     @pytest.mark.usefixtures("enrollment_config")
     def test_get_offered_participation_only_offers_decline(
         self, active_user, authenticated_client, agenda_item


### PR DESCRIPTION
## The bug

Production user report:

> Jeżeli ma się dodatkowych graczy do zapisywania i już się kliknie ich raz, to nie można odkliknąć. Można tylko ich zapisać lub dodać na listę oczekujących ale nie da się całkiem usunąć oznaczenia ich.

The enrollment table (`chronology/enroll_select.html`) rendered each person's `user_` radio group with only the Enroll/Waitlist columns (Cancel for already-enrolled people). HTML radios cannot be unchecked, so once you clicked anything for a connected user there was no way back to "leave this person alone" before submitting — a classic radio trap. The backend form has accepted an empty `("", "No change")` choice all along (`_build_user_choices` in `src/ludamus/adapters/web/django/forms.py`); the template just never rendered it.

## The fix

- Add a "No change" column to the table, rendering a default-checked radio with `value=""` in every row — consistent for both not-yet-enrolled rows and enrolled/waiting rows, so any selection can be undone.
- The new radio uses a neutral `accent-foreground-muted` so the action columns keep their existing color coding (`accent-success` / `accent-warning` / `accent-danger`), and carries an `aria-label` like the existing inputs.
- Bump the "no connected users" row's `colspan` from 5 to 6.
- "No change" was already translated ("Bez zmian"); the PL catalog only gains the new template location, no new strings.

`anonymous_enroll.html` was checked for the same pattern — it has no radio table, so no change needed there.

## Screenshot

Every row starts on the default-checked "No change" — any Enroll/Waitlist click can now be undone before submitting:

![enrollment table with the No change column](https://raw.githubusercontent.com/zagrajmy/ludamus/shots/pr-488/enroll-no-change.png)

_(Image lives on the temporary `shots/pr-488` branch — delete it after merge.)_

## Tests

New integration tests in `tests/integration/web/chronology/test_session_enroll_page.py`:

- `test_get_renders_default_checked_no_change_radio_per_row` — the page renders a default-checked no-change radio for both an available row and an already-enrolled row.
- `test_post_no_change_value_leaves_user_unenrolled` — POSTing the empty value performs no action and leaves the user unenrolled.

Full suite: 2381 passed, 7 skipped. `djlint src --profile=django` (0 errors), `black --check`, `ruff check` (no new findings), `pylint -sn` on the touched test file all clean. `makemessages` drift check reproduced only the known issue #487 flag-stripping; `python-brace-format` flag count stays at 8.

A thermo-nuclear code-quality review of this diff returned APPROVE; POST parity of the missing-key vs empty-string cases was verified against `forms.py`/`views.py` (`required=False` + truthiness gate), and the deeper template/form choice-matrix duplication it surfaced is filed as a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_017YQfLmJnXQuqYWoHN49pyo)_