### PR TITLE
Fix unreadable native select popup in dark mode

### DIFF
--- a/src/ludamus/client/src/index.css
+++ b/src/ludamus/client/src/index.css
@@ -558,6 +558,20 @@ button:active {
   }
 }
 
+/*
+ * Chromium paints the native <select> popup with the element's computed
+ * background-color, not the page's color-scheme: Tailwind preflight makes form
+ * controls transparent, which composites the popup over white — in dark mode
+ * that means near-white option text on a white popup. An explicit background
+ * restores a readable popup in both themes. Kept in @layer base so bg-*
+ * utilities on individual selects still win.
+ */
+@layer base {
+  select {
+    background-color: var(--color-bg-secondary);
+  }
+}
+
 /* Select dropdown chevron fix */
 select:not([multiple]):not([size]) {
   appearance: none;


### PR DESCRIPTION
## Problem

In dark mode, native `<select>` dropdowns (e.g. the proposal filter bar on `/panel/.../proposals`) opened a **white popup with near-white option text** — options were unreadable.

`color-scheme: dark` was *not* missing: `.dark { color-scheme: dark }` is present and the select computes `color-scheme: dark`. The real cause: **Chromium paints the select popup with the element's computed `background-color`**, and Tailwind preflight sets form controls to `background-color: transparent`, which composites the popup over white regardless of color-scheme. Selects that carry a `bg-*` utility (like the tessera select component's `bg-bg-secondary`) were unaffected — only bare ones (`filter-input`) broke.

## Fix

One base-layer rule in `index.css`:

```css
@layer base {
  select {
    background-color: var(--color-bg-secondary);
  }
}
```

- `--color-bg-secondary` matches the filter card the broken selects sit on, so closed controls look unchanged.
- `@layer base` keeps per-select `bg-*` utilities winning (verified: `bg-neutral-800` still overrides).
- Light theme resolves to the light token, so light-mode popups are unaffected.

## Verification

Reproduced and verified in headed Chromium under Xvfb against the built CSS (same content hash production serves):

- Before: white popup, invisible light-gray options.
- After: dark popup (`#171717`), readable white option text; light theme still correct; utility-class overrides intact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M1c9VfQLpvFk1fGVWPPfn1

---
_Generated by [Claude Code](https://claude.ai/code/session_01M1c9VfQLpvFk1fGVWPPfn1)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the default styling for dropdown menus so native select options stay readable in Chromium across light and dark themes.
  * Ensured select-specific background utilities can still override the default appearance when needed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->