### PR TITLE
Format party-feature templates with djlint

### DIFF
--- a/src/ludamus/templates/chronology/enroll_select.html
+++ b/src/ludamus/templates/chronology/enroll_select.html
@@ -112,9 +112,7 @@
                             {% endfor %}
                         </div>
                         {% if selected_party %}
-                            <p class="text-xs text-foreground-muted mt-2">
-                                {% translate "The party moves up the waiting list together." %}
-                            </p>
+                            <p class="text-xs text-foreground-muted mt-2">{% translate "The party moves up the waiting list together." %}</p>
                         {% endif %}
                     </div>
                 {% endif %}

--- a/src/ludamus/templates/chronology/offer_claim.html
+++ b/src/ludamus/templates/chronology/offer_claim.html
@@ -17,9 +17,7 @@
             </div>
             <div class="card-body">
                 {# Flow-neutral copy: this page serves both waitlist offers and seats a party leader held. #}
-                <p>
-                    {% translate "A seat is being held for you. Claim it before the deadline below or it will be released." %}
-                </p>
+                <p>{% translate "A seat is being held for you. Claim it before the deadline below or it will be released." %}</p>
                 <p>
                     <strong>{% translate "Claim by:" %}</strong> {{ offer.offer_expires_at|date:"DATETIME_FORMAT" }}
                 </p>

--- a/src/ludamus/templates/crowd/user/parties.html
+++ b/src/ludamus/templates/crowd/user/parties.html
@@ -208,14 +208,10 @@
                                                         {% csrf_token %}
                                                         {% if row.member.consent_mode == "accept_invites" %}
                                                             <input type="hidden" name="mode" value="accept_by_default">
-                                                            <button type="submit" class="btn btn-secondary btn-sm">
-                                                                {% translate "Allow direct enrollment" %}
-                                                            </button>
+                                                            <button type="submit" class="btn btn-secondary btn-sm">{% translate "Allow direct enrollment" %}</button>
                                                         {% else %}
                                                             <input type="hidden" name="mode" value="accept_invites">
-                                                            <button type="submit" class="btn btn-secondary btn-sm">
-                                                                {% translate "Require my approval" %}
-                                                            </button>
+                                                            <button type="submit" class="btn btn-secondary btn-sm">{% translate "Require my approval" %}</button>
                                                         {% endif %}
                                                     </form>
                                                 {% elif entry.party.is_leader and not row.member.is_leader and not row.member.is_login_less %}
@@ -301,7 +297,8 @@
                                             {% translate "Invite a member" %}
                                         </summary>
                                         <div class="mt-3">
-                                            <form action="{% url 'web:crowd:parties-invite' pk=entry.party.pk %}" method="post">
+                                            <form action="{% url 'web:crowd:parties-invite' pk=entry.party.pk %}"
+                                                  method="post">
                                                 {% csrf_token %}
                                                 {% tessera_form entry.invite_form %}
                                                 <button type="submit" class="btn btn-secondary">{% translate "Send invite" %}</button>


### PR DESCRIPTION
CI-unbreak: `offer_claim.html`, `parties.html`, and `enroll_select.html` landed unformatted with the party PRs (#494–#496), so the `checks` job (djlint via hk) fails for **every** open PR — #502's failure was this, not its own diff.

Pure `djlint --reformat --format-css --format-js` output, 3 files, +6/−13. Repo-wide `djlint --check` and lint verified clean after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SY4mun2DMQgKzBv6gRnk8R

---
_Generated by [Claude Code](https://claude.ai/code/session_01SY4mun2DMQgKzBv6gRnk8R)_