### PR TITLE
Give the copy popover a real entrance and a clean exit

### DIFF
--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -31,8 +31,13 @@ fi
 # python, markdownlint-cli2, ...) on PATH for every shell in the session, so
 # tools resolve directly instead of needing `mise exec`/activation per command.
 # Persisted for the session via CLAUDE_ENV_FILE.
+#
+# PREPEND, don't append: mise inserts its managed paths (incl. the .venv
+# activation from `_.python.venv`) at the shims' position in PATH. Appended
+# shims put the venv after the container's bare /usr/local/bin/python, and
+# every `mise run` task fails with "No module named 'django'".
 if [ -n "${CLAUDE_ENV_FILE:-}" ]; then
-  echo "export PATH=\"\$PATH:$HOME/.local/share/mise/shims\"" >> "$CLAUDE_ENV_FILE"
+  echo "export PATH=\"$HOME/.local/share/mise/shims:\$PATH\"" >> "$CLAUDE_ENV_FILE"
 fi
 
 # Installs are best-effort: a blocked dependency (e.g. a registry trust gate)

--- a/src/ludamus/adapters/web/django/templatetags/tessera/copy.py
+++ b/src/ludamus/adapters/web/django/templatetags/tessera/copy.py
@@ -19,12 +19,17 @@ from .icon import icon as render_icon
 # writes its label and toggles `data-show` on a successful copy; the CSS fades /
 # scales it in. It's an aria-live region so screen readers hear the confirmation.
 # Styled after the graphql-hive docs heading copy-link popover.
+# Entrance (300ms spring, rises 2px) is slower than the exit (150ms ease-out):
+# the confirmation should land with some presence, the cleanup should get out
+# of the way. The un-prefixed duration/ease govern the exit — they are what's
+# in effect once `data-show` is gone.
 _POPOVER_CLASS = (
     "pointer-events-none absolute bottom-full left-1/2 z-10 mb-2 -translate-x-1/2 "
     "whitespace-nowrap rounded-md bg-bg-secondary px-2 py-1 text-xs font-medium "
     "tracking-[0.01em] text-foreground shadow-(--shadow-card) ring-1 ring-border "
-    "opacity-0 scale-90 transition duration-150 ease-out "
-    "data-[show]:opacity-100 data-[show]:scale-100"
+    "origin-bottom opacity-0 scale-90 translate-y-0.5 transition duration-150 ease-out "
+    "data-[show]:opacity-100 data-[show]:scale-100 data-[show]:translate-y-0 "
+    "data-[show]:duration-300 data-[show]:ease-spring-a-bit"
 )
 
 

--- a/src/ludamus/client/src/copy.ts
+++ b/src/ludamus/client/src/copy.ts
@@ -5,11 +5,28 @@
 // On success a `[data-copy-popover]` child confirms the copy without resizing
 // the button (it's absolute + pointer-events-none). The popover is an aria-live
 // region: writing its label on success announces it to screen readers, clearing
-// it on hide stops it re-announcing. An unavailable clipboard (insecure context)
-// or a rejected write shows nothing rather than a false confirmation.
+// it once the fade-out ends stops it re-announcing. An unavailable clipboard
+// (insecure context) or a rejected write shows nothing rather than a false
+// confirmation.
 
 const FEEDBACK_MS = 1500;
 const timers = new WeakMap<HTMLElement, number>();
+
+const hidePopover = (popover: HTMLElement): void => {
+  delete popover.dataset.show;
+  // Keep the label through the fade-out — clearing it up front collapses the
+  // popover to an empty pill and the exit reads as a glitch, not a fade. It
+  // still must be cleared afterwards so the next copy re-announces on the
+  // aria-live region. The guard covers a re-copy mid-fade: the entrance's own
+  // transitionend consumes the listener while the popover is back on show.
+  popover.addEventListener(
+    "transitionend",
+    () => {
+      if (popover.dataset.show === undefined) popover.textContent = "";
+    },
+    { once: true },
+  );
+};
 
 const confirmCopy = (button: HTMLElement): void => {
   const popover = button.querySelector<HTMLElement>("[data-copy-popover]");
@@ -21,8 +38,7 @@ const confirmCopy = (button: HTMLElement): void => {
   timers.set(
     button,
     globalThis.setTimeout(() => {
-      delete popover.dataset.show;
-      popover.textContent = "";
+      hidePopover(popover);
       timers.delete(button);
     }, FEEDBACK_MS),
   );


### PR DESCRIPTION
## Summary

The "Copied!" popover was technically animated but read as "just appears": the 150ms entrance ran on the strong `--ease-out` curve, so it was ~44% done after one frame and ~90% done by 60ms. Worse, the exit cleared the label in the same tick it started, so the fade-out ran on an empty pill and the text blinked out.

## Key changes

- **Entrance** (`tessera/copy.py`): 300ms on the `spring-a-bit` ease, rising 2px from below (`translate-y-0.5 → 0`) and scaling from the popover's bottom edge (`origin-bottom`, the side facing the button). The un-prefixed `duration-150 ease-out` still governs the exit, so the confirmation lands with presence and the cleanup gets out of the way.
- **Exit** (`client/src/copy.ts`): the label now stays through the fade-out and is cleared on `transitionend`, keeping the aria-live re-announcement behavior. A guard covers re-copying mid-fade.
- **Session hook** (`.claude/hooks/session-start.sh`): prepend mise shims to PATH instead of appending. mise inserts its managed paths (including the `.venv` activation) at the shims' position, so appended shims left the venv behind the container's bare `/usr/local/bin/python` and every `mise run` task failed with "No module named 'django'".

## Verification

Frame-by-frame sampling of the popover's computed style via Playwright against the `/design/` page (a still screenshot can't capture motion):

- Entrance: opacity 0→1, `translate` 2px→−0.2px→0 and `scale` 0.9→1.01→1 (spring overshoot, settling at ~310ms), `transform-origin` at bottom center.
- Exit: label persists through the full 150ms fade (opacity 1→0 with "Copied!" visible), cleared right after `transitionend`.

Full test suite passes (2379 passed, 7 skipped); `mise run check` is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EgpTB6USVaLetNze2mhPcJ