### PR TITLE
fix(panel): English schedule label + single-day event date

### DIFF
--- a/src/ludamus/locale/pl/LC_MESSAGES/django.po
+++ b/src/ludamus/locale/pl/LC_MESSAGES/django.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-07-07 23:05+0200\n"
+"POT-Creation-Date: 2026-07-07 23:23+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -5231,7 +5231,11 @@ msgid "Venues"
 msgstr "Lokalizacje"
 
 #: src/ludamus/templates/panel/base.html
-msgid "Harmonogram"
+#: src/ludamus/templates/panel/timetable-log.html
+#: src/ludamus/templates/panel/timetable-overview.html
+#: src/ludamus/templates/panel/timetable-problems.html
+#: src/ludamus/templates/panel/timetable.html
+msgid "Schedule"
 msgstr "Harmonogram"
 
 #: src/ludamus/templates/panel/base.html
@@ -7255,13 +7259,6 @@ msgstr "Dziennik zmian harmonogramu"
 #: src/ludamus/templates/panel/timetable-overview.html
 #: src/ludamus/templates/panel/timetable-problems.html
 #: src/ludamus/templates/panel/timetable.html
-msgid "Schedule"
-msgstr "Harmonogram"
-
-#: src/ludamus/templates/panel/timetable-log.html
-#: src/ludamus/templates/panel/timetable-overview.html
-#: src/ludamus/templates/panel/timetable-problems.html
-#: src/ludamus/templates/panel/timetable.html
 msgid "Organizer Overview"
 msgstr "Przegląd harmonogramu"
 
@@ -7503,6 +7500,9 @@ msgstr "Temat"
 #: src/ludamus/templates/staging_email_inbox.html
 msgid "No emails captured yet."
 msgstr "Brak przechwyconych e-maili."
+
+#~ msgid "Harmonogram"
+#~ msgstr "Harmonogram"
 
 #~ msgid "Something broke on our end. Try again in a moment."
 #~ msgstr "Coś się zepsuło po naszej stronie. Spróbuj ponownie za chwilę."

--- a/src/ludamus/locale/pl/LC_MESSAGES/django.po
+++ b/src/ludamus/locale/pl/LC_MESSAGES/django.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-07-06 02:45+0200\n"
+"POT-Creation-Date: 2026-07-07 14:51+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -5212,7 +5212,11 @@ msgid "Venues"
 msgstr "Lokalizacje"
 
 #: src/ludamus/templates/panel/base.html
-msgid "Harmonogram"
+#: src/ludamus/templates/panel/timetable-log.html
+#: src/ludamus/templates/panel/timetable-overview.html
+#: src/ludamus/templates/panel/timetable-problems.html
+#: src/ludamus/templates/panel/timetable.html
+msgid "Schedule"
 msgstr "Harmonogram"
 
 #: src/ludamus/templates/panel/base.html
@@ -7228,13 +7232,6 @@ msgstr ""
 #: src/ludamus/templates/panel/timetable-log.html
 msgid "Schedule Activity Log"
 msgstr "Dziennik zmian harmonogramu"
-
-#: src/ludamus/templates/panel/timetable-log.html
-#: src/ludamus/templates/panel/timetable-overview.html
-#: src/ludamus/templates/panel/timetable-problems.html
-#: src/ludamus/templates/panel/timetable.html
-msgid "Schedule"
-msgstr "Harmonogram"
 
 #: src/ludamus/templates/panel/timetable-log.html
 #: src/ludamus/templates/panel/timetable-overview.html

--- a/src/ludamus/templates/panel/base.html
+++ b/src/ludamus/templates/panel/base.html
@@ -257,7 +257,7 @@
                                         {% icon "tag" class="size-4.5 mr-2" %}
                                         <span class="sidebar-label">{{ t_tracks }}</span>
                                     </a>
-                                    {% translate "Harmonogram" as t_timetable %}
+                                    {% translate "Schedule" as t_timetable %}
                                     <a href="{% url 'panel:timetable' slug=current_event.slug %}"
                                        title="{{ t_timetable }}"
                                        class="sidebar-link flex text-sm items-center px-2 py-3 {% if active_nav == 'timetable' %}text-white bg-neutral-800{% else %}text-neutral-300 hover:bg-neutral-800{% endif %} rounded-lg transition hover:duration-0">
@@ -357,7 +357,7 @@
                         <div class="hidden sm:flex items-center space-x-4 shrink-0">
                             {% if current_event %}
                                 <span class="text-sm text-foreground-muted hidden md:inline">
-                                    {% translate "Event:" %} <strong>{{ current_event.start_time|date:"d M" }} - {{ current_event.end_time|date:"d M Y" }}</strong>
+                                    {% translate "Event:" %} <strong>{% if current_event.start_time|date:"Ymd" == current_event.end_time|date:"Ymd" %}{{ current_event.start_time|date:"d M Y" }}{% else %}{{ current_event.start_time|date:"d M" }} - {{ current_event.end_time|date:"d M Y" }}{% endif %}</strong>
                                 </span>
                                 {% if is_proposal_active %}
                                     <span class="px-3 py-1 bg-success-bg text-success-text text-sm rounded-full whitespace-nowrap">{% translate "Proposals Open" %}</span>

