### PR TITLE
Silence factory_boy postgeneration deprecation warnings

### DIFF
--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -70,6 +70,8 @@ class UserFactory(DjangoModelFactory):
     class Meta:
         model = User
         django_get_or_create = ("username",)
+        # The manager hook only creates rows; the user needs no second save.
+        skip_postgeneration_save = True
 
     username = Faker("user_name")
     email = Faker("email")


### PR DESCRIPTION
Backlog item from the MCP-stack reviews (recorded on #486).

## What

`skip_postgeneration_save = True` on `UserFactory`. Its only postgeneration hook (`manager` → `sponsor_user`) creates `Party`/`PartyMembership` rows and never mutates the user instance, so the second save it suppresses was already a no-op.

## Why

The suite emitted ~1,800 `DeprecationWarning: UserFactory._after_postgeneration will stop saving the instance...` lines. This is also factory_boy 4.x's future default, so we're aligned ahead of the upgrade.

## Testing

Full suite: 2533 passed, 7 skipped, **zero warnings** (previously ~1,820).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SY4mun2DMQgKzBv6gRnk8R

---
_Generated by [Claude Code](https://claude.ai/code/session_01SY4mun2DMQgKzBv6gRnk8R)_