### PR TITLE
Add audit logging for MCP tool calls

### DIFF
--- a/docs/agents/mcp.md
+++ b/docs/agents/mcp.md
@@ -76,3 +76,7 @@ don't get re-derived or contradicted:
 
 Domain errors need no new plumbing: `NotFoundError` and invalid arguments
 already map to MCP `isError` results, and unknown tools to JSON-RPC errors.
+
+Every `tools/call` is audit-logged **with its arguments verbatim**. Do not add
+a tool whose arguments carry personal data without adding redaction to the
+audit line first.

--- a/src/ludamus/gates/mcp/protocol.py
+++ b/src/ludamus/gates/mcp/protocol.py
@@ -73,8 +73,7 @@ def _call_tool(
     params: JsonDict,
 ) -> JsonDict:
     name = params.get("name")
-    arguments = params.get("arguments")
-    if arguments is None:
+    if (arguments := params.get("arguments")) is None:
         arguments = {}
     outcome, response = _run_tool(
         registry=registry,
@@ -85,8 +84,10 @@ def _call_tool(
     )
     # Audit trail (#480): one line per tools/call. Only the actor id is
     # threaded in on purpose; a richer actor context is #481.
+    # %r on client-controlled values: repr escapes newlines, so a crafted
+    # tool name cannot inject fake audit lines.
     logger.info(
-        "mcp.tools_call user_id=%s tool=%s outcome=%s arguments=%s",
+        "mcp.tools_call user_id=%s tool=%r outcome=%s arguments=%r",
         actor_id,
         name,
         outcome,

--- a/src/ludamus/gates/mcp/protocol.py
+++ b/src/ludamus/gates/mcp/protocol.py
@@ -73,7 +73,9 @@ def _call_tool(
     params: JsonDict,
 ) -> JsonDict:
     name = params.get("name")
-    arguments = params.get("arguments") or {}
+    arguments = params.get("arguments")
+    if arguments is None:
+        arguments = {}
     outcome, response = _run_tool(
         registry=registry,
         services=services,

--- a/src/ludamus/gates/mcp/protocol.py
+++ b/src/ludamus/gates/mcp/protocol.py
@@ -8,6 +8,7 @@ self-contained, which is all a tool-only server needs.
 
 from __future__ import annotations
 
+import logging
 from typing import TYPE_CHECKING
 
 from ludamus.gates.mcp.registry import ToolError, UnknownToolError
@@ -25,6 +26,8 @@ PARSE_ERROR = -32700
 INVALID_REQUEST = -32600
 METHOD_NOT_FOUND = -32601
 INVALID_PARAMS = -32602
+
+logger = logging.getLogger(__name__)
 
 type JsonDict = dict[str, object]
 
@@ -65,13 +68,41 @@ def _call_tool(
     *,
     registry: ToolRegistry,
     services: ServicesProtocol,
+    actor_id: int,
     message_id: object,
     params: JsonDict,
 ) -> JsonDict:
     name = params.get("name")
     arguments = params.get("arguments") or {}
+    outcome, response = _run_tool(
+        registry=registry,
+        services=services,
+        message_id=message_id,
+        name=name,
+        arguments=arguments,
+    )
+    # Audit trail (#480): one line per tools/call. Only the actor id is
+    # threaded in on purpose; a richer actor context is #481.
+    logger.info(
+        "mcp.tools_call user_id=%s tool=%s outcome=%s arguments=%s",
+        actor_id,
+        name,
+        outcome,
+        arguments,
+    )
+    return response
+
+
+def _run_tool(
+    *,
+    registry: ToolRegistry,
+    services: ServicesProtocol,
+    message_id: object,
+    name: object,
+    arguments: object,
+) -> tuple[str, JsonDict]:
     if not isinstance(name, str) or not isinstance(arguments, dict):
-        return error_response(
+        return "invalid-params", error_response(
             message_id=message_id,
             code=INVALID_PARAMS,
             message="Invalid tool call params",
@@ -79,20 +110,26 @@ def _call_tool(
     try:
         text = registry.call(services=services, name=name, arguments=arguments)
     except UnknownToolError:
-        return error_response(
+        return "unknown-tool", error_response(
             message_id=message_id, code=INVALID_PARAMS, message=f"Unknown tool: {name}"
         )
     except NotFoundError:
-        return _text_result(
+        return "error", _text_result(
             message_id=message_id, text="Resource not found", is_error=True
         )
     except ToolError as error:
-        return _text_result(message_id=message_id, text=str(error), is_error=True)
-    return _text_result(message_id=message_id, text=text, is_error=False)
+        return "error", _text_result(
+            message_id=message_id, text=str(error), is_error=True
+        )
+    return "ok", _text_result(message_id=message_id, text=text, is_error=False)
 
 
 def handle_message(
-    *, registry: ToolRegistry, services: ServicesProtocol, message: JsonDict
+    *,
+    registry: ToolRegistry,
+    services: ServicesProtocol,
+    actor_id: int,
+    message: JsonDict,
 ) -> JsonDict | None:
     method = message.get("method")
     message_id = message.get("id")
@@ -119,6 +156,7 @@ def handle_message(
             return _call_tool(
                 registry=registry,
                 services=services,
+                actor_id=actor_id,
                 message_id=message_id,
                 params=params,
             )

--- a/src/ludamus/gates/web/django/mcp/views.py
+++ b/src/ludamus/gates/web/django/mcp/views.py
@@ -67,7 +67,7 @@ class McpEndpointView(View):
 
     @staticmethod
     def post(request: RootRequest) -> HttpResponse:
-        if _authenticated_superuser_id(request) is None:
+        if (actor_id := _authenticated_superuser_id(request)) is None:
             response = JsonResponse(
                 {"error": "A valid maintainer Bearer token is required."}, status=401
             )
@@ -94,7 +94,10 @@ class McpEndpointView(View):
             )
 
         result = handle_message(
-            registry=_REGISTRY, services=request.services, message=message
+            registry=_REGISTRY,
+            services=request.services,
+            actor_id=actor_id,
+            message=message,
         )
         if result is None:
             return HttpResponse(status=202)

--- a/tests/integration/web/mcp/test_mcp_endpoint.py
+++ b/tests/integration/web/mcp/test_mcp_endpoint.py
@@ -412,7 +412,7 @@ class TestAudit:
             {"sphere_id": sphere.pk},
         )
         assert records[0].getMessage() == (
-            f"mcp.tools_call user_id={superuser.pk} tool=get_sphere outcome=ok "
+            f"mcp.tools_call user_id={superuser.pk} tool='get_sphere' outcome=ok "
             f"arguments={{'sphere_id': {sphere.pk}}}"
         )
 

--- a/tests/integration/web/mcp/test_mcp_endpoint.py
+++ b/tests/integration/web/mcp/test_mcp_endpoint.py
@@ -280,6 +280,23 @@ class TestTools:
             "message": "Unknown tool: drop_database",
         }
 
+    def test_falsy_non_dict_arguments_are_invalid(self, client, token):
+        response = post_message(
+            client,
+            {
+                "jsonrpc": "2.0",
+                "id": 1,
+                "method": "tools/call",
+                "params": {"name": "list_spheres", "arguments": []},
+            },
+            token=token,
+        )
+
+        assert response.json()["error"] == {
+            "code": -32602,
+            "message": "Invalid tool call params",
+        }
+
     def test_invalid_arguments(self, client, token):
         response = call_tool(client, token, "get_sphere", {})
 

--- a/tests/integration/web/mcp/test_mcp_endpoint.py
+++ b/tests/integration/web/mcp/test_mcp_endpoint.py
@@ -1,4 +1,5 @@
 import json
+import logging
 from http import HTTPStatus
 
 import pytest
@@ -370,3 +371,62 @@ class TestTools:
         )
 
         assert json.loads(tool_text(response)) == []
+
+
+AUDIT_LOGGER = "ludamus.gates.mcp.protocol"
+
+
+def audit_records(caplog):
+    return [record for record in caplog.records if record.name == AUDIT_LOGGER]
+
+
+class TestAudit:
+    def test_successful_call_is_logged(self, client, token, superuser, sphere, caplog):
+        caplog.set_level(logging.INFO, logger=AUDIT_LOGGER)
+
+        call_tool(client, token, "get_sphere", {"sphere_id": sphere.pk})
+
+        records = audit_records(caplog)
+        assert len(records) == 1
+        assert records[0].args == (
+            superuser.pk,
+            "get_sphere",
+            "ok",
+            {"sphere_id": sphere.pk},
+        )
+        assert records[0].getMessage() == (
+            f"mcp.tools_call user_id={superuser.pk} tool=get_sphere outcome=ok "
+            f"arguments={{'sphere_id': {sphere.pk}}}"
+        )
+
+    def test_unknown_tool_is_logged(self, client, token, superuser, caplog):
+        caplog.set_level(logging.INFO, logger=AUDIT_LOGGER)
+
+        call_tool(client, token, "drop_database", {"force": True})
+
+        records = audit_records(caplog)
+        assert len(records) == 1
+        assert records[0].args == (
+            superuser.pk,
+            "drop_database",
+            "unknown-tool",
+            {"force": True},
+        )
+
+    def test_invalid_arguments_are_logged_as_error(
+        self, client, token, superuser, caplog
+    ):
+        caplog.set_level(logging.INFO, logger=AUDIT_LOGGER)
+
+        call_tool(client, token, "get_sphere", {})
+
+        records = audit_records(caplog)
+        assert len(records) == 1
+        assert records[0].args == (superuser.pk, "get_sphere", "error", {})
+
+    def test_other_methods_are_not_logged(self, client, token, caplog):
+        caplog.set_level(logging.INFO, logger=AUDIT_LOGGER)
+
+        post_message(client, {"jsonrpc": "2.0", "id": 1, "method": "ping"}, token=token)
+
+        assert audit_records(caplog) == []


### PR DESCRIPTION
Closes #480. Part of the MCP/agents epic #486; first PR of a stack (#481 follows on top).

## What

One structured log line per `tools/call` on the maintainer MCP endpoint — the server-side audit trail that so far existed only in the client's (Executor's) logs:

```
mcp.tools_call user_id=7 tool=get_sphere outcome=ok arguments={'sphere_id': 1}
```

- Outcome classified as `ok` / `error` / `unknown-tool` / `invalid-params`; other JSON-RPC methods (`ping`, `tools/list`, …) are not logged.
- The authenticated user id is threaded from the auth layer into the protocol handler as a plain `actor_id: int` — deliberately not the full `ActorContext` from #481, which lands in the next PR of this stack.
- Logging with lazy `%` args under the `ludamus.gates.mcp.protocol` logger; per the issue, log-file-only for now (no model, no migration), promote to a queryable model only if we need it.

## Testing

Four new integration tests assert the audit record's exact fields via `caplog`: success case, unknown tool, invalid arguments, and that non-tool methods stay silent. Full gauntlet green locally: black, ruff, mypy strict (protocol.py has no relaxations), pylint 10/10, import-linter 7/7, 557 tests.

## Screenshots

No UI change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SY4mun2DMQgKzBv6gRnk8R

---
_Generated by [Claude Code](https://claude.ai/code/session_01SY4mun2DMQgKzBv6gRnk8R)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added audit logging for every JSON-RPC `tools/call`, recording caller ID, tool name, outcome, and provided arguments.
  * Tool execution now receives the authenticated caller’s ID for improved traceability.

* **Bug Fixes**
  * Rejected invalid tool arguments as proper JSON-RPC errors and ensured consistent error mapping for unknown/missing tools.

* **Tests**
  * Extended MCP endpoint integration tests to verify exactly one audit log entry for tool calls (success, unknown tool, invalid arguments) and none for non-tool methods.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->