--- a/tests/integration/web/panel/test_timetable.py
+++ b/tests/integration/web/panel/test_timetable.py
@@ -1,5 +1,6 @@
-from datetime import timedelta
+from datetime import UTC, datetime, timedelta
 from http import HTTPStatus
+from unittest.mock import ANY
 
 import pytest
 from django.contrib import messages
@@ -10,6 +11,7 @@ from ludamus.pacts import EventDTO
 from ludamus.pacts.chronology import TIMETABLE_SLOT_MINUTES, TimetableGridDTO
 from tests.integration.conftest import (
     AgendaItemFactory,
+    EventFactory,
     SessionFactory,
     SpaceFactory,
     TimeSlotFactory,
@@ -253,3 +255,70 @@ class TestTimetablePageView:
         assert response.status_code == HTTPStatus.OK
         assert response.context["slot_violation_session_pks"] == {session.pk}
         assert response.context["conflict_session_pks"] == set()
+
+
+class TestPanelBaseHeader:
+    """Tests for the shared panel/base.html sidebar and header."""
+
+    @staticmethod
+    def get_url(event):
+        return reverse("panel:timetable", kwargs={"slug": event.slug})
+
+    def test_schedule_nav_label_renders_in_english(
+        self, authenticated_client, active_user, sphere, event
+    ):
+        sphere.managers.add(active_user)
+
+        response = authenticated_client.get(self.get_url(event))
+
+        assert_response(
+            response,
+            HTTPStatus.OK,
+            template_name="panel/timetable.html",
+            context_data=ANY,
+            contains='<span class="sidebar-label">Schedule</span>',
+            not_contains="Harmonogram",
+        )
+
+    def test_single_day_event_shows_one_date(
+        self, authenticated_client, active_user, sphere
+    ):
+        sphere.managers.add(active_user)
+        event = EventFactory(
+            sphere=sphere,
+            slug="one-day",
+            start_time=datetime(2026, 8, 6, 9, 0, tzinfo=UTC),
+            end_time=datetime(2026, 8, 6, 18, 0, tzinfo=UTC),
+        )
+
+        response = authenticated_client.get(self.get_url(event))
+
+        assert_response(
+            response,
+            HTTPStatus.OK,
+            template_name="panel/timetable.html",
+            context_data=ANY,
+            contains="<strong>06 Aug 2026</strong>",
+            not_contains="06 Aug - 06 Aug",
+        )
+
+    def test_multi_day_event_shows_date_range(
+        self, authenticated_client, active_user, sphere
+    ):
+        sphere.managers.add(active_user)
+        event = EventFactory(
+            sphere=sphere,
+            slug="multi-day",
+            start_time=datetime(2026, 8, 6, 9, 0, tzinfo=UTC),
+            end_time=datetime(2026, 8, 8, 12, 0, tzinfo=UTC),
+        )
+
+        response = authenticated_client.get(self.get_url(event))
+
+        assert_response(
+            response,
+            HTTPStatus.OK,
+            template_name="panel/timetable.html",
+            context_data=ANY,
+            contains="<strong>06 Aug - 08 Aug 2026</strong>",
+        )


### PR DESCRIPTION
Two small UX/copy fixes in the shared panel chrome (`src/ludamus/templates/panel/base.html`).

## P9 — "Harmonogram" nav label in the default/English locale
The sidebar timetable link used a Polish msgid, `{% translate "Harmonogram" as t_timetable %}`. With the default/English locale that rendered the nav item as **"Harmonogram"**, even though the page it opens is titled **"Schedule"** and every sibling nav item (Venues, Tracks, Print Materials, …) is English.

Fix: switch the source string to `"Schedule"`. A plain `"Schedule"` msgid already exists (used by the timetable pages) with the Polish translation **"Harmonogram"**, so the nav item reuses it — English renders "Schedule", Polish still renders "Harmonogram". The now-orphaned `"Harmonogram"` msgid was removed from the catalog and the catalog recompiled. `mise run messages-check` is green.

## P8 — single-day event showed a range to itself
The shared header rendered the event date as `start - end`, so a one-day event showed **"06 Aug - 06 Aug 2026"**. This header is shown on every panel page, so the range-to-itself appeared everywhere.

Fix: a same-day guard renders a single date for one-day events and keeps the range for multi-day:
```
{% if current_event.start_time|date:"Ymd" == current_event.end_time|date:"Ymd" %}{{ current_event.start_time|date:"d M Y" }}{% else %}{{ current_event.start_time|date:"d M" }} - {{ current_event.end_time|date:"d M Y" }}{% endif %}
```

Refs #543 (P8, P9)

## Testing
Added `TestPanelBaseHeader` to `tests/integration/web/panel/test_timetable.py` (integration tests, `assert_response`): schedule nav label renders "Schedule" (not "Harmonogram") in the default locale; a single-day event renders one date; a multi-day event renders the range.

- `mise run test:py` (panel/timetable) → `16 passed`
- `mise run lint:djlint` → `Linted 175 files, found 0 errors.`
- `mise run messages-check` → `Translations fresh: extraction current, all messages translated.`
- `ruff check` / `ruff format --check` on the touched test → clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_017y1ivr5CqCWLA8eGDCGqZj)_