### PR TITLE
fix(panel): Proposals defaults to all statuses

### DIFF
--- a/src/ludamus/gates/web/django/chronology/panel/views/proposals.py
+++ b/src/ludamus/gates/web/django/chronology/panel/views/proposals.py
@@ -100,11 +100,13 @@ class ProposalsPageView(PanelAccessMixin, EventContextMixin, View):
         if filter_category_pk not in {c.pk for c in categories}:
             filter_category_pk = None
 
+        # Default (no status param) shows every proposal: an event whose
+        # sessions weren't created via proposals should not look empty on first
+        # load. Explicit picks (a real status or the "scheduled" pseudo-filter)
+        # still narrow the list.
         status_raw = self.request.GET.get("status")
         filter_status: str | None
-        if status_raw is None:
-            filter_status = SessionStatus.PENDING
-        elif status_raw == SCHEDULED_FILTER or status_raw in set(SessionStatus):
+        if status_raw == SCHEDULED_FILTER or status_raw in set(SessionStatus):
             filter_status = status_raw
         else:
             filter_status = None

--- a/src/ludamus/gates/web/django/chronology/panel/views/proposals.py
+++ b/src/ludamus/gates/web/django/chronology/panel/views/proposals.py
@@ -105,11 +105,11 @@ class ProposalsPageView(PanelAccessMixin, EventContextMixin, View):
         # load. Explicit picks (a real status or the "scheduled" pseudo-filter)
         # still narrow the list.
         status_raw = self.request.GET.get("status")
-        filter_status: str | None
-        if status_raw == SCHEDULED_FILTER or status_raw in set(SessionStatus):
-            filter_status = status_raw
-        else:
-            filter_status = None
+        filter_status: str | None = (
+            status_raw
+            if status_raw == SCHEDULED_FILTER or status_raw in set(SessionStatus)
+            else None
+        )
 
         # Scheduled is a placement fact, not a status: the "scheduled" option
         # filters on agenda-item existence, and picking a real status excludes

--- a/src/ludamus/locale/pl/LC_MESSAGES/django.po
+++ b/src/ludamus/locale/pl/LC_MESSAGES/django.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-07-07 20:55+0200\n"
+"POT-Creation-Date: 2026-07-07 21:08+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -6968,11 +6968,6 @@ msgid "No proposals match the current filters."
 msgstr "Żadne zgłoszenia nie pasują do bieżących filtrów."
 
 #: src/ludamus/templates/panel/proposals.html
-#: src/ludamus/templates/panel/timetable-log.html
-msgid "Clear filters"
-msgstr "Wyczyść filtry"
-
-#: src/ludamus/templates/panel/proposals.html
 msgid "No proposals submitted yet."
 msgstr "Brak przesłanych zgłoszeń."
 
@@ -7258,6 +7253,10 @@ msgstr "Przegląd harmonogramu"
 #: src/ludamus/templates/panel/timetable.html
 msgid "Problems"
 msgstr "Problemy"
+
+#: src/ludamus/templates/panel/timetable-log.html
+msgid "Clear filters"
+msgstr "Wyczyść filtry"
 
 #: src/ludamus/templates/panel/timetable-log.html
 msgid "Change"

--- a/src/ludamus/locale/pl/LC_MESSAGES/django.po
+++ b/src/ludamus/locale/pl/LC_MESSAGES/django.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-07-06 02:45+0200\n"
+"POT-Creation-Date: 2026-07-07 20:55+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -6964,6 +6964,15 @@ msgid "Filter"
 msgstr "Filtruj"
 
 #: src/ludamus/templates/panel/proposals.html
+msgid "No proposals match the current filters."
+msgstr "Żadne zgłoszenia nie pasują do bieżących filtrów."
+
+#: src/ludamus/templates/panel/proposals.html
+#: src/ludamus/templates/panel/timetable-log.html
+msgid "Clear filters"
+msgstr "Wyczyść filtry"
+
+#: src/ludamus/templates/panel/proposals.html
 msgid "No proposals submitted yet."
 msgstr "Brak przesłanych zgłoszeń."
 
@@ -7249,10 +7258,6 @@ msgstr "Przegląd harmonogramu"
 #: src/ludamus/templates/panel/timetable.html
 msgid "Problems"
 msgstr "Problemy"
-
-#: src/ludamus/templates/panel/timetable-log.html
-msgid "Clear filters"
-msgstr "Wyczyść filtry"
 
 #: src/ludamus/templates/panel/timetable-log.html
 msgid "Change"

--- a/src/ludamus/templates/panel/proposals.html
+++ b/src/ludamus/templates/panel/proposals.html
@@ -215,9 +215,7 @@
         {% else %}
             <div class="card p-8 text-center">
                 {% if filter_search or filter_status or filter_category_pk or filter_track_pk or filter_fields.values|join:"" %}
-                    <p class="text-foreground-muted mb-4">{% translate "No proposals match the current filters." %}</p>
-                    <a href="{% url 'panel:proposals' slug=current_event.slug %}"
-                       class="btn btn-secondary text-sm">{% translate "Clear filters" %}</a>
+                    <p class="text-foreground-muted">{% translate "No proposals match the current filters." %}</p>
                 {% else %}
                     <p class="text-foreground-muted mb-4">{% translate "No proposals submitted yet." %}</p>
                     {% url 'panel:proposal-create' slug=current_event.slug as create_url %}

