### PR TITLE
Regenerate PL catalog: canonical position for reused msgid

### DIFF
--- a/src/ludamus/locale/pl/LC_MESSAGES/django.po
+++ b/src/ludamus/locale/pl/LC_MESSAGES/django.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-07-05 21:27+0200\n"
+"POT-Creation-Date: 2026-07-05 22:31+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -1321,6 +1321,11 @@ msgid "Note"
 msgstr "Notatka"
 
 #: src/ludamus/gates/web/django/chronology/panel/views/discounts.py
+#: src/ludamus/gates/web/django/multiverse/panel/views/connections.py
+msgid "Connection not found."
+msgstr "Połączenie nie zostało znalezione."
+
+#: src/ludamus/gates/web/django/chronology/panel/views/discounts.py
 #, python-format
 msgid "Export failed: %(hint)s"
 msgstr "Eksport nie powiódł się: %(hint)s"
@@ -1329,10 +1334,14 @@ msgstr "Eksport nie powiódł się: %(hint)s"
 #, python-format
 msgid "Accreditation sheet exported (%(count)d creator)."
 msgid_plural "Accreditation sheet exported (%(count)d creators)."
-msgstr[0] "Arkusz akredytacji został wyeksportowany (%(count)d twórca programu)."
-msgstr[1] "Arkusz akredytacji został wyeksportowany (%(count)d twórców programu)."
-msgstr[2] "Arkusz akredytacji został wyeksportowany (%(count)d twórców programu)."
-msgstr[3] "Arkusz akredytacji został wyeksportowany (%(count)d twórcy programu)."
+msgstr[0] ""
+"Arkusz akredytacji został wyeksportowany (%(count)d twórca programu)."
+msgstr[1] ""
+"Arkusz akredytacji został wyeksportowany (%(count)d twórców programu)."
+msgstr[2] ""
+"Arkusz akredytacji został wyeksportowany (%(count)d twórców programu)."
+msgstr[3] ""
+"Arkusz akredytacji został wyeksportowany (%(count)d twórcy programu)."
 
 #: src/ludamus/gates/web/django/chronology/panel/views/event_settings.py
 msgid "allowed"
@@ -2334,10 +2343,6 @@ msgstr "Ogłoszenie zostało usunięte."
 #: src/ludamus/gates/web/django/multiverse/panel/views/connections.py
 msgid "A connection with this display name already exists."
 msgstr "Połączenie o tej nazwie wyświetlanej już istnieje."
-
-#: src/ludamus/gates/web/django/multiverse/panel/views/connections.py
-msgid "Connection not found."
-msgstr "Połączenie nie zostało znalezione."
 
 #: src/ludamus/gates/web/django/multiverse/panel/views/connections.py
 msgid "Connection created successfully."
@@ -5546,8 +5551,8 @@ msgid ""
 "Writes every creator with their accreditation type and discount into the "
 "first tab of the selected spreadsheet, replacing its current content."
 msgstr ""
-"Zapisuje wszystkich twórców programu wraz z rodzajem akredytacji i zniżką "
-"do pierwszej zakładki wybranego arkusza, zastępując jego obecną zawartość."
+"Zapisuje wszystkich twórców programu wraz z rodzajem akredytacji i zniżką do "
+"pierwszej zakładki wybranego arkusza, zastępując jego obecną zawartość."
 
 #: src/ludamus/templates/panel/discounts/export.html
 msgid ""


### PR DESCRIPTION
Fixes the red `checks` job on `main` (and by extension #532, which branches from it).

## Root cause

The #529 review fix added `_("Connection not found.")` to the discounts export view, reusing the msgid that already existed for the connections panel. `makemessages` then wants the entry at its canonical position with **merged source references** (both `discounts.py` and `connections.py`), and rewraps two long msgstr blocks — so the committed catalog no longer matched a fresh extraction and `mise run messages-check` failed.

## Fix

`mise run messages` output committed verbatim: entry repositioned with merged refs, mechanical line rewrapping, POT-Creation-Date bump. **No translation content changes** — every msgstr string is byte-identical, only placement and wrapping moved.

## Validation

- `mise run messages-check` — "1493 translated messages. Translations fresh: extraction current, all messages translated."

---
_Generated by [Claude Code](https://claude.ai/code/session_0197EVF9UR68hJf8GU2xqCiK)_