### PR TITLE
Distinguish invalid-arguments in the MCP audit trail; rename organizer token view

### DIFF
--- a/src/ludamus/gates/mcp/protocol.py
+++ b/src/ludamus/gates/mcp/protocol.py
@@ -11,7 +11,11 @@ from __future__ import annotations
 import logging
 from typing import TYPE_CHECKING, Literal
 
-from ludamus.gates.mcp.registry import ToolError, UnknownToolError
+from ludamus.gates.mcp.registry import (
+    InvalidArgumentsError,
+    ToolError,
+    UnknownToolError,
+)
 from ludamus.pacts import NotFoundError
 
 if TYPE_CHECKING:
@@ -31,7 +35,9 @@ INVALID_PARAMS = -32602
 logger = logging.getLogger(__name__)
 
 type JsonDict = dict[str, object]
-type ToolOutcome = Literal["ok", "error", "invalid-params", "unknown-tool"]
+type ToolOutcome = Literal[
+    "ok", "error", "invalid-arguments", "invalid-params", "unknown-tool"
+]
 
 
 def error_response(*, message_id: object, code: int, message: str) -> JsonDict:
@@ -120,6 +126,8 @@ def _run_tool(
         )
     except UnknownToolError:
         return "unknown-tool", f"Unknown tool: {name}"
+    except InvalidArgumentsError as error:
+        return "invalid-arguments", str(error)
     except NotFoundError:
         return "error", "Resource not found"
     except ToolError as error:

--- a/src/ludamus/gates/mcp/registry.py
+++ b/src/ludamus/gates/mcp/registry.py
@@ -29,6 +29,10 @@ class ToolError(Exception):
     """Tool failure reported to the MCP client as an `isError` result."""
 
 
+class InvalidArgumentsError(ToolError):
+    """Arguments failed the tool's input-model validation."""
+
+
 class UnknownToolError(Exception):
     pass
 
@@ -79,7 +83,7 @@ class Tool[InputT: BaseModel](ToolProtocol, ABC):
                 for item in error.errors()
             )
             message = f"Invalid arguments: {details}"
-            raise ToolError(message) from error
+            raise InvalidArgumentsError(message) from error
         return self.handle(ToolCall(services=services, actor=actor, data=data))
 
     @staticmethod

--- a/src/ludamus/gates/web/django/multiverse/panel/urls.py
+++ b/src/ludamus/gates/web/django/multiverse/panel/urls.py
@@ -33,7 +33,7 @@ urlpatterns = [
         announcements.AnnouncementDeletePageView.as_view(),
         name="announcement-delete",
     ),
-    path("mcp/", mcp_token.McpTokenPageView.as_view(), name="mcp-token"),
+    path("mcp/", mcp_token.OrganizerMcpTokenPageView.as_view(), name="mcp-token"),
     path("connections/", connections.ConnectionsPageView.as_view(), name="connections"),
     path(
         "connections/create/",

--- a/src/ludamus/gates/web/django/multiverse/panel/views/mcp_token.py
+++ b/src/ludamus/gates/web/django/multiverse/panel/views/mcp_token.py
@@ -21,7 +21,7 @@ if TYPE_CHECKING:
 TEMPLATE = "multiverse/panel/mcp-token.html"
 
 
-class McpTokenPageView(SphereAccessMixin, View):
+class OrganizerMcpTokenPageView(SphereAccessMixin, View):
     request: MultiverseRequest
 
     def get(self, _request: MultiverseRequest) -> HttpResponse:

--- a/tests/integration/web/mcp/test_mcp_endpoint.py
+++ b/tests/integration/web/mcp/test_mcp_endpoint.py
@@ -435,7 +435,7 @@ class TestAudit:
             {"force": True},
         )
 
-    def test_invalid_arguments_are_logged_as_error(
+    def test_invalid_arguments_are_logged_distinctly(
         self, client, token, superuser, caplog
     ):
         caplog.set_level(logging.INFO, logger=AUDIT_LOGGER)
@@ -449,7 +449,7 @@ class TestAudit:
             "maintainer",
             None,
             "get_sphere",
-            "error",
+            "invalid-arguments",
             {},
         )
 


### PR DESCRIPTION
Two backlog items from the MCP-stack thermo reviews (recorded on #486). Part of epic #486.

## What

- **Audit granularity**: pydantic validation failures previously logged `outcome=error`, indistinguishable from domain errors. `InvalidArgumentsError(ToolError)` now surfaces them as `outcome=invalid-arguments` in the audit line. Client-facing behavior is byte-identical (same `isError` result, same message) — only the audit attribution changes.
- **Name collision ended**: the organizer panel view is now `OrganizerMcpTokenPageView`; the maintainer page keeps `McpTokenPageView`. Tracebacks and greps read unambiguously again.

## Testing

Audit test updated to assert the new outcome (`test_invalid_arguments_are_logged_distinctly`); all client-behavior tests pass unchanged, proving the response contract didn't move. 665 MCP/multiverse/unit tests green; mypy strict, pylint (message-grep), ruff, import-linter clean.

## Screenshots

No UI change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SY4mun2DMQgKzBv6gRnk8R

---
_Generated by [Claude Code](https://claude.ai/code/session_01SY4mun2DMQgKzBv6gRnk8R)_