### PR TITLE
Add ast-grep rule banning Faker(&quot;slug&quot;) in factories

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -68,7 +68,7 @@ run = [
 
 [tasks."lint:ast-grep"]
 description = "Run structural code pattern checks via ast-grep"
-run = "ast-grep scan --error src"
+run = "ast-grep scan --error src tests"
 
 [tasks."lint:codespell"]
 description = "Find typos in source and test files"

--- a/rules/no-faker-slug.yml
+++ b/rules/no-faker-slug.yml
@@ -1,0 +1,20 @@
+id: no-faker-slug
+language: python
+severity: error
+rule:
+  kind: call
+  all:
+    - has:
+        field: function
+        regex: '(^|\.)Faker$'
+    - has:
+        field: arguments
+        has:
+          kind: string
+          regex: "^['\"]slug['\"]$"
+message: |
+  Do not use Faker("slug") in factories — it draws from a small word list and
+  collides across instances, causing flaky unique-constraint failures (see
+  plan 003). Use a deterministic unique slug instead:
+    slug = factory.Sequence(lambda n: f"thing-{n}")
+    slug = factory.LazyAttribute(lambda o: slugify(o.name))


### PR DESCRIPTION
Small regression guardrail — the lint-rule half of audit plan 006, locking in the already-merged plan 003.

## Why

`Faker("slug")` draws from a small fixed word list, so it collides across factory instances and reintroduces flaky unique-constraint failures in the test suite — exactly the bug class plan 003 fixed by moving factories to `Sequence`/`LazyAttribute` slugs. A structural lint rule stops it coming back.

## What

- **`rules/no-faker-slug.yml`** — flags any `Faker("slug")` / `factory.Faker("slug")` call in either quote style, using a `kind: call` + regex rule so it's quote- and call-form-agnostic. Other providers (`Faker("name")`, etc.) are left untouched.
- **`mise.toml`** — factories live under `tests/`, but `lint:ast-grep` only scanned `src`, so the scan is widened to `src tests`. The existing rules are all `language: html`, so they don't fire on Python test files; the full rule set on `src tests` is clean.

## Validation

- `mise run lint:ast-grep` (full rule set, `src tests`) — exit 0 on the current tree.
- In-context proof: injecting `Faker("slug")` into a real factory in `tests/integration/conftest.py` makes the task fail on the exact line; removing it returns to green.
- Rule unit-checked against both quote styles and both call forms, and confirmed not to flag `Faker("name")`.

## Not in this PR

The other, larger half of plan 006 — the N+1 query-audit test client (report-then-ratchet, per-test annotations) — is intentionally separate; it's MED-risk and touches the whole integration suite.

## Note

While picking this up I verified **plan 004 (mills coverage blind spot) is already resolved** on `main`: a live `--cov=ludamus` run measures all four layers it worried about (mills 22 / pacts 15 / inits 7 / specs 5 modules), and the stale root `coverage.xml` is already removed and gitignored. Nothing to do there — it can be closed out in the plans tracker.

---
_Generated by [Claude Code](https://claude.ai/code/session_0197EVF9UR68hJf8GU2xqCiK)_