### PR TITLE
refactor(mills): enrollment service + slot-math relocation

### DIFF
--- a/docs/refactors/glimpse-strangler.md
+++ b/docs/refactors/glimpse-strangler.md
@@ -56,6 +56,16 @@ Already migrated into `gates/`: the whole **Panel** (chronology + multiverse),
 - Encounters fully in `gates` + `links` + `mills`/`pacts`.
 - Panel views split into one file per area under
   `gates/web/django/chronology/panel/views/`.
+- Enrollment slot math (`get_used_slots`, `can_enroll_users`,
+  `get_vc_available_slots`) moved out of `adapters/db/django/models.py` into
+  `mills/enrollment.py`, with the ORM query behind
+  `EnrollmentParticipationRepositoryProtocol`
+  (`links/db/django/enrollment.py`). An `EnrollmentService` now lives on
+  `request.services.enrollment`; `SessionEnrollPageView` and
+  `create_enrollment_form` run on it and no longer touch `request.di`
+  (issue #457, PR-7). The view's transactional enrollment batch
+  (`_process_enrollments` and friends) still uses the ORM directly and moves
+  into the service together with the view's relocation to `gates/`.
 
 ## Next step
 

--- a/src/ludamus/adapters/db/django/models.py
+++ b/src/ludamus/adapters/db/django/models.py
@@ -22,7 +22,6 @@ from ludamus.pacts import (
     SessionParticipationStatus,
     SessionStatus,
     SpherePage,
-    VirtualEnrollmentConfig,
 )
 from ludamus.pacts.crowd import UserType
 from ludamus.pacts.discounts import DiscountKind
@@ -32,7 +31,6 @@ from ludamus.pacts.submissions import ImportLogStatus
 if TYPE_CHECKING:
     from collections.abc import Collection, Iterator
 
-    from ludamus.pacts import EventDTO
     from ludamus.pacts.crowd import UserDTO
 
 
@@ -1634,52 +1632,6 @@ class FacilitatorChangeLog(models.Model):
 
     def __str__(self) -> str:
         return f"edit {self.facilitator} by {self.user}"
-
-
-def can_enroll_users(
-    *,
-    users: list[UserDTO],
-    event: EventDTO,
-    virtual_config: VirtualEnrollmentConfig,
-    users_to_enroll: list[UserDTO],
-) -> bool:
-    # Get currently enrolled users (CONFIRMED + OFFERED both hold a slot)
-    currently_enrolled = set(
-        SessionParticipation.objects.filter(
-            status__in=OCCUPYING_PARTICIPATION_STATUSES,
-            user_id__in=[u.pk for u in users],
-            session__event_id=event.pk,
-        )
-        .values_list("user_id", flat=True)
-        .distinct()
-    )
-
-    # Add new users to enroll
-    users_to_enroll_ids = {u.pk for u in users_to_enroll}
-    total_enrolled = currently_enrolled | users_to_enroll_ids
-
-    return len(total_enrolled) <= virtual_config.allowed_slots
-
-
-def get_used_slots(users: list[UserDTO], event: EventDTO) -> int:
-    # Count unique users who hold at least one seat (confirmed or offered)
-    return len(
-        SessionParticipation.objects.filter(
-            status__in=OCCUPYING_PARTICIPATION_STATUSES,
-            user_id__in=[u.pk for u in users],
-            session__event_id=event.pk,
-        )
-        .values_list("user", flat=True)
-        .distinct()
-    )
-
-
-def get_vc_available_slots(
-    *, users: list[UserDTO], event: EventDTO, virtual_config: VirtualEnrollmentConfig
-) -> int:
-    return max(
-        0, virtual_config.allowed_slots - get_used_slots(users=users, event=event)
-    )
 
 
 class Connection(models.Model):

--- a/src/ludamus/adapters/web/django/forms.py
+++ b/src/ludamus/adapters/web/django/forms.py
@@ -6,7 +6,6 @@ from datetime import UTC, datetime
 from typing import TYPE_CHECKING, Any, cast
 
 from django import forms
-from django.conf import settings
 from django.core.exceptions import ValidationError
 from django.utils.translation import gettext as _
 
@@ -17,21 +16,14 @@ from ludamus.adapters.db.django.models import (
     SessionParticipationStatus,
     Space,
     TimeSlot,
-    can_enroll_users,
-    get_used_slots,
-    get_vc_available_slots,
 )
-from ludamus.mills.enrollment import get_user_enrollment_config
-from ludamus.pacts import (
-    EnrollmentConfigRepositoryProtocol,
-    EventDTO,
-    TicketAPIProtocol,
-    VirtualEnrollmentConfig,
-)
+from ludamus.pacts import EventDTO, VirtualEnrollmentConfig
 from ludamus.pacts.crowd import UserData, UserDTO, UserType
 
 if TYPE_CHECKING:
-    from collections.abc import Callable, Iterable
+    from collections.abc import Callable
+
+    from ludamus.pacts.enrollment import EnrollmentServiceProtocol
 
 
 TODAY = datetime.now(tz=UTC).date()
@@ -224,16 +216,15 @@ class _UserEnrollmentChoiceField(forms.ChoiceField):
 
 def _make_enrollment_clean(
     *,
-    current_user: UserDTO,
-    connected_users: Iterable[UserDTO],
+    all_users: list[UserDTO],
     enrollment_config: EnrollmentConfig | None,
     current_user_enrollment_config: VirtualEnrollmentConfig | None,
     field_to_user_name: dict[str, str],
+    enrollment: EnrollmentServiceProtocol,
 ) -> Callable[..., dict[str, Any] | None]:
     # Only user_* fields count against the membership slot cap: +N guests are
     # walk-ins without memberships, so they intentionally bypass it — the
     # session capacity check still gates them.
-    all_users = [current_user, *connected_users]
 
     def clean(self: forms.Form) -> dict[str, Any] | None:
         if not (cleaned_data := forms.Form.clean(self)):
@@ -252,7 +243,7 @@ def _make_enrollment_clean(
             and enrollment_config
             and enrollment_config.restrict_to_configured_users
             and current_user_enrollment_config
-            and not can_enroll_users(
+            and not enrollment.can_enroll_users(
                 users=all_users,
                 event=EventDTO.model_validate(enrollment_config.event),
                 virtual_config=current_user_enrollment_config,
@@ -260,8 +251,8 @@ def _make_enrollment_clean(
             )
         ):
             event = EventDTO.model_validate(enrollment_config.event)
-            used_slots = get_used_slots(users=all_users, event=event)
-            available_slots = get_vc_available_slots(
+            used_slots = enrollment.get_used_slots(users=all_users, event=event)
+            available_slots = enrollment.get_vc_available_slots(
                 users=all_users,
                 event=event,
                 virtual_config=current_user_enrollment_config,
@@ -381,16 +372,11 @@ def create_enrollment_form(
     session: Session,
     current_user: UserDTO,
     roster: EnrollmentRoster,
-    enrollment_config_repo: EnrollmentConfigRepositoryProtocol,
-    ticket_api: TicketAPIProtocol,
+    enrollment: EnrollmentServiceProtocol,
 ) -> type[forms.Form]:
     enrollment_config = session.event.get_most_liberal_config(session)
-    current_user_enrollment_config = get_user_enrollment_config(
-        event=EventDTO.model_validate(session.event),
-        user_email=current_user.email,
-        enrollment_config_repo=enrollment_config_repo,
-        ticket_api=ticket_api,
-        check_interval_minutes=settings.MEMBERSHIP_API_CHECK_INTERVAL,
+    current_user_enrollment_config = enrollment.virtual_config(
+        event=EventDTO.model_validate(session.event), user_email=current_user.email
     )
     user_can_enroll = bool(
         enrollment_config
@@ -479,11 +465,11 @@ def create_enrollment_form(
     # viewer and their sponsored companions count against it — a real member's
     # seat spends that member's allowance, not the enroller's.
     clean = _make_enrollment_clean(
-        current_user=current_user,
-        connected_users=roster.companions,
+        all_users=[current_user, *roster.companions],
         enrollment_config=enrollment_config,
         current_user_enrollment_config=current_user_enrollment_config,
         field_to_user_name=field_to_user_name,
+        enrollment=enrollment,
     )
 
     if roster.guest_count is not None:

--- a/src/ludamus/adapters/web/django/views.py
+++ b/src/ludamus/adapters/web/django/views.py
@@ -73,7 +73,6 @@ from ludamus.gates.web.django.helpers import placeholder_cover_url
 from ludamus.mills import AcceptProposalService
 from ludamus.mills.enrollment import (
     AnonymousEnrollmentService,
-    build_anonymous_user,
     get_user_enrollment_config,
 )
 from ludamus.pacts import (
@@ -1646,16 +1645,15 @@ class SessionEnrollPageView(LoginRequiredMixin, View):
         members = self._party_members(session, selection.selected)
         form = create_enrollment_form(
             session=session,
-            current_user=self.request.di.uow.active_users.read(
-                self.request.context.current_user_slug
+            current_user=request.services.enrollment.read_viewer(
+                request.context.current_user_slug
             ),
             roster=EnrollmentRoster(
                 companions=tuple(selection.companions),
                 members=tuple(members),
                 guest_count=self._guest_count(session),
             ),
-            enrollment_config_repo=request.di.uow.enrollment_configs,
-            ticket_api=request.di.ticket_api,
+            enrollment=request.services.enrollment,
         )()
 
         return TemplateResponse(
@@ -1735,7 +1733,7 @@ class SessionEnrollPageView(LoginRequiredMixin, View):
             return []
         users = {
             user.pk: user
-            for user in self.request.di.uow.active_users.read_by_ids(
+            for user in self.request.services.enrollment.read_users(
                 [member.user_pk for member in eligible]
             )
         }
@@ -1757,18 +1755,9 @@ class SessionEnrollPageView(LoginRequiredMixin, View):
         ]
 
     def _member_has_access(self, session: Session, user: UserDTO) -> bool:
-        # On a restricted event a member's seat spends that member's own
-        # allowance, so a member without slots cannot be seated by the leader.
-        if not user.email:
-            return False
-        config = get_user_enrollment_config(
-            event=EventDTO.model_validate(session.event),
-            user_email=user.email,
-            enrollment_config_repo=self.request.di.uow.enrollment_configs,
-            ticket_api=self.request.di.ticket_api,
-            check_interval_minutes=settings.MEMBERSHIP_API_CHECK_INTERVAL,
+        return self.request.services.enrollment.has_slot_access(
+            event=EventDTO.model_validate(session.event), user_email=user.email
         )
-        return bool(config and config.allowed_slots)
 
     @staticmethod
     def _validate_request(
@@ -1808,7 +1797,7 @@ class SessionEnrollPageView(LoginRequiredMixin, View):
         user_data: list[SessionUserParticipationData] = []
 
         all_users = [
-            self.request.di.uow.active_users.read(
+            self.request.services.enrollment.read_viewer(
                 self.request.context.current_user_slug
             ),
             *companions,
@@ -1888,12 +1877,11 @@ class SessionEnrollPageView(LoginRequiredMixin, View):
         # Initialize form with POST data
         form_class = create_enrollment_form(
             session=session,
-            current_user=self.request.di.uow.active_users.read(
-                self.request.context.current_user_slug
+            current_user=request.services.enrollment.read_viewer(
+                request.context.current_user_slug
             ),
             roster=roster,
-            enrollment_config_repo=request.di.uow.enrollment_configs,
-            ticket_api=request.di.ticket_api,
+            enrollment=request.services.enrollment,
         )
         form = form_class(data=request.POST)
         if not form.is_valid():
@@ -1905,7 +1893,7 @@ class SessionEnrollPageView(LoginRequiredMixin, View):
             # Check for specific enrollment restrictions and provide helpful messages
             enrollment_config = session.event.get_most_liberal_config(session)
             if enrollment_config and enrollment_config.restrict_to_configured_users:
-                if not request.di.uow.active_users.read(
+                if not request.services.enrollment.read_viewer(
                     request.context.current_user_slug
                 ).email:
                     messages.error(
@@ -1913,16 +1901,12 @@ class SessionEnrollPageView(LoginRequiredMixin, View):
                         _("Email address is required for enrollment in this session."),
                     )
                 else:
-                    user_email = request.di.uow.active_users.read(
+                    user_email = request.services.enrollment.read_viewer(
                         request.context.current_user_slug
                     ).email
                     event = session.event
-                    if not get_user_enrollment_config(
-                        event=EventDTO.model_validate(event),
-                        user_email=user_email,
-                        enrollment_config_repo=request.di.uow.enrollment_configs,
-                        ticket_api=request.di.ticket_api,
-                        check_interval_minutes=settings.MEMBERSHIP_API_CHECK_INTERVAL,
+                    if not request.services.enrollment.virtual_config(
+                        event=EventDTO.model_validate(event), user_email=user_email
                     ):
                         messages.error(
                             self.request,
@@ -1973,7 +1957,7 @@ class SessionEnrollPageView(LoginRequiredMixin, View):
             *(
                 RosterMember(user=user)
                 for user in (
-                    self.request.di.uow.active_users.read(
+                    self.request.services.enrollment.read_viewer(
                         self.request.context.current_user_slug
                     ),
                     *roster.companions,
@@ -2195,7 +2179,7 @@ class SessionEnrollPageView(LoginRequiredMixin, View):
             )
 
     def _actor_name(self) -> str:
-        return self.request.di.uow.active_users.read(
+        return self.request.services.enrollment.read_viewer(
             self.request.context.current_user_slug
         ).full_name
 
@@ -2378,23 +2362,13 @@ class SessionEnrollPageView(LoginRequiredMixin, View):
     def _create_guests(
         self, *, session: Session, count: int, party_pk: int | None
     ) -> None:
-        users = self.request.di.uow.anonymous_users
-        viewer_name = self.request.di.uow.active_users.read(
-            self.request.context.current_user_slug
-        ).full_name
-        for _i in range(count):
-            user_data = build_anonymous_user(
-                f"guest-{token_urlsafe(8).lower()}", name=f"{viewer_name} +1"
-            )
-            users.create(user_data)
-            guest = users.read(user_data["slug"])
-            SessionParticipation.objects.create(
-                session=session,
-                user_id=guest.pk,
-                status=SessionParticipationStatus.CONFIRMED,
-                party_id=party_pk,
-                enrolled_by_id=self.request.context.current_user_id,
-            )
+        self.request.services.enrollment.create_guests(
+            session_id=session.pk,
+            count=count,
+            party_id=party_pk,
+            enrolled_by_id=self.request.context.current_user_id,
+            viewer_name=self._actor_name(),
+        )
 
 
 class ProposalAcceptPageView(LoginRequiredMixin, View):

--- a/src/ludamus/inits/repositories.py
+++ b/src/ludamus/inits/repositories.py
@@ -4,14 +4,18 @@ from ludamus.links.db.django import repositories
 from ludamus.links.db.django.agenda_item import AgendaItemRepository
 from ludamus.links.db.django.bookmarks import BookmarkRepository
 from ludamus.links.db.django.content_change_log import ContentChangeLogRepository
-from ludamus.links.db.django.crowd import ClaimRepository
-from ludamus.links.db.django.enrollment import ParticipationPromotionRepository
+from ludamus.links.db.django.crowd import ClaimRepository, UserRepository
+from ludamus.links.db.django.enrollment import (
+    EnrollmentParticipationRepository,
+    ParticipationPromotionRepository,
+)
 from ludamus.links.db.django.facilitator_change_log import (
     FacilitatorChangeLogRepository,
 )
 from ludamus.links.db.django.notifications import NotificationReadRepository
 from ludamus.links.db.django.party import PartyRepository
 from ludamus.links.db.django.safety import EventBanRepository, ShadowbanRepository
+from ludamus.pacts.crowd import UserType
 
 
 class Repositories:
@@ -73,6 +77,22 @@ class Repositories:
     @cached_property
     def participation_promotion(self) -> ParticipationPromotionRepository:
         return ParticipationPromotionRepository()
+
+    @cached_property
+    def enrollment_participations(self) -> EnrollmentParticipationRepository:
+        return EnrollmentParticipationRepository()
+
+    @cached_property
+    def enrollment_configs(self) -> repositories.EnrollmentConfigRepository:
+        return repositories.EnrollmentConfigRepository()
+
+    @cached_property
+    def active_users(self) -> UserRepository:
+        return UserRepository(user_type=UserType.ACTIVE)
+
+    @cached_property
+    def anonymous_users(self) -> UserRepository:
+        return UserRepository(user_type=UserType.ANONYMOUS)
 
     @cached_property
     def notifications(self) -> NotificationReadRepository:

--- a/src/ludamus/inits/services.py
+++ b/src/ludamus/inits/services.py
@@ -13,6 +13,7 @@ from ludamus.links.db.django.schedule_change_log import ScheduleChangeLogReposit
 from ludamus.links.encryption import FernetDecryptor, FernetEncryptor
 from ludamus.links.google_docs import GoogleDocsProposalImporter, GoogleSheetsWriter
 from ludamus.links.scheduler import CronSweepOfferScheduler
+from ludamus.links.ticket_api import MembershipApiClient
 from ludamus.mills.bookmarks import BookmarkService
 from ludamus.mills.chronology import (
     EventIntegrationsService,
@@ -24,7 +25,11 @@ from ludamus.mills.chronology import (
 )
 from ludamus.mills.crowd import ClaimService
 from ludamus.mills.discounts import DiscountsExportService, DiscountsService
-from ludamus.mills.enrollment import NotificationsService, WaitlistPromotionService
+from ludamus.mills.enrollment import (
+    EnrollmentService,
+    NotificationsService,
+    WaitlistPromotionService,
+)
 from ludamus.mills.multiverse import (
     AnnouncementsService,
     ConnectionsService,
@@ -44,6 +49,7 @@ from ludamus.mills.submissions.personal_data_fields import (
 )
 from ludamus.mills.venues import SpaceTreeService, VenuesService
 from ludamus.pacts.chronology import IntegrationImplementationId
+from ludamus.pacts.enrollment import EnrollmentRepos
 from ludamus.pacts.submissions import ImportRepos
 
 if TYPE_CHECKING:
@@ -197,6 +203,21 @@ class Services:
     @cached_property
     def notifications(self) -> NotificationsService:
         return NotificationsService(self._transaction, self._repos.notifications)
+
+    @cached_property
+    def enrollment(self) -> EnrollmentService:
+        membership_check_interval: int = settings.MEMBERSHIP_API_CHECK_INTERVAL
+        return EnrollmentService(
+            transaction=self._transaction,
+            repos=EnrollmentRepos(
+                users=self._repos.active_users,
+                anonymous_users=self._repos.anonymous_users,
+                enrollment_configs=self._repos.enrollment_configs,
+                participations=self._repos.enrollment_participations,
+                ticket_api=MembershipApiClient(),
+            ),
+            membership_check_interval=membership_check_interval,
+        )
 
     @cached_property
     def shadowban(self) -> ShadowbanService:

--- a/src/ludamus/links/db/django/enrollment.py
+++ b/src/ludamus/links/db/django/enrollment.py
@@ -18,13 +18,13 @@ from ludamus.adapters.db.django.models import (
     SessionParticipation,
     User,
     UserEnrollmentConfig,
-    get_used_slots,
 )
 from ludamus.links.db.django.companions import active_companions, sponsors_by_member
-from ludamus.pacts import EventDTO
+from ludamus.pacts import OCCUPYING_PARTICIPATION_STATUSES, EventDTO
 from ludamus.pacts.crowd import UserDTO
 from ludamus.pacts.enrollment import (
     UNLIMITED_SLOTS,
+    EnrollmentParticipationRepositoryProtocol,
     OfferDTO,
     PromotionStateDTO,
     WaitingParticipantDTO,
@@ -35,9 +35,33 @@ from ludamus.pacts.legacy import PromotionMode, SessionParticipationStatus
 if TYPE_CHECKING:
 
     from ludamus.adapters.db.django.models import Event
-    from ludamus.pacts.enrollment import HeldSeatData
+    from ludamus.pacts.enrollment import GuestSeatData, HeldSeatData
 
 _DEFAULT_OFFER_WINDOW = timedelta(hours=24)
+
+
+class EnrollmentParticipationRepository(EnrollmentParticipationRepositoryProtocol):
+    @staticmethod
+    def occupying_user_ids(*, user_ids: list[int], event_id: int) -> set[int]:
+        return set(
+            SessionParticipation.objects.filter(
+                status__in=OCCUPYING_PARTICIPATION_STATUSES,
+                user_id__in=user_ids,
+                session__event_id=event_id,
+            )
+            .values_list("user_id", flat=True)
+            .distinct()
+        )
+
+    @staticmethod
+    def create_confirmed(seat: GuestSeatData) -> None:
+        SessionParticipation.objects.create(
+            session_id=seat.session_id,
+            user_id=seat.user_id,
+            status=SessionParticipationStatus.CONFIRMED,
+            party_id=seat.party_id,
+            enrolled_by_id=seat.enrolled_by_id,
+        )
 
 
 class ParticipationPromotionRepository:
@@ -151,7 +175,14 @@ class ParticipationPromotionRepository:
             UserDTO.model_validate(owner),
             *(UserDTO.model_validate(c) for c in companions),
         ]
-        return max(0, allowed - get_used_slots(members, event_dto))
+        # Used slots = distinct owner/companion users holding a seat; the same
+        # accounting `mills.enrollment.get_used_slots` applies at the gates.
+        used = len(
+            EnrollmentParticipationRepository.occupying_user_ids(
+                user_ids=[member.pk for member in members], event_id=event_dto.pk
+            )
+        )
+        return max(0, allowed - used)
 
     @staticmethod
     def confirm(participation_ids: list[int]) -> None:

--- a/src/ludamus/mills/enrollment.py
+++ b/src/ludamus/mills/enrollment.py
@@ -21,6 +21,8 @@ from ludamus.pacts import (
 from ludamus.pacts.crowd import UserData, UserDTO, UserType
 from ludamus.pacts.enrollment import (
     ClaimResult,
+    EnrollmentServiceProtocol,
+    GuestSeatData,
     HeldSeatData,
     NavbarNotificationsDTO,
     OfferNotification,
@@ -42,6 +44,8 @@ if TYPE_CHECKING:
     )
     from ludamus.pacts.crowd import UserRepositoryProtocol
     from ludamus.pacts.enrollment import (
+        EnrollmentParticipationRepositoryProtocol,
+        EnrollmentRepos,
         NotificationReadRepositoryProtocol,
         OfferDTO,
         OfferExpirySchedulerProtocol,
@@ -450,3 +454,155 @@ def get_user_enrollment_config(
         if (virtual_config.has_user_config or virtual_config.has_domain_config)
         else None
     )
+
+
+def get_used_slots(
+    *,
+    users: list[UserDTO],
+    event: EventDTO,
+    participations: EnrollmentParticipationRepositoryProtocol,
+) -> int:
+    # Count unique users who hold at least one seat (confirmed or offered)
+    return len(
+        participations.occupying_user_ids(
+            user_ids=[u.pk for u in users], event_id=event.pk
+        )
+    )
+
+
+def can_enroll_users(
+    *,
+    users: list[UserDTO],
+    event: EventDTO,
+    virtual_config: VirtualEnrollmentConfig,
+    users_to_enroll: list[UserDTO],
+    participations: EnrollmentParticipationRepositoryProtocol,
+) -> bool:
+    # Get currently enrolled users (CONFIRMED + OFFERED both hold a slot)
+    currently_enrolled = participations.occupying_user_ids(
+        user_ids=[u.pk for u in users], event_id=event.pk
+    )
+
+    # Add new users to enroll
+    users_to_enroll_ids = {u.pk for u in users_to_enroll}
+    total_enrolled = currently_enrolled | users_to_enroll_ids
+
+    return len(total_enrolled) <= virtual_config.allowed_slots
+
+
+def get_vc_available_slots(
+    *,
+    users: list[UserDTO],
+    event: EventDTO,
+    virtual_config: VirtualEnrollmentConfig,
+    participations: EnrollmentParticipationRepositoryProtocol,
+) -> int:
+    return max(
+        0,
+        virtual_config.allowed_slots
+        - get_used_slots(users=users, event=event, participations=participations),
+    )
+
+
+class EnrollmentService(EnrollmentServiceProtocol):
+    def __init__(
+        self,
+        *,
+        transaction: TransactionProtocol,
+        repos: EnrollmentRepos,
+        membership_check_interval: int,
+    ) -> None:
+        self._transaction = transaction
+        self._users = repos.users
+        self._anonymous_users = repos.anonymous_users
+        self._enrollment_configs = repos.enrollment_configs
+        self._participations = repos.participations
+        self._ticket_api = repos.ticket_api
+        self._membership_check_interval = membership_check_interval
+
+    def read_viewer(self, slug: str) -> UserDTO:
+        return self._users.read(slug)
+
+    def read_users(self, pks: list[int]) -> list[UserDTO]:
+        return self._users.read_by_ids(pks)
+
+    def virtual_config(
+        self, *, event: EventDTO, user_email: str
+    ) -> VirtualEnrollmentConfig | None:
+        return get_user_enrollment_config(
+            event=event,
+            user_email=user_email,
+            enrollment_config_repo=self._enrollment_configs,
+            ticket_api=self._ticket_api,
+            check_interval_minutes=self._membership_check_interval,
+        )
+
+    def has_slot_access(self, *, event: EventDTO, user_email: str) -> bool:
+        # On a restricted event a member's seat spends that member's own
+        # allowance, so a member without slots cannot be seated by the leader.
+        if not user_email:
+            return False
+        config = self.virtual_config(event=event, user_email=user_email)
+        return bool(config and config.allowed_slots)
+
+    def can_enroll_users(
+        self,
+        *,
+        users: list[UserDTO],
+        event: EventDTO,
+        virtual_config: VirtualEnrollmentConfig,
+        users_to_enroll: list[UserDTO],
+    ) -> bool:
+        return can_enroll_users(
+            users=users,
+            event=event,
+            virtual_config=virtual_config,
+            users_to_enroll=users_to_enroll,
+            participations=self._participations,
+        )
+
+    def get_used_slots(self, *, users: list[UserDTO], event: EventDTO) -> int:
+        return get_used_slots(
+            users=users, event=event, participations=self._participations
+        )
+
+    def get_vc_available_slots(
+        self,
+        *,
+        users: list[UserDTO],
+        event: EventDTO,
+        virtual_config: VirtualEnrollmentConfig,
+    ) -> int:
+        return get_vc_available_slots(
+            users=users,
+            event=event,
+            virtual_config=virtual_config,
+            participations=self._participations,
+        )
+
+    def create_guests(
+        self,
+        *,
+        session_id: int,
+        count: int,
+        party_id: int | None,
+        enrolled_by_id: int,
+        viewer_name: str,
+    ) -> None:
+        # Runs as a savepoint inside the enrollment batch transaction, after
+        # the per-user requests, with the session row locked by the caller.
+        with self._transaction.atomic():
+            for _ in range(count):
+                user_data = build_anonymous_user(
+                    f"guest-{token_urlsafe(8).lower()}", name=f"{viewer_name} +1"
+                )
+                self._anonymous_users.create(user_data)
+                guest = self._anonymous_users.read(user_data["slug"])
+                self._participations.create_confirmed(
+                    GuestSeatData(
+                        session_id=session_id,
+                        user_id=guest.pk,
+                        party_id=party_id,
+                        enrolled_by_id=enrolled_by_id,
+                    )
+                )

--- a/src/ludamus/pacts/enrollment.py
+++ b/src/ludamus/pacts/enrollment.py
@@ -5,6 +5,7 @@ service depends on these ports (repository, notifier, scheduler) so the
 promotion / offer-lifecycle decisions stay unit-testable with fakes.
 """
 
+from dataclasses import dataclass
 from datetime import datetime, timedelta
 from typing import TYPE_CHECKING, Protocol
 
@@ -15,6 +16,13 @@ from ludamus.pacts.legacy import PromotionMode
 if TYPE_CHECKING:
     from collections.abc import Iterable
 
+    from ludamus.pacts.crowd import UserDTO, UserRepositoryProtocol
+    from ludamus.pacts.legacy import (
+        EnrollmentConfigRepositoryProtocol,
+        EventDTO,
+        TicketAPIProtocol,
+        VirtualEnrollmentConfig,
+    )
     from ludamus.pacts.party import HeldSeatNotification
 
 # Sentinel for "no membership limit" so the whole-party fit check is a plain
@@ -233,6 +241,77 @@ class UserNotifierProtocol(Protocol):
 
 class OfferExpirySchedulerProtocol(Protocol):
     def schedule_expiry(self, *, participation_id: int, run_at: datetime) -> None: ...
+
+
+class GuestSeatData(BaseModel):
+    # The CONFIRMED row a +N headcount guest materialises as.
+    session_id: int
+    user_id: int
+    party_id: int | None
+    enrolled_by_id: int
+
+
+class EnrollmentParticipationRepositoryProtocol(Protocol):
+    @staticmethod
+    def occupying_user_ids(*, user_ids: list[int], event_id: int) -> set[int]: ...
+
+    @staticmethod
+    def create_confirmed(seat: GuestSeatData) -> None: ...
+
+
+@dataclass(frozen=True)
+class EnrollmentRepos:
+    # The repos the enrollment service reads rosters and writes guest seats
+    # through; `ticket_api` rides along because membership lookups always
+    # accompany the config reads. Mirrors the `ImportRepos` bundle the
+    # submissions services use to keep a many-repo constructor within the
+    # argument-count limit.
+    users: UserRepositoryProtocol
+    anonymous_users: UserRepositoryProtocol
+    enrollment_configs: EnrollmentConfigRepositoryProtocol
+    participations: EnrollmentParticipationRepositoryProtocol
+    ticket_api: TicketAPIProtocol
+
+
+class EnrollmentServiceProtocol(Protocol):
+    def read_viewer(self, slug: str) -> UserDTO: ...
+
+    def read_users(self, pks: list[int]) -> list[UserDTO]: ...
+
+    def virtual_config(
+        self, *, event: EventDTO, user_email: str
+    ) -> VirtualEnrollmentConfig | None: ...
+
+    def has_slot_access(self, *, event: EventDTO, user_email: str) -> bool: ...
+
+    def can_enroll_users(
+        self,
+        *,
+        users: list[UserDTO],
+        event: EventDTO,
+        virtual_config: VirtualEnrollmentConfig,
+        users_to_enroll: list[UserDTO],
+    ) -> bool: ...
+
+    def get_used_slots(self, *, users: list[UserDTO], event: EventDTO) -> int: ...
+
+    def get_vc_available_slots(
+        self,
+        *,
+        users: list[UserDTO],
+        event: EventDTO,
+        virtual_config: VirtualEnrollmentConfig,
+    ) -> int: ...
+
+    def create_guests(
+        self,
+        *,
+        session_id: int,
+        count: int,
+        party_id: int | None,
+        enrolled_by_id: int,
+        viewer_name: str,
+    ) -> None: ...
 
 
 class WaitlistPromotionServiceProtocol(Protocol):

--- a/src/ludamus/pacts/services.py
+++ b/src/ludamus/pacts/services.py
@@ -25,6 +25,7 @@ if TYPE_CHECKING:
         DiscountsServiceProtocol,
     )
     from ludamus.pacts.enrollment import (
+        EnrollmentServiceProtocol,
         NotificationsServiceProtocol,
         WaitlistPromotionServiceProtocol,
     )
@@ -99,6 +100,8 @@ class ServicesProtocol(Protocol):
     def waitlist_promotion(self) -> WaitlistPromotionServiceProtocol: ...
     @property
     def notifications(self) -> NotificationsServiceProtocol: ...
+    @property
+    def enrollment(self) -> EnrollmentServiceProtocol: ...
     @property
     def print_materials(self) -> PrintMaterialsServiceProtocol: ...
     @property

--- a/tests/integration/links/test_enrollment_participation_repository.py
+++ b/tests/integration/links/test_enrollment_participation_repository.py
@@ -1,0 +1,109 @@
+from ludamus.adapters.db.django.models import (
+    SessionParticipation,
+    SessionParticipationStatus,
+)
+from ludamus.links.db.django.enrollment import EnrollmentParticipationRepository
+from ludamus.pacts.enrollment import GuestSeatData
+from tests.integration.conftest import SessionFactory, UserFactory
+
+
+class TestOccupyingUserIds:
+    def test_counts_confirmed_and_offered_distinct_per_event(self, event):
+        session_a = SessionFactory(event=event, category=None)
+        session_b = SessionFactory(event=event, category=None)
+        occupier = UserFactory(username="occupier", email="occupier@example.com")
+        offered = UserFactory(username="offered", email="offered@example.com")
+        # Same user holding a seat in two sessions of the event is one distinct id.
+        SessionParticipation.objects.create(
+            session=session_a,
+            user=occupier,
+            status=SessionParticipationStatus.CONFIRMED.value,
+        )
+        SessionParticipation.objects.create(
+            session=session_b,
+            user=occupier,
+            status=SessionParticipationStatus.CONFIRMED.value,
+        )
+        SessionParticipation.objects.create(
+            session=session_a,
+            user=offered,
+            status=SessionParticipationStatus.OFFERED.value,
+        )
+
+        result = EnrollmentParticipationRepository.occupying_user_ids(
+            user_ids=[occupier.pk, offered.pk], event_id=event.pk
+        )
+
+        assert result == {occupier.pk, offered.pk}
+
+    def test_excludes_waiting_status(self, event):
+        session = SessionFactory(event=event, category=None)
+        waiter = UserFactory(username="waiter", email="waiter@example.com")
+        SessionParticipation.objects.create(
+            session=session,
+            user=waiter,
+            status=SessionParticipationStatus.WAITING.value,
+        )
+
+        result = EnrollmentParticipationRepository.occupying_user_ids(
+            user_ids=[waiter.pk], event_id=event.pk
+        )
+
+        assert result == set()
+
+    def test_filters_by_event(self, event):
+        session = SessionFactory(event=event, category=None)
+        other_session = SessionFactory(category=None)
+        user = UserFactory(username="enrolled", email="enrolled@example.com")
+        SessionParticipation.objects.create(
+            session=other_session,
+            user=user,
+            status=SessionParticipationStatus.CONFIRMED.value,
+        )
+        SessionParticipation.objects.create(
+            session=session,
+            user=user,
+            status=SessionParticipationStatus.CONFIRMED.value,
+        )
+
+        result = EnrollmentParticipationRepository.occupying_user_ids(
+            user_ids=[user.pk], event_id=other_session.event.pk
+        )
+
+        assert result == {user.pk}
+
+    def test_filters_by_user_set(self, event):
+        session = SessionFactory(event=event, category=None)
+        wanted = UserFactory(username="wanted", email="wanted@example.com")
+        unwanted = UserFactory(username="unwanted", email="unwanted@example.com")
+        for user in (wanted, unwanted):
+            SessionParticipation.objects.create(
+                session=session,
+                user=user,
+                status=SessionParticipationStatus.CONFIRMED.value,
+            )
+
+        result = EnrollmentParticipationRepository.occupying_user_ids(
+            user_ids=[wanted.pk], event_id=event.pk
+        )
+
+        assert result == {wanted.pk}
+
+
+class TestCreateConfirmed:
+    def test_persists_confirmed_participation(self, event, active_user):
+        session = SessionFactory(event=event, category=None)
+        guest = UserFactory(username="guest", email="guest@example.com")
+        seat = GuestSeatData(
+            session_id=session.pk,
+            user_id=guest.pk,
+            party_id=None,
+            enrolled_by_id=active_user.pk,
+        )
+
+        EnrollmentParticipationRepository.create_confirmed(seat)
+
+        participation = SessionParticipation.objects.get(session=session, user=guest)
+        assert participation.status == SessionParticipationStatus.CONFIRMED.value
+        assert participation.party_id is None
+        assert participation.enrolled_by_id == active_user.pk

--- a/tests/unit/test_enrollment_service.py
+++ b/tests/unit/test_enrollment_service.py
@@ -1,0 +1,409 @@
+from contextlib import contextmanager
+from datetime import UTC, datetime, timedelta
+
+from ludamus.mills.enrollment import (
+    EnrollmentService,
+    can_enroll_users,
+    get_used_slots,
+    get_vc_available_slots,
+)
+from ludamus.pacts.crowd import UserDTO, UserType
+from ludamus.pacts.enrollment import EnrollmentRepos
+from ludamus.pacts.legacy import (
+    EnrollmentConfigDTO,
+    EventDTO,
+    UserEnrollmentConfigDTO,
+    VirtualEnrollmentConfig,
+)
+
+_NOW = datetime(2026, 6, 4, 12, 0, tzinfo=UTC)
+_EVENT_ID = 11
+_CHECK_INTERVAL = 60
+_ALLOWED_SLOTS = 3
+_SESSION_ID = 42
+_PARTY_ID = 9
+_GUEST_COUNT = 2
+
+
+def _user(pk, slug="viewer", email="viewer@example.com", name="Viewer"):
+    return UserDTO(
+        avatar_url="",
+        date_joined=_NOW,
+        discord_username="",
+        email=email,
+        full_name=name,
+        is_active=True,
+        is_authenticated=True,
+        is_staff=False,
+        is_superuser=False,
+        name=name,
+        pk=pk,
+        slug=slug,
+        use_gravatar=False,
+        user_type=UserType.ACTIVE,
+        username=slug,
+    )
+
+
+def _event(pk=_EVENT_ID):
+    return EventDTO(
+        description="",
+        end_time=_NOW + timedelta(days=2),
+        name="Konwencik",
+        pk=pk,
+        proposal_end_time=None,
+        proposal_start_time=None,
+        publication_time=None,
+        slug="konwencik",
+        sphere_id=1,
+        start_time=_NOW + timedelta(days=1),
+    )
+
+
+def _enrollment_config(pk=5):
+    return EnrollmentConfigDTO(
+        allow_anonymous_enrollment=False,
+        banner_text="",
+        end_time=_NOW + timedelta(days=1),
+        event_id=_EVENT_ID,
+        limit_to_end_time=False,
+        max_waitlist_sessions=3,
+        percentage_slots=100,
+        pk=pk,
+        restrict_to_configured_users=True,
+        start_time=_NOW - timedelta(days=1),
+    )
+
+
+def _user_config(allowed_slots):
+    return UserEnrollmentConfigDTO(
+        allowed_slots=allowed_slots,
+        enrollment_config_id=5,
+        fetched_from_api=False,
+        last_check=_NOW,
+        pk=17,
+        user_email="viewer@example.com",
+    )
+
+
+@contextmanager
+def _atomic():
+    yield
+
+
+class FakeTransaction:
+    def __init__(self):
+        self.atomic_entered = 0
+
+    def atomic(self):
+        self.atomic_entered += 1
+        return _atomic()
+
+
+class FakeParticipations:
+    def __init__(self, occupying=frozenset()):
+        self._occupying = set(occupying)
+        self.queries: list[dict] = []
+        self.created: list[object] = []
+
+    def occupying_user_ids(self, *, user_ids, event_id):
+        self.queries.append({"user_ids": list(user_ids), "event_id": event_id})
+        return self._occupying & set(user_ids)
+
+    def create_confirmed(self, seat):
+        self.created.append(seat)
+
+
+class FakeUsers:
+    def __init__(self, users=()):
+        self._by_slug = {user.slug: user for user in users}
+        self.created: list[dict] = []
+
+    def create(self, user_data):
+        self.created.append(dict(user_data))
+        self._by_slug[user_data["slug"]] = _user(
+            pk=1000 + len(self.created),
+            slug=user_data["slug"],
+            email="",
+            name=user_data.get("name", ""),
+        )
+
+    def read(self, slug):
+        return self._by_slug[slug]
+
+    def read_by_ids(self, pks):
+        return sorted(
+            (user for user in self._by_slug.values() if user.pk in pks),
+            key=lambda user: user.pk,
+        )
+
+
+class FakeEnrollmentConfigs:
+    def __init__(self, configs=(), user_config=None):
+        self._configs = list(configs)
+        self._user_config = user_config
+
+    def read_list(self, _event_id, **_time_window):
+        return list(self._configs)
+
+    def read_user_config(self, _config, _user_email):
+        return self._user_config
+
+    def read_domain_config(self, _config, _domain):
+        return None
+
+
+class FakeTicketAPI:
+    def __init__(self):
+        self.calls: list[str] = []
+
+    def fetch_membership_count(self, user_email):
+        self.calls.append(user_email)
+        return 0
+
+
+def _service(
+    *, users=None, anonymous_users=None, enrollment_configs=None, participations=None
+):
+    return EnrollmentService(
+        transaction=FakeTransaction(),
+        repos=EnrollmentRepos(
+            users=users if users is not None else FakeUsers(),
+            anonymous_users=(
+                anonymous_users if anonymous_users is not None else FakeUsers()
+            ),
+            enrollment_configs=(
+                enrollment_configs
+                if enrollment_configs is not None
+                else FakeEnrollmentConfigs()
+            ),
+            participations=(
+                participations if participations is not None else FakeParticipations()
+            ),
+            ticket_api=FakeTicketAPI(),
+        ),
+        membership_check_interval=_CHECK_INTERVAL,
+    )
+
+
+class TestSlotMath:
+    def test_get_used_slots_counts_distinct_occupying_users(self):
+        occupying = {1, 2}
+        participations = FakeParticipations(occupying=occupying)
+
+        used = get_used_slots(
+            users=[_user(1), _user(2), _user(3)],
+            event=_event(),
+            participations=participations,
+        )
+
+        assert used == len(occupying)
+        assert participations.queries == [
+            {"user_ids": [1, 2, 3], "event_id": _EVENT_ID}
+        ]
+
+    def test_can_enroll_users_allows_within_limit(self):
+        allowed = can_enroll_users(
+            users=[_user(1), _user(2)],
+            event=_event(),
+            virtual_config=VirtualEnrollmentConfig(allowed_slots=2),
+            users_to_enroll=[_user(2)],
+            participations=FakeParticipations(occupying={1}),
+        )
+
+        assert allowed is True
+
+    def test_can_enroll_users_rejects_over_limit(self):
+        allowed = can_enroll_users(
+            users=[_user(1), _user(2)],
+            event=_event(),
+            virtual_config=VirtualEnrollmentConfig(allowed_slots=1),
+            users_to_enroll=[_user(2)],
+            participations=FakeParticipations(occupying={1}),
+        )
+
+        assert allowed is False
+
+    def test_can_enroll_users_does_not_double_count_enrolled_user(self):
+        allowed = can_enroll_users(
+            users=[_user(1)],
+            event=_event(),
+            virtual_config=VirtualEnrollmentConfig(allowed_slots=1),
+            users_to_enroll=[_user(1)],
+            participations=FakeParticipations(occupying={1}),
+        )
+
+        assert allowed is True
+
+    def test_get_vc_available_slots_subtracts_used(self):
+        available = get_vc_available_slots(
+            users=[_user(1), _user(2)],
+            event=_event(),
+            virtual_config=VirtualEnrollmentConfig(allowed_slots=_ALLOWED_SLOTS),
+            participations=FakeParticipations(occupying={1}),
+        )
+
+        assert available == _ALLOWED_SLOTS - 1
+
+    def test_get_vc_available_slots_clamps_at_zero(self):
+        available = get_vc_available_slots(
+            users=[_user(1), _user(2)],
+            event=_event(),
+            virtual_config=VirtualEnrollmentConfig(allowed_slots=1),
+            participations=FakeParticipations(occupying={1, 2}),
+        )
+
+        assert available == 0
+
+
+class TestEnrollmentService:
+    def test_read_viewer_returns_user_by_slug(self):
+        viewer = _user(1)
+        service = _service(users=FakeUsers([viewer]))
+
+        assert service.read_viewer("viewer") == viewer
+
+    def test_read_users_returns_users_by_ids(self):
+        first, second = _user(1, slug="a"), _user(2, slug="b")
+        service = _service(users=FakeUsers([first, second]))
+
+        assert service.read_users([2]) == [second]
+
+    def test_virtual_config_combines_stored_user_config(self):
+        service = _service(
+            enrollment_configs=FakeEnrollmentConfigs(
+                configs=[_enrollment_config()], user_config=_user_config(4)
+            )
+        )
+
+        config = service.virtual_config(event=_event(), user_email="viewer@example.com")
+
+        assert config == VirtualEnrollmentConfig(
+            allowed_slots=4, has_domain_config=False, has_user_config=True
+        )
+
+    def test_has_slot_access_false_without_email(self):
+        ticket_api = FakeTicketAPI()
+        service = EnrollmentService(
+            transaction=FakeTransaction(),
+            repos=EnrollmentRepos(
+                users=FakeUsers(),
+                anonymous_users=FakeUsers(),
+                enrollment_configs=FakeEnrollmentConfigs(
+                    configs=[_enrollment_config()], user_config=_user_config(4)
+                ),
+                participations=FakeParticipations(),
+                ticket_api=ticket_api,
+            ),
+            membership_check_interval=_CHECK_INTERVAL,
+        )
+
+        assert service.has_slot_access(event=_event(), user_email="") is False
+        assert not ticket_api.calls
+
+    def test_has_slot_access_true_with_allowed_slots(self):
+        service = _service(
+            enrollment_configs=FakeEnrollmentConfigs(
+                configs=[_enrollment_config()], user_config=_user_config(2)
+            )
+        )
+
+        access = service.has_slot_access(
+            event=_event(), user_email="viewer@example.com"
+        )
+
+        assert access is True
+
+    def test_has_slot_access_false_without_config(self):
+        service = _service(enrollment_configs=FakeEnrollmentConfigs())
+
+        access = service.has_slot_access(
+            event=_event(), user_email="viewer@example.com"
+        )
+
+        assert access is False
+
+    def test_get_used_slots_delegates_to_injected_repo(self):
+        service = _service(participations=FakeParticipations(occupying={1}))
+
+        used = service.get_used_slots(users=[_user(1), _user(2)], event=_event())
+
+        assert used == 1
+
+    def test_can_enroll_users_uses_injected_repo(self):
+        service = _service(participations=FakeParticipations(occupying={1}))
+
+        allowed = service.can_enroll_users(
+            users=[_user(1), _user(2)],
+            event=_event(),
+            virtual_config=VirtualEnrollmentConfig(allowed_slots=1),
+            users_to_enroll=[_user(2)],
+        )
+
+        assert allowed is False
+
+    def test_get_vc_available_slots_uses_injected_repo(self):
+        service = _service(participations=FakeParticipations(occupying={1}))
+
+        available = service.get_vc_available_slots(
+            users=[_user(1)],
+            event=_event(),
+            virtual_config=VirtualEnrollmentConfig(allowed_slots=_ALLOWED_SLOTS),
+        )
+
+        assert available == _ALLOWED_SLOTS - 1
+
+    def test_create_guests_creates_users_and_confirmed_seats_atomically(self):
+        anonymous_users = FakeUsers()
+        participations = FakeParticipations()
+        transaction = FakeTransaction()
+        service = EnrollmentService(
+            transaction=transaction,
+            repos=EnrollmentRepos(
+                users=FakeUsers(),
+                anonymous_users=anonymous_users,
+                enrollment_configs=FakeEnrollmentConfigs(),
+                participations=participations,
+                ticket_api=FakeTicketAPI(),
+            ),
+            membership_check_interval=_CHECK_INTERVAL,
+        )
+
+        service.create_guests(
+            session_id=_SESSION_ID,
+            count=_GUEST_COUNT,
+            party_id=_PARTY_ID,
+            enrolled_by_id=1,
+            viewer_name="Wanda Wiewiórka",
+        )
+
+        assert transaction.atomic_entered == 1
+        assert len(anonymous_users.created) == _GUEST_COUNT
+        assert all(
+            data["slug"].startswith("guest-") for data in anonymous_users.created
+        )
+        assert all(
+            data["name"] == "Wanda Wiewiórka +1" for data in anonymous_users.created
+        )
+        assert len(participations.created) == _GUEST_COUNT
+        assert all(seat.session_id == _SESSION_ID for seat in participations.created)
+        assert all(seat.party_id == _PARTY_ID for seat in participations.created)
+        assert all(seat.enrolled_by_id == 1 for seat in participations.created)
+
+    def test_create_guests_with_zero_count_creates_nothing(self):
+        anonymous_users = FakeUsers()
+        participations = FakeParticipations()
+        service = _service(
+            anonymous_users=anonymous_users, participations=participations
+        )
+
+        service.create_guests(
+            session_id=_SESSION_ID,
+            count=0,
+            party_id=None,
+            enrolled_by_id=1,
+            viewer_name="Wanda",
+        )
+
+        assert not anonymous_users.created
+        assert not participations.created


### PR DESCRIPTION
Part of #457 (PR-7). Behavior-preserving GLIMPSE strangler move.

## What
Relocates the enrollment slot math out of the ORM models file and puts the enroll page on `request.services`:

- `can_enroll_users`, `get_used_slots`, `get_vc_available_slots` moved from `adapters/db/django/models.py` into `mills/enrollment.py`. The ORM query behind them (distinct users holding a CONFIRMED/OFFERED seat) now lives in `EnrollmentParticipationRepository` (`links/db/django/enrollment.py`) behind `EnrollmentParticipationRepositoryProtocol`; the mills functions are Django-free and take the repo protocol.
- New `EnrollmentService` in `mills/enrollment.py`, exposed as `request.services.enrollment` (`EnrollmentServiceProtocol` in `pacts/enrollment.py`, wired in `inits/services.py` via an `EnrollmentRepos` bundle + `MembershipApiClient`; `active_users` / `anonymous_users` / `enrollment_configs` / `enrollment_participations` added to `inits/repositories.py`). It owns: viewer/roster reads, virtual enrollment-config resolution (`virtual_config`), member slot-access checks (`has_slot_access`), the slot math, and +N guest creation (`create_guests`, atomic).
- `SessionEnrollPageView` no longer touches `request.di` — every `active_users` / `enrollment_configs` / `anonymous_users` / `ticket_api` call site now goes through the service. `create_enrollment_form` takes the service instead of `enrollment_config_repo` + `ticket_api` (same call timing for the membership-API reads, so refresh side effects are unchanged).
- `ParticipationPromotionRepository._slots_remaining` uses the shared `occupying_user_ids` query instead of importing the models-file function (a direct mills import would transitively pull `specs` into `links`, which importlinter forbids).

## Why
Isolating the slot-math relocation (ORM file → mills) as a behavior-preserving move makes Party step 2's `effective_manager_id → effective_slot_owner` change a one-spot edit, and gives the enrollment page its service home on `request.services`. Advances Refactors 1–3.

Explicitly remaining (out of PR-7's safe scope, noted in `docs/refactors/glimpse-strangler.md`): the view's transactional enrollment batch (`_process_enrollments`, capacity checks, cancellations, guest trims) still uses the ORM directly inside the view — it moves into the service together with the view's relocation to `gates/`. The view file itself stays in `adapters/` per PR-7 scope.

## Verification
Re-run after rebasing onto `cf80da1` (kept both the discount-export and enrollment additions in `inits/services.py`):

- `lint-imports --config=pyproject.toml`: 7 contracts kept, 0 broken
- `ruff check src tests` + `black --check`: clean
- `mypy src`: no issues in 198 files
- `pylint src` / `pylint --disable=duplicate-code tests`: 10.00 / 10.00
- `ast-grep scan --error src`, `codespell`, `vulture`, `impeccable`: clean
- `pytest --collect-only`: no import errors
- `pytest tests/integration -k "enroll or anonymous"`: 274 passed, 3 skipped
- `pytest tests/unit`: 569 passed (incl. 17 new `test_enrollment_service.py` tests)
- full `pytest tests` (pre-rebase baseline): 2674 passed, 7 skipped
- messages: catalog unchanged by this diff (no new translatable strings); `msgfmt --check --statistics`: 1493 translated, 0 fuzzy/untranslated

Depends on PR-6 (#469, merged). No UI change — the enroll page renders and behaves identically, so no screenshots.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enrollment handling now uses a centralized service, improving the sign-up flow for sessions and guests.
  * Guest enrollment is now created as part of the same workflow, including confirmed seat assignment.

* **Bug Fixes**
  * Slot availability checks are now more consistent, helping prevent over-enrollment and better handling already-filled seats.
  * Enrollment screens now refresh with the correct user and capacity information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->