### PR TITLE
Install hk git hooks explicitly in the session-start hook

### DIFF
--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -48,6 +48,12 @@ mise install || echo "WARN: 'mise install' failed; some tools may be unavailable
 mise bootstrap packages apply --yes || echo "WARN: 'mise bootstrap packages apply' failed"
 mise run bootstrap || echo "WARN: 'mise run bootstrap' failed; JS deps/build may be unavailable"
 
+# `mise run bootstrap` already runs `hk install --mise`, but only after
+# poetry/aube installs that can fail in restricted sandboxes. Git hooks must be
+# installed in every session regardless, so install them explicitly too
+# (idempotent — hk rewrites .git/hooks in place).
+mise exec -- hk install --mise || echo "WARN: 'hk install' failed; git hooks not installed"
+
 # Playwright backs the e2e suite and `aubx agent-browser` screenshots; both
 # share the Chromium it provisions.
 mise run test:e2e:install \


### PR DESCRIPTION
Answering "is hk pre-commit always installed in Claude sessions?" — it was **wired but fragile**: SessionStart → `mise run bootstrap` → `hk install --mise` (tasks.toml:77), so hook installation only happened if the poetry/aube install steps before it survived, and until #530 the installed hooks crashed on the pkl-package download anyway.

This adds an explicit, idempotent `mise exec -- hk install --mise` line to `.claude/hooks/session-start.sh` (with the same best-effort `|| WARN` shape as its neighbors), so every session gets working pre-commit/commit-msg hooks even when part of the bootstrap chain fails.

Verified live in this sandboxed session: the commit on this branch was made **with hooks enabled** — the full pre-commit sweep (large-files, merge-conflict, private-key, EOF, varlock, trailing-whitespace) and gitlint on commit-msg all executed and passed, no `--no-verify`. shellcheck clean.

---
_Generated by [Claude Code](https://claude.ai/code/session_0197EVF9UR68hJf8GU2xqCiK)_