--- a/src/ludamus/templates/panel/proposals.html
+++ b/src/ludamus/templates/panel/proposals.html
@@ -214,10 +214,16 @@
             {% endif %}
         {% else %}
             <div class="card p-8 text-center">
-                <p class="text-foreground-muted mb-4">{% translate "No proposals submitted yet." %}</p>
-                {% url 'panel:proposal-create' slug=current_event.slug as create_url %}
-                {% translate "Create Session" as t_create %}
-                {% tessera_button t_create href=create_url icon="plus" %}
+                {% if filter_search or filter_status or filter_category_pk or filter_track_pk or filter_fields.values|join:"" %}
+                    <p class="text-foreground-muted mb-4">{% translate "No proposals match the current filters." %}</p>
+                    <a href="{% url 'panel:proposals' slug=current_event.slug %}"
+                       class="btn btn-secondary text-sm">{% translate "Clear filters" %}</a>
+                {% else %}
+                    <p class="text-foreground-muted mb-4">{% translate "No proposals submitted yet." %}</p>
+                    {% url 'panel:proposal-create' slug=current_event.slug as create_url %}
+                    {% translate "Create Session" as t_create %}
+                    {% tessera_button t_create href=create_url icon="plus" %}
+                {% endif %}
             </div>
         {% endif %}
         {% if deleted_proposals %}

--- a/tests/integration/web/panel/test_proposals_page.py
+++ b/tests/integration/web/panel/test_proposals_page.py
@@ -46,7 +46,7 @@ _TRACK_FILTER_CONTEXT = {
     "filter_track_pk": None,
     "page_obj": PageMatcher(number=1, num_pages=1),
     "filter_category_pk": None,
-    "filter_status": SessionStatus.PENDING,
+    "filter_status": None,
     "statuses": _STATUSES,
 }
 
@@ -880,7 +880,7 @@ class TestProposalsPageView:
                 "page_obj": PageMatcher(number=1, num_pages=1),
                 "categories": [],
                 "filter_category_pk": None,
-                "filter_status": SessionStatus.PENDING,
+                "filter_status": None,
                 "statuses": _STATUSES,
             },
         )
@@ -915,7 +915,7 @@ class TestProposalsPageView:
                 "page_obj": PageMatcher(number=1, num_pages=1),
                 "categories": [],
                 "filter_category_pk": None,
-                "filter_status": SessionStatus.PENDING,
+                "filter_status": None,
                 "statuses": _STATUSES,
             },
         )
@@ -966,7 +966,7 @@ class TestProposalsPageView:
             },
         )
 
-    def test_default_status_filter_shows_only_pending(
+    def test_default_status_filter_shows_all_statuses(
         self, authenticated_client, active_user, sphere, event
     ):
         sphere.managers.add(active_user)
@@ -989,12 +989,22 @@ class TestProposalsPageView:
             participants_limit=5,
             status="accepted",
         )
+        Session.objects.create(
+            event=event,
+            category=category,
+            display_name="Rejected Host",
+            title="Rejected Session",
+            slug="rejected-session",
+            participants_limit=5,
+            status="rejected",
+        )
 
         response = authenticated_client.get(self.get_url(event))
 
         assert response.status_code == HTTPStatus.OK
-        assert [p.title for p in response.context["proposals"]] == ["Pending Session"]
-        assert response.context["filter_status"] == SessionStatus.PENDING
+        titles = {p.title for p in response.context["proposals"]}
+        assert titles == {"Pending Session", "Accepted Session", "Rejected Session"}
+        assert response.context["filter_status"] is None
 
     def test_filters_by_status_param(
         self, authenticated_client, active_user, sphere, event


### PR DESCRIPTION
## Problem

The organizer Proposals page defaulted its status filter to **Pending** whenever no `status` query param was present. An event whose sessions weren't created via proposals (e.g. imported or created directly) would then render **"No proposals submitted yet."** on first load, even when accepted/scheduled sessions existed. Misleading.

## Before / After

**Before:** first load (`/panel/event/<slug>/proposals/`) implicitly applied `status=pending`, hiding accepted/on-hold/rejected/scheduled proposals and showing the empty state when no pending ones existed.

**After:** first load shows **every** proposal regardless of status. The status `<select>` already marks "All statuses" as selected when unfiltered (`{% if not filter_status %}`), so the dropdown reflects the new default and still lets the organizer narrow to Pending / Accepted / On hold / Rejected / Scheduled. The meaning of the explicit `scheduled` pseudo-filter and each real status is unchanged.

The empty state ("No proposals submitted yet.") now only appears on the default view when the event truly has no proposals.

## Testing

Run from the worktree venv (`PYTHONPATH=src`, `.env.test` loaded):

- `pytest tests/integration/web/panel/test_proposals_page.py -q` → **33 passed**
- `pytest tests/integration tests/unit -k proposals -q` → **76 passed, 2692 deselected**
- `mypy src` → **Success: no issues found in 209 source files**
- `ruff check --fix scripts src tests` → **All checks passed!**

Updated `test_default_status_filter_shows_only_pending` → `test_default_status_filter_shows_all_statuses` (pending + accepted + rejected all appear, `filter_status is None`), and flipped the shared/inline `filter_status` context expectations from `PENDING` to `None`.

Refs #543 (P2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_017y1ivr5CqCWLA8eGDCGqZj)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * The proposals list now shows all session statuses by default when no status filter is selected, instead of limiting results to pending items.
  * The special “scheduled” filter continues to work separately from regular session status filters.
  * Updated the proposals panel to reflect the new default filtering behavior in displayed results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->