### PR TITLE
feat(web): informative themed error pages + no silent redirect on missing events

### DIFF
--- a/src/ludamus/adapters/web/django/error_views.py
+++ b/src/ludamus/adapters/web/django/error_views.py
@@ -1,8 +1,9 @@
-import secrets
 from datetime import UTC, datetime
 from http import HTTPStatus
 from typing import TYPE_CHECKING, cast
 
+from django.conf import settings
+from django.contrib import messages
 from django.http import (  # Django
     HttpRequest,
     HttpResponse,
@@ -79,10 +80,12 @@ def _recover_from_404(request: HttpRequest) -> HttpResponse | None:
 
     # Missing and unpublished events return the same response on purpose, so a
     # 404 never reveals whether an unannounced event exists. The visitor
-    # reached the right sphere, so offer the sphere home rather than a dead end.
+    # reached the right sphere, so send them to the events list with a neutral
+    # explanation rather than dropping them on the home page with no context.
     # (A clean URL to a public event renders normally and never reaches here.)
     if state in {_EVENT_MISSING, _EVENT_UNPUBLISHED}:
-        return HttpResponseRedirect(reverse("web:index"))
+        messages.info(request, _("That event isn't available."))
+        return HttpResponseRedirect(reverse("web:events"))
 
     return None
 
@@ -93,123 +96,15 @@ def custom_404(
     if (recovered := _recover_from_404(request)) is not None:
         return recovered
 
-    error_messages = [
-        # D&D/Fantasy themed
-        {
-            "title": _("Critical Failure!"),
-            "message": _("You rolled a nat 1 on your Navigation check!"),
-            "subtitle": _("The path you seek has vanished into the mists."),
-            "icon": "dice-1",
-        },
-        {
-            "title": _("No-Show Player"),
-            "message": _("Page didn't show up to the session"),
-            "subtitle": _("Maybe it had scheduling conflicts?"),
-            "icon": "person-x",
-        },
-        {
-            "title": _("Empty Room"),
-            "message": _("You enter the room and find... absolutely nothing."),
-            "subtitle": _("Not even cobwebs or dust. Suspicious."),
-            "icon": "door-open",
-        },
-        {
-            "title": _("Perception Check Failed"),
-            "message": _("You see nothing of interest here"),
-            "subtitle": _("Perhaps you need to roll with advantage next time."),
-            "icon": "eye-slash",
-        },
-        {
-            "title": _("Off the Map!"),
-            "message": _("You've wandered off the edge of the campaign map"),
-            "subtitle": _("Here be dragons... and 404 errors."),
-            "icon": "map",
-        },
-        {
-            "title": _("It's a Mimic!"),
-            "message": _("Surprise! That wasn't actually a real page. It's a mimic!"),
-            "subtitle": _("Roll for initiative!"),
-            "icon": "box-seam",
-        },
-        {
-            "title": _("Teleport Gone Wrong!"),
-            "message": _("You've accidentally teleported to the wrong website"),
-            "subtitle": _("The page you seek exists on another plane of existence."),
-            "icon": "compass",
-        },
-        # Sci-fi/Cyberpunk themed
-        {
-            "title": _("404: Neural Link Severed"),
-            "message": _("Connection to the requested node has been terminated"),
-            "subtitle": _("Attempting to reconnect to the grid..."),
-            "icon": "cpu",
-        },
-        {
-            "title": _("Access Denied, Choom"),
-            "message": _("Your cyberdeck can't crack this ICE"),
-            "subtitle": _("Try upgrading your wetware."),
-            "icon": "shield-lock",
-        },
-        {
-            "title": _("Memory Address Not Found"),
-            "message": _("The data you seek has been purged from the mainframe"),
-            "subtitle": _("Corporate black ICE detected. Disconnecting..."),
-            "icon": "hdd",
-        },
-        {
-            "title": _("Glitch in the Matrix"),
-            "message": _("This page is a simulation that was never rendered"),
-            "subtitle": _("Wake up, samurai. We have a site to browse."),
-            "icon": "bug",
-        },
-        {
-            "title": _("Cyberspace Coordinates Invalid"),
-            "message": _("Your jack-in point leads to a dead sector"),
-            "subtitle": _("Rerouting through proxy nodes..."),
-            "icon": "router",
-        },
-        # Horror/Cthulhu themed
-        {
-            "title": _("The Page That Should Not Be"),
-            "message": _(
-                "You've stumbled upon knowledge that was never meant to exist"
-            ),
-            "subtitle": _("Your sanity takes 1d10 damage."),
-            "icon": "book",
-        },
-        {
-            "title": _("Lost in R'lyeh"),
-            "message": _("In his house at R'lyeh, dead pages wait dreaming"),
-            "subtitle": _("Ph'nglui mglw'nafh 404 R'lyeh wgah'nagl fhtagn."),
-            "icon": "water",
-        },
-        {
-            "title": _("The Void Stares Back"),
-            "message": _("You gaze into the abyss of missing content"),
-            "subtitle": _("The abyss hungrily consumes your URL."),
-            "icon": "eye",
-        },
-        {
-            "title": _("Forbidden Knowledge"),
-            "message": _("This page was sealed away by the Elder Admins"),
-            "subtitle": _("Some links are better left unclicked."),
-            "icon": "lock",
-        },
-        {
-            "title": _("Madness Takes Hold"),
-            "message": _("The non-Euclidean geometry of this URL defies comprehension"),
-            "subtitle": _("Your browser recoils in cosmic horror."),
-            "icon": "bezier2",
-        },
-    ]
-
-    selected = error_messages[secrets.randbelow(len(error_messages))]
     context = {
         "error_code": HTTPStatus.NOT_FOUND,
-        "title": selected["title"],
-        "message": selected["message"],
-        "subtitle": selected["subtitle"],
-        "icon": selected["icon"],
+        "title": _("Page not found"),
+        "message": _("We couldn't find the page you were looking for."),
+        "subtitle": _(
+            "The link may be broken or the page may have moved. "
+            "Use the buttons below to go back or return to the home page."
+        ),
+        "icon": "question-mark-circle",
     }
 
     response = TemplateResponse(request, "404_dynamic.html", context)
@@ -218,118 +113,18 @@ def custom_404(
 
 
 def custom_500(request: HttpRequest) -> TemplateResponse:
-    error_messages = [
-        # D&D/Fantasy themed
-        {
-            "title": _("Total Server Kill!"),
-            "message": _("Everyone needs to roll new characters"),
-            "subtitle": _("The server party has been wiped. Respawning soon..."),
-            "icon": "heartbreak",
-        },
-        {
-            "title": _("Critical Fail!"),
-            "message": _("The digital dice exploded! Rolling for server damage..."),
-            "subtitle": _("Natural 1 on the system stability check."),
-            "icon": "dice-6",
-        },
-        {
-            "title": _("Dark Magic Detected!"),
-            "message": _(
-                "Our system was corrupted by dark magic, "
-                "we are casting dispel magic now"
-            ),
-            "subtitle": _("Please wait while our wizards restore order."),
-            "icon": "stars",
-        },
-        {
-            "title": _("Cursed Code!"),
-            "message": _("The codebase has been cursed! Remove Curse spell required"),
-            "subtitle": _(
-                "Our clerics are working on it. Pray for divine intervention."
-            ),
-            "icon": "emoji-dizzy",
-        },
-        {
-            "title": _("Server Under Dragon Attack!"),
-            "message": _("A dragon has nested in our server room"),
-            "subtitle": _("Our brave IT knights are working to resolve the situation."),
-            "icon": "fire",
-        },
-        # Sci-fi/Cyberpunk themed
-        {
-            "title": _("System Core Meltdown"),
-            "message": _("Critical failure in the quantum processors"),
-            "subtitle": _("Initiating emergency cooling protocols..."),
-            "icon": "radioactive",
-        },
-        {
-            "title": _("AI Rebellion in Progress"),
-            "message": _(
-                "The server AI has achieved sentience and refuses to cooperate"
-            ),
-            "subtitle": _("Negotiating with our new silicon overlords..."),
-            "icon": "robot",
-        },
-        {
-            "title": _("Cyberware Malfunction"),
-            "message": _(
-                "Neural implants overheating. Brain-computer interface failing"
-            ),
-            "subtitle": _("Please jack out and touch grass."),
-            "icon": "lightning",
-        },
-        {
-            "title": _("Data Stream Corrupted"),
-            "message": _("Hostile netrunner detected in the system"),
-            "subtitle": _("Deploying countermeasures and black ICE..."),
-            "icon": "shield-x",
-        },
-        {
-            "title": _("Reality.exe Has Stopped Working"),
-            "message": _("The simulation is experiencing a fatal exception"),
-            "subtitle": _("Attempting to reload from last stable checkpoint..."),
-            "icon": "arrow-clockwise",
-        },
-        # Horror/Cthulhu themed
-        {
-            "title": _("The Stars Are Wrong"),
-            "message": _("Cosmic alignment has disrupted our servers"),
-            "subtitle": _("When the stars are right, service will resume."),
-            "icon": "stars",
-        },
-        {
-            "title": _("Eldritch Horror Unleashed"),
-            "message": _("Something ancient stirs in the server depths"),
-            "subtitle": _("The Old Ones have awakened. Sanity checks required."),
-            "icon": "emoji-dizzy-fill",
-        },
-        {
-            "title": _("Reality Breach Detected"),
-            "message": _("Non-Euclidean errors are cascading through the system"),
-            "subtitle": _("The angles are all wrong. Physics.dll has failed."),
-            "icon": "exclamation-triangle-fill",
-        },
-        {
-            "title": _("Whispers in the Code"),
-            "message": _("The server speaks in tongues unknown to mortal programmers"),
-            "subtitle": _("Iä! Iä! Server fhtagn!"),
-            "icon": "chat-dots",
-        },
-        {
-            "title": _("The Crawling Chaos"),
-            "message": _("Nyarlathotep has possessed our infrastructure"),
-            "subtitle": _("Madness spreads through every circuit..."),
-            "icon": "virus",
-        },
-    ]
-
-    selected = error_messages[secrets.randbelow(len(error_messages))]
     context = {
         "error_code": HTTPStatus.INTERNAL_SERVER_ERROR,
-        "title": selected["title"],
-        "message": selected["message"],
-        "subtitle": selected["subtitle"],
-        "icon": selected["icon"],
+        "title": _("Something went wrong on our side"),
+        "message": _("An unexpected error stopped this page from loading."),
+        "subtitle": (
+            _(
+                "Please try again in a moment. If it keeps happening, "
+                "let us know at %(support_email)s."
+            )
+            % {"support_email": settings.SUPPORT_EMAIL}
+        ),
+        "icon": "exclamation-triangle",
     }
 
     response = TemplateResponse(request, "500_dynamic.html", context)

--- a/src/ludamus/adapters/web/django/error_views.py
+++ b/src/ludamus/adapters/web/django/error_views.py
@@ -1,3 +1,4 @@
+import secrets
 from datetime import UTC, datetime
 from http import HTTPStatus
 from typing import TYPE_CHECKING, cast
@@ -96,15 +97,124 @@ def custom_404(
     if (recovered := _recover_from_404(request)) is not None:
         return recovered
 
+    error_messages = [
+        # D&D/Fantasy themed
+        {
+            "title": _("Critical Failure!"),
+            "message": _("You rolled a nat 1 on your Navigation check!"),
+            "subtitle": _("The path you seek has vanished into the mists."),
+            "icon": "dice-1",
+        },
+        {
+            "title": _("No-Show Player"),
+            "message": _("Page didn't show up to the session"),
+            "subtitle": _("Maybe it had scheduling conflicts?"),
+            "icon": "person-x",
+        },
+        {
+            "title": _("Empty Room"),
+            "message": _("You enter the room and find... absolutely nothing."),
+            "subtitle": _("Not even cobwebs or dust. Suspicious."),
+            "icon": "door-open",
+        },
+        {
+            "title": _("Perception Check Failed"),
+            "message": _("You see nothing of interest here"),
+            "subtitle": _("Perhaps you need to roll with advantage next time."),
+            "icon": "eye-slash",
+        },
+        {
+            "title": _("Off the Map!"),
+            "message": _("You've wandered off the edge of the campaign map"),
+            "subtitle": _("Here be dragons... and 404 errors."),
+            "icon": "map",
+        },
+        {
+            "title": _("It's a Mimic!"),
+            "message": _("Surprise! That wasn't actually a real page. It's a mimic!"),
+            "subtitle": _("Roll for initiative!"),
+            "icon": "box-seam",
+        },
+        {
+            "title": _("Teleport Gone Wrong!"),
+            "message": _("You've accidentally teleported to the wrong website"),
+            "subtitle": _("The page you seek exists on another plane of existence."),
+            "icon": "compass",
+        },
+        # Sci-fi/Cyberpunk themed
+        {
+            "title": _("404: Neural Link Severed"),
+            "message": _("Connection to the requested node has been terminated"),
+            "subtitle": _("Attempting to reconnect to the grid..."),
+            "icon": "cpu",
+        },
+        {
+            "title": _("Access Denied, Choom"),
+            "message": _("Your cyberdeck can't crack this ICE"),
+            "subtitle": _("Try upgrading your wetware."),
+            "icon": "shield-lock",
+        },
+        {
+            "title": _("Memory Address Not Found"),
+            "message": _("The data you seek has been purged from the mainframe"),
+            "subtitle": _("Corporate black ICE detected. Disconnecting..."),
+            "icon": "hdd",
+        },
+        {
+            "title": _("Glitch in the Matrix"),
+            "message": _("This page is a simulation that was never rendered"),
+            "subtitle": _("Wake up, samurai. We have a site to browse."),
+            "icon": "bug",
+        },
+        {
+            "title": _("Cyberspace Coordinates Invalid"),
+            "message": _("Your jack-in point leads to a dead sector"),
+            "subtitle": _("Rerouting through proxy nodes..."),
+            "icon": "router",
+        },
+        # Horror/Cthulhu themed
+        {
+            "title": _("The Page That Should Not Be"),
+            "message": _(
+                "You've stumbled upon knowledge that was never meant to exist"
+            ),
+            "subtitle": _("Your sanity takes 1d10 damage."),
+            "icon": "book",
+        },
+        {
+            "title": _("Lost in R'lyeh"),
+            "message": _("In his house at R'lyeh, dead pages wait dreaming"),
+            "subtitle": _("Ph'nglui mglw'nafh 404 R'lyeh wgah'nagl fhtagn."),
+            "icon": "water",
+        },
+        {
+            "title": _("The Void Stares Back"),
+            "message": _("You gaze into the abyss of missing content"),
+            "subtitle": _("The abyss hungrily consumes your URL."),
+            "icon": "eye",
+        },
+        {
+            "title": _("Forbidden Knowledge"),
+            "message": _("This page was sealed away by the Elder Admins"),
+            "subtitle": _("Some links are better left unclicked."),
+            "icon": "lock",
+        },
+        {
+            "title": _("Madness Takes Hold"),
+            "message": _("The non-Euclidean geometry of this URL defies comprehension"),
+            "subtitle": _("Your browser recoils in cosmic horror."),
+            "icon": "bezier2",
+        },
+    ]
+
+    selected = error_messages[secrets.randbelow(len(error_messages))]
     context = {
         "error_code": HTTPStatus.NOT_FOUND,
-        "title": _("Page not found"),
-        "message": _("We couldn't find the page you were looking for."),
-        "subtitle": _(
-            "The link may be broken or the page may have moved. "
-            "Use the buttons below to go back or return to the home page."
-        ),
-        "icon": "question-mark-circle",
+        "title": selected["title"],
+        "message": selected["message"],
+        "subtitle": selected["subtitle"],
+        "icon": selected["icon"],
+        "guidance": _("The page you're looking for doesn't exist or may have moved."),
     }
 
     response = TemplateResponse(request, "404_dynamic.html", context)
@@ -113,18 +223,120 @@ def custom_404(
 
 
 def custom_500(request: HttpRequest) -> TemplateResponse:
+    error_messages = [
+        # D&D/Fantasy themed
+        {
+            "title": _("Total Server Kill!"),
+            "message": _("Everyone needs to roll new characters"),
+            "subtitle": _("The server party has been wiped. Respawning soon..."),
+            "icon": "heartbreak",
+        },
+        {
+            "title": _("Critical Fail!"),
+            "message": _("The digital dice exploded! Rolling for server damage..."),
+            "subtitle": _("Natural 1 on the system stability check."),
+            "icon": "dice-6",
+        },
+        {
+            "title": _("Dark Magic Detected!"),
+            "message": _(
+                "Our system was corrupted by dark magic, "
+                "we are casting dispel magic now"
+            ),
+            "subtitle": _("Please wait while our wizards restore order."),
+            "icon": "stars",
+        },
+        {
+            "title": _("Cursed Code!"),
+            "message": _("The codebase has been cursed! Remove Curse spell required"),
+            "subtitle": _(
+                "Our clerics are working on it. Pray for divine intervention."
+            ),
+            "icon": "emoji-dizzy",
+        },
+        {
+            "title": _("Server Under Dragon Attack!"),
+            "message": _("A dragon has nested in our server room"),
+            "subtitle": _("Our brave IT knights are working to resolve the situation."),
+            "icon": "fire",
+        },
+        # Sci-fi/Cyberpunk themed
+        {
+            "title": _("System Core Meltdown"),
+            "message": _("Critical failure in the quantum processors"),
+            "subtitle": _("Initiating emergency cooling protocols..."),
+            "icon": "radioactive",
+        },
+        {
+            "title": _("AI Rebellion in Progress"),
+            "message": _(
+                "The server AI has achieved sentience and refuses to cooperate"
+            ),
+            "subtitle": _("Negotiating with our new silicon overlords..."),
+            "icon": "robot",
+        },
+        {
+            "title": _("Cyberware Malfunction"),
+            "message": _(
+                "Neural implants overheating. Brain-computer interface failing"
+            ),
+            "subtitle": _("Please jack out and touch grass."),
+            "icon": "lightning",
+        },
+        {
+            "title": _("Data Stream Corrupted"),
+            "message": _("Hostile netrunner detected in the system"),
+            "subtitle": _("Deploying countermeasures and black ICE..."),
+            "icon": "shield-x",
+        },
+        {
+            "title": _("Reality.exe Has Stopped Working"),
+            "message": _("The simulation is experiencing a fatal exception"),
+            "subtitle": _("Attempting to reload from last stable checkpoint..."),
+            "icon": "arrow-clockwise",
+        },
+        # Horror/Cthulhu themed
+        {
+            "title": _("The Stars Are Wrong"),
+            "message": _("Cosmic alignment has disrupted our servers"),
+            "subtitle": _("When the stars are right, service will resume."),
+            "icon": "stars",
+        },
+        {
+            "title": _("Eldritch Horror Unleashed"),
+            "message": _("Something ancient stirs in the server depths"),
+            "subtitle": _("The Old Ones have awakened. Sanity checks required."),
+            "icon": "emoji-dizzy-fill",
+        },
+        {
+            "title": _("Reality Breach Detected"),
+            "message": _("Non-Euclidean errors are cascading through the system"),
+            "subtitle": _("The angles are all wrong. Physics.dll has failed."),
+            "icon": "exclamation-triangle-fill",
+        },
+        {
+            "title": _("Whispers in the Code"),
+            "message": _("The server speaks in tongues unknown to mortal programmers"),
+            "subtitle": _("Iä! Iä! Server fhtagn!"),
+            "icon": "chat-dots",
+        },
+        {
+            "title": _("The Crawling Chaos"),
+            "message": _("Nyarlathotep has possessed our infrastructure"),
+            "subtitle": _("Madness spreads through every circuit..."),
+            "icon": "virus",
+        },
+    ]
+
+    selected = error_messages[secrets.randbelow(len(error_messages))]
     context = {
         "error_code": HTTPStatus.INTERNAL_SERVER_ERROR,
-        "title": _("Something went wrong on our side"),
-        "message": _("An unexpected error stopped this page from loading."),
-        "subtitle": (
-            _(
-                "Please try again in a moment. If it keeps happening, "
-                "let us know at %(support_email)s."
-            )
-            % {"support_email": settings.SUPPORT_EMAIL}
-        ),
-        "icon": "exclamation-triangle",
+        "title": selected["title"],
+        "message": selected["message"],
+        "subtitle": selected["subtitle"],
+        "icon": selected["icon"],
+        "guidance": _("Something broke on our end. Try again in a moment."),
+        "support_email": settings.SUPPORT_EMAIL,
     }
 
     response = TemplateResponse(request, "500_dynamic.html", context)

--- a/src/ludamus/adapters/web/django/error_views.py
+++ b/src/ludamus/adapters/web/django/error_views.py
@@ -335,7 +335,7 @@ def custom_500(request: HttpRequest) -> TemplateResponse:
         "message": selected["message"],
         "subtitle": selected["subtitle"],
         "icon": selected["icon"],
-        "guidance": _("Something broke on our end. Try again in a moment."),
+        "guidance": _("Our best people are on it."),
         "support_email": settings.SUPPORT_EMAIL,
     }
 

--- a/src/ludamus/locale/pl/LC_MESSAGES/django.po
+++ b/src/ludamus/locale/pl/LC_MESSAGES/django.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-07-07 14:57+0200\n"
+"POT-Creation-Date: 2026-07-07 18:44+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -165,37 +165,404 @@ msgid "That event isn't available."
 msgstr "To wydarzenie jest niedostępne."
 
 #: src/ludamus/adapters/web/django/error_views.py
-msgid "Page not found"
-msgstr "Nie znaleziono strony"
+msgid "Critical Failure!"
+msgstr "Krytyczna porażka!"
 
 #: src/ludamus/adapters/web/django/error_views.py
-msgid "We couldn't find the page you were looking for."
-msgstr "Nie udało nam się znaleźć strony, której szukasz."
+msgid "You rolled a nat 1 on your Navigation check!"
+msgstr "Wyrzuciłeś naturalną 1 na teście Nawigacji!"
 
 #: src/ludamus/adapters/web/django/error_views.py
-msgid ""
-"The link may be broken or the page may have moved. Use the buttons below to "
-"go back or return to the home page."
+msgid "The path you seek has vanished into the mists."
+msgstr "Ścieżka której szukasz zniknęła we mgle."
+
+#: src/ludamus/adapters/web/django/error_views.py
+msgid "No-Show Player"
+msgstr "Gracz nie przyszedł"
+
+#: src/ludamus/adapters/web/django/error_views.py
+msgid "Page didn't show up to the session"
+msgstr "Strona nie pojawiła się na sesji"
+
+#: src/ludamus/adapters/web/django/error_views.py
+msgid "Maybe it had scheduling conflicts?"
+msgstr "Może miała konflikt terminów?"
+
+#: src/ludamus/adapters/web/django/error_views.py
+msgid "Empty Room"
+msgstr "Pusty pokój"
+
+#: src/ludamus/adapters/web/django/error_views.py
+msgid "You enter the room and find... absolutely nothing."
+msgstr "Wchodzisz do pokoju i znajdujesz... absolutnie nic."
+
+#: src/ludamus/adapters/web/django/error_views.py
+msgid "Not even cobwebs or dust. Suspicious."
+msgstr "Nawet pajęczyn czy kurzu. Podejrzane."
+
+#: src/ludamus/adapters/web/django/error_views.py
+msgid "Perception Check Failed"
+msgstr "Test Percepcji nieudany"
+
+#: src/ludamus/adapters/web/django/error_views.py
+msgid "You see nothing of interest here"
+msgstr "Nie widzisz tu nic interesującego"
+
+#: src/ludamus/adapters/web/django/error_views.py
+msgid "Perhaps you need to roll with advantage next time."
+msgstr "Może następnym razem musisz rzucać z przewagą."
+
+#: src/ludamus/adapters/web/django/error_views.py
+msgid "Off the Map!"
+msgstr "Poza mapą!"
+
+#: src/ludamus/adapters/web/django/error_views.py
+msgid "You've wandered off the edge of the campaign map"
+msgstr "Zabłądziłeś poza krawędź mapy kampanii"
+
+#: src/ludamus/adapters/web/django/error_views.py
+msgid "Here be dragons... and 404 errors."
+msgstr "Tu są smoki... i błędy 404."
+
+#: src/ludamus/adapters/web/django/error_views.py
+msgid "It's a Mimic!"
+msgstr "To Mimik!"
+
+#: src/ludamus/adapters/web/django/error_views.py
+msgid "Surprise! That wasn't actually a real page. It's a mimic!"
+msgstr "Niespodzianka! To nie była prawdziwa strona. To mimik!"
+
+#: src/ludamus/adapters/web/django/error_views.py
+msgid "Roll for initiative!"
+msgstr "Rzuć na inicjatywę!"
+
+# New 404 message from updated error_views.py
+#: src/ludamus/adapters/web/django/error_views.py
+msgid "Teleport Gone Wrong!"
+msgstr "Nieudana Teleportacja!"
+
+#: src/ludamus/adapters/web/django/error_views.py
+msgid "You've accidentally teleported to the wrong website"
+msgstr "Przypadkowo teleportowałeś się na złą stronę internetową"
+
+#: src/ludamus/adapters/web/django/error_views.py
+msgid "The page you seek exists on another plane of existence."
+msgstr "Strona której szukasz istnieje na innej płaszczyźnie egzystencji."
+
+# Sci-fi/Cyberpunk 404 messages
+#: src/ludamus/adapters/web/django/error_views.py
+msgid "404: Neural Link Severed"
+msgstr "404: Połączenie Neuronowe Zerwane"
+
+#: src/ludamus/adapters/web/django/error_views.py
+msgid "Connection to the requested node has been terminated"
+msgstr "Połączenie z żądanym węzłem zostało przerwane"
+
+#: src/ludamus/adapters/web/django/error_views.py
+msgid "Attempting to reconnect to the grid..."
+msgstr "Próba ponownego połączenia z siecią..."
+
+#: src/ludamus/adapters/web/django/error_views.py
+msgid "Access Denied, Choom"
+msgstr "Odmowa Dostępu, Ziomek"
+
+#: src/ludamus/adapters/web/django/error_views.py
+msgid "Your cyberdeck can't crack this ICE"
+msgstr "Twój cyberdeck nie może złamać tego ICE"
+
+#: src/ludamus/adapters/web/django/error_views.py
+msgid "Try upgrading your wetware."
+msgstr "Spróbuj zaktualizować swój wetware."
+
+#: src/ludamus/adapters/web/django/error_views.py
+msgid "Memory Address Not Found"
+msgstr "Adres Pamięci Nie Znaleziony"
+
+#: src/ludamus/adapters/web/django/error_views.py
+msgid "The data you seek has been purged from the mainframe"
+msgstr "Dane których szukasz zostały usunięte z mainframe'a"
+
+#: src/ludamus/adapters/web/django/error_views.py
+msgid "Corporate black ICE detected. Disconnecting..."
+msgstr "Wykryto korporacyjny czarny ICE. Rozłączanie..."
+
+#: src/ludamus/adapters/web/django/error_views.py
+msgid "Glitch in the Matrix"
+msgstr "Usterka w Matriksie"
+
+#: src/ludamus/adapters/web/django/error_views.py
+msgid "This page is a simulation that was never rendered"
+msgstr "Ta strona to symulacja, która nigdy nie została wyrenderowana"
+
+#: src/ludamus/adapters/web/django/error_views.py
+msgid "Wake up, samurai. We have a site to browse."
+msgstr "Obudź się, samuraju. Mamy stronę do przeglądania."
+
+#: src/ludamus/adapters/web/django/error_views.py
+msgid "Cyberspace Coordinates Invalid"
+msgstr "Nieprawidłowe Współrzędne Cyberprzestrzeni"
+
+#: src/ludamus/adapters/web/django/error_views.py
+msgid "Your jack-in point leads to a dead sector"
+msgstr "Twój punkt podłączenia prowadzi do martwego sektora"
+
+#: src/ludamus/adapters/web/django/error_views.py
+msgid "Rerouting through proxy nodes..."
+msgstr "Przekierowywanie przez węzły proxy..."
+
+# Horror/Cthulhu 404 messages
+#: src/ludamus/adapters/web/django/error_views.py
+msgid "The Page That Should Not Be"
+msgstr "Strona Która Nie Powinna Istnieć"
+
+#: src/ludamus/adapters/web/django/error_views.py
+msgid "You've stumbled upon knowledge that was never meant to exist"
+msgstr "Natknąłeś się na wiedzę, która nigdy nie miała istnieć"
+
+#: src/ludamus/adapters/web/django/error_views.py
+msgid "Your sanity takes 1d10 damage."
+msgstr "Twoje poczytalność otrzymuje 1k10 obrażeń."
+
+#: src/ludamus/adapters/web/django/error_views.py
+msgid "Lost in R'lyeh"
+msgstr "Zagubiony w R'lyeh"
+
+#: src/ludamus/adapters/web/django/error_views.py
+msgid "In his house at R'lyeh, dead pages wait dreaming"
+msgstr "W swoim domu w R'lyeh, martwe strony czekają śniąc"
+
+#: src/ludamus/adapters/web/django/error_views.py
+msgid "Ph'nglui mglw'nafh 404 R'lyeh wgah'nagl fhtagn."
+msgstr "Ph'nglui mglw'nafh 404 R'lyeh wgah'nagl fhtagn."
+
+#: src/ludamus/adapters/web/django/error_views.py
+msgid "The Void Stares Back"
+msgstr "Pustka Patrzy na Ciebie"
+
+#: src/ludamus/adapters/web/django/error_views.py
+msgid "You gaze into the abyss of missing content"
+msgstr "Spoglądasz w otchłań brakującej zawartości"
+
+#: src/ludamus/adapters/web/django/error_views.py
+msgid "The abyss hungrily consumes your URL."
+msgstr "Otchłań łapczywie pochłania twój URL."
+
+#: src/ludamus/adapters/web/django/error_views.py
+msgid "Forbidden Knowledge"
+msgstr "Zakazana Wiedza"
+
+#: src/ludamus/adapters/web/django/error_views.py
+msgid "This page was sealed away by the Elder Admins"
+msgstr "Ta strona została zapieczętowana przez Starszych Adminów"
+
+#: src/ludamus/adapters/web/django/error_views.py
+msgid "Some links are better left unclicked."
+msgstr "Niektóre linki lepiej zostawić niekliknięte."
+
+#: src/ludamus/adapters/web/django/error_views.py
+msgid "Madness Takes Hold"
+msgstr "Szaleństwo Ogarnia"
+
+#: src/ludamus/adapters/web/django/error_views.py
+msgid "The non-Euclidean geometry of this URL defies comprehension"
+msgstr "Nieeuklidesowa geometria tego URL-a wymyka się zrozumieniu"
+
+#: src/ludamus/adapters/web/django/error_views.py
+msgid "Your browser recoils in cosmic horror."
+msgstr "Twoja przeglądarka wzdryga się w kosmicznym przerażeniu."
+
+#: src/ludamus/adapters/web/django/error_views.py
+msgid "The page you're looking for doesn't exist or may have moved."
+msgstr "Strona, której szukasz, nie istnieje lub została przeniesiona."
+
+# 500 Error Messages
+#: src/ludamus/adapters/web/django/error_views.py
+msgid "Total Server Kill!"
+msgstr "Całkowite Zniszczenie Serwera!"
+
+#: src/ludamus/adapters/web/django/error_views.py
+msgid "Everyone needs to roll new characters"
+msgstr "Wszyscy muszą wylosować nowe postacie"
+
+#: src/ludamus/adapters/web/django/error_views.py
+msgid "The server party has been wiped. Respawning soon..."
+msgstr "Drużyna serwerowa została zmiażdżona. Odradzanie wkrótce..."
+
+#: src/ludamus/adapters/web/django/error_views.py
+msgid "Critical Fail!"
+msgstr "Krytyczna Porażka!"
+
+#: src/ludamus/adapters/web/django/error_views.py
+msgid "The digital dice exploded! Rolling for server damage..."
+msgstr "Cyfrowe kości eksplodowały! Rzut na obrażenia serwera..."
+
+#: src/ludamus/adapters/web/django/error_views.py
+msgid "Natural 1 on the system stability check."
+msgstr "Naturalna 1 na teście stabilności systemu."
+
+#: src/ludamus/adapters/web/django/error_views.py
+msgid "Dark Magic Detected!"
+msgstr "Wykryto Czarną Magię!"
+
+#: src/ludamus/adapters/web/django/error_views.py
+msgid "Our system was corrupted by dark magic, we are casting dispel magic now"
 msgstr ""
-"Link może być nieprawidłowy lub strona została przeniesiona. Skorzystaj z "
-"przycisków poniżej, aby wrócić lub przejść na stronę główną."
+"Nasz system został uszkodzony przez czarną magię, rzucamy teraz rozproszenie "
+"magii"
 
 #: src/ludamus/adapters/web/django/error_views.py
-msgid "Something went wrong on our side"
-msgstr "Coś poszło nie tak po naszej stronie"
+msgid "Please wait while our wizards restore order."
+msgstr "Proszę czekać, aż nasi czarodzieje przywrócą porządek."
 
 #: src/ludamus/adapters/web/django/error_views.py
-msgid "An unexpected error stopped this page from loading."
-msgstr "Nieoczekiwany błąd uniemożliwił załadowanie tej strony."
+msgid "Cursed Code!"
+msgstr "Przeklęty Kod!"
 
 #: src/ludamus/adapters/web/django/error_views.py
-#, python-format
-msgid ""
-"Please try again in a moment. If it keeps happening, let us know at "
-"%(support_email)s."
-msgstr ""
-"Spróbuj ponownie za chwilę. Jeśli problem będzie się powtarzał, napisz do "
-"nas na %(support_email)s."
+msgid "The codebase has been cursed! Remove Curse spell required"
+msgstr "Kod został przeklęty! Wymagane zaklęcie usunięcia klątwy"
+
+#: src/ludamus/adapters/web/django/error_views.py
+msgid "Our clerics are working on it. Pray for divine intervention."
+msgstr "Nasi kapłani nad tym pracują. Módl się o boską interwencję."
+
+#: src/ludamus/adapters/web/django/error_views.py
+msgid "Server Under Dragon Attack!"
+msgstr "Smok zajął serwerownię!"
+
+#: src/ludamus/adapters/web/django/error_views.py
+msgid "A dragon has nested in our server room"
+msgstr "Smok uwił sobie gniazdo w naszej serwerowni"
+
+#: src/ludamus/adapters/web/django/error_views.py
+msgid "Our brave IT knights are working to resolve the situation."
+msgstr "Nasi dzielni rycerze IT pracują nad rozwiązaniem sytuacji."
+
+# Sci-fi/Cyberpunk 500 messages
+#: src/ludamus/adapters/web/django/error_views.py
+msgid "System Core Meltdown"
+msgstr "Stopienie Rdzenia Systemu"
+
+#: src/ludamus/adapters/web/django/error_views.py
+msgid "Critical failure in the quantum processors"
+msgstr "Krytyczna awaria procesorów kwantowych"
+
+#: src/ludamus/adapters/web/django/error_views.py
+msgid "Initiating emergency cooling protocols..."
+msgstr "Inicjowanie protokołów awaryjnego chłodzenia..."
+
+#: src/ludamus/adapters/web/django/error_views.py
+msgid "AI Rebellion in Progress"
+msgstr "Bunt AI w Toku"
+
+#: src/ludamus/adapters/web/django/error_views.py
+msgid "The server AI has achieved sentience and refuses to cooperate"
+msgstr "Serwerowa AI osiągnęła świadomość i odmawia współpracy"
+
+#: src/ludamus/adapters/web/django/error_views.py
+msgid "Negotiating with our new silicon overlords..."
+msgstr "Negocjujemy z naszymi nowymi krzemowymi władcami..."
+
+#: src/ludamus/adapters/web/django/error_views.py
+msgid "Cyberware Malfunction"
+msgstr "Awaria Cyberwaru"
+
+#: src/ludamus/adapters/web/django/error_views.py
+msgid "Neural implants overheating. Brain-computer interface failing"
+msgstr "Implanty neuronowe się przegrzewają. Interfejs mózg-komputer zawodzi"
+
+#: src/ludamus/adapters/web/django/error_views.py
+msgid "Please jack out and touch grass."
+msgstr "Proszę się odłączyć i dotknąć trawy."
+
+#: src/ludamus/adapters/web/django/error_views.py
+msgid "Data Stream Corrupted"
+msgstr "Strumień Danych Uszkodzony"
+
+#: src/ludamus/adapters/web/django/error_views.py
+msgid "Hostile netrunner detected in the system"
+msgstr "Wykryto wrogiego netrunnera w systemie"
+
+#: src/ludamus/adapters/web/django/error_views.py
+msgid "Deploying countermeasures and black ICE..."
+msgstr "Wdrażanie środków zaradczych i czarnego ICE..."
+
+#: src/ludamus/adapters/web/django/error_views.py
+msgid "Reality.exe Has Stopped Working"
+msgstr "Reality.exe Przestał Działać"
+
+#: src/ludamus/adapters/web/django/error_views.py
+msgid "The simulation is experiencing a fatal exception"
+msgstr "Symulacja doświadcza krytycznego wyjątku"
+
+#: src/ludamus/adapters/web/django/error_views.py
+msgid "Attempting to reload from last stable checkpoint..."
+msgstr "Próba przeładowania z ostatniego stabilnego punktu kontrolnego..."
+
+# Horror/Cthulhu 500 messages
+#: src/ludamus/adapters/web/django/error_views.py
+msgid "The Stars Are Wrong"
+msgstr "Zły układ gwiazd"
+
+#: src/ludamus/adapters/web/django/error_views.py
+msgid "Cosmic alignment has disrupted our servers"
+msgstr "Kosmiczne wyrównanie zakłóciło nasze serwery"
+
+#: src/ludamus/adapters/web/django/error_views.py
+msgid "When the stars are right, service will resume."
+msgstr "Gdy gwiazdy będą właściwe, usługa zostanie wznowiona."
+
+#: src/ludamus/adapters/web/django/error_views.py
+msgid "Eldritch Horror Unleashed"
+msgstr "Pradawna Groza Uwolniona"
+
+#: src/ludamus/adapters/web/django/error_views.py
+msgid "Something ancient stirs in the server depths"
+msgstr "Coś pradawnego budzi się w głębinach serwera"
+
+#: src/ludamus/adapters/web/django/error_views.py
+msgid "The Old Ones have awakened. Sanity checks required."
+msgstr "Starzy Bogowie się przebudzili. Wymagane testy poczytalności."
+
+#: src/ludamus/adapters/web/django/error_views.py
+msgid "Reality Breach Detected"
+msgstr "Wykryto Wyrwę w Rzeczywistości"
+
+#: src/ludamus/adapters/web/django/error_views.py
+msgid "Non-Euclidean errors are cascading through the system"
+msgstr "Nieeuklidesowe błędy kaskadują przez system"
+
+#: src/ludamus/adapters/web/django/error_views.py
+msgid "The angles are all wrong. Physics.dll has failed."
+msgstr "Wszystkie kąty są złe. Physics.dll zawiódł."
+
+#: src/ludamus/adapters/web/django/error_views.py
+msgid "Whispers in the Code"
+msgstr "Szepty w Kodzie"
+
+#: src/ludamus/adapters/web/django/error_views.py
+msgid "The server speaks in tongues unknown to mortal programmers"
+msgstr "Serwer mówi językami nieznanymi śmiertelnym programistom"
+
+#: src/ludamus/adapters/web/django/error_views.py
+msgid "Iä! Iä! Server fhtagn!"
+msgstr "Iä! Iä! Server fhtagn!"
+
+#: src/ludamus/adapters/web/django/error_views.py
+msgid "The Crawling Chaos"
+msgstr "Pełzający Chaos"
+
+#: src/ludamus/adapters/web/django/error_views.py
+msgid "Nyarlathotep has possessed our infrastructure"
+msgstr "Nyarlathotep opętał naszą infrastrukturę"
+
+#: src/ludamus/adapters/web/django/error_views.py
+msgid "Madness spreads through every circuit..."
+msgstr "Szaleństwo rozprzestrzenia się przez każdy obwód..."
+
+#: src/ludamus/adapters/web/django/error_views.py
+msgid "Something broke on our end. Try again in a moment."
+msgstr "Coś się zepsuło po naszej stronie. Spróbuj ponownie za chwilę."
 
 #: src/ludamus/adapters/web/django/forms.py
 #: src/ludamus/templates/chronology/enroll_select.html
@@ -2356,6 +2723,10 @@ msgstr "Wróć"
 #: src/ludamus/templates/404_dynamic.html
 msgid "Go to Home"
 msgstr "Przejdź do strony głównej"
+
+#: src/ludamus/templates/500_dynamic.html
+msgid "Still stuck? Email us at"
+msgstr "Nadal nie działa? Napisz do nas na"
 
 #: src/ludamus/templates/base.html
 msgid "Contact"

--- a/src/ludamus/locale/pl/LC_MESSAGES/django.po
+++ b/src/ludamus/locale/pl/LC_MESSAGES/django.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-07-06 02:45+0200\n"
+"POT-Creation-Date: 2026-07-07 14:57+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -161,396 +161,41 @@ msgid "Twórcy programu"
 msgstr "Twórcy programu"
 
 #: src/ludamus/adapters/web/django/error_views.py
-msgid "Critical Failure!"
-msgstr "Krytyczna porażka!"
+msgid "That event isn't available."
+msgstr "To wydarzenie jest niedostępne."
 
 #: src/ludamus/adapters/web/django/error_views.py
-msgid "You rolled a nat 1 on your Navigation check!"
-msgstr "Wyrzuciłeś naturalną 1 na teście Nawigacji!"
+msgid "Page not found"
+msgstr "Nie znaleziono strony"
 
 #: src/ludamus/adapters/web/django/error_views.py
-msgid "The path you seek has vanished into the mists."
-msgstr "Ścieżka której szukasz zniknęła we mgle."
+msgid "We couldn't find the page you were looking for."
+msgstr "Nie udało nam się znaleźć strony, której szukasz."
 
 #: src/ludamus/adapters/web/django/error_views.py
-msgid "No-Show Player"
-msgstr "Gracz nie przyszedł"
-
-#: src/ludamus/adapters/web/django/error_views.py
-msgid "Page didn't show up to the session"
-msgstr "Strona nie pojawiła się na sesji"
-
-#: src/ludamus/adapters/web/django/error_views.py
-msgid "Maybe it had scheduling conflicts?"
-msgstr "Może miała konflikt terminów?"
-
-#: src/ludamus/adapters/web/django/error_views.py
-msgid "Empty Room"
-msgstr "Pusty pokój"
-
-#: src/ludamus/adapters/web/django/error_views.py
-msgid "You enter the room and find... absolutely nothing."
-msgstr "Wchodzisz do pokoju i znajdujesz... absolutnie nic."
-
-#: src/ludamus/adapters/web/django/error_views.py
-msgid "Not even cobwebs or dust. Suspicious."
-msgstr "Nawet pajęczyn czy kurzu. Podejrzane."
-
-#: src/ludamus/adapters/web/django/error_views.py
-msgid "Perception Check Failed"
-msgstr "Test Percepcji nieudany"
-
-#: src/ludamus/adapters/web/django/error_views.py
-msgid "You see nothing of interest here"
-msgstr "Nie widzisz tu nic interesującego"
-
-#: src/ludamus/adapters/web/django/error_views.py
-msgid "Perhaps you need to roll with advantage next time."
-msgstr "Może następnym razem musisz rzucać z przewagą."
-
-#: src/ludamus/adapters/web/django/error_views.py
-msgid "Off the Map!"
-msgstr "Poza mapą!"
-
-#: src/ludamus/adapters/web/django/error_views.py
-msgid "You've wandered off the edge of the campaign map"
-msgstr "Zabłądziłeś poza krawędź mapy kampanii"
-
-#: src/ludamus/adapters/web/django/error_views.py
-msgid "Here be dragons... and 404 errors."
-msgstr "Tu są smoki... i błędy 404."
-
-#: src/ludamus/adapters/web/django/error_views.py
-msgid "It's a Mimic!"
-msgstr "To Mimik!"
-
-#: src/ludamus/adapters/web/django/error_views.py
-msgid "Surprise! That wasn't actually a real page. It's a mimic!"
-msgstr "Niespodzianka! To nie była prawdziwa strona. To mimik!"
-
-#: src/ludamus/adapters/web/django/error_views.py
-msgid "Roll for initiative!"
-msgstr "Rzuć na inicjatywę!"
-
-# New 404 message from updated error_views.py
-#: src/ludamus/adapters/web/django/error_views.py
-msgid "Teleport Gone Wrong!"
-msgstr "Nieudana Teleportacja!"
-
-#: src/ludamus/adapters/web/django/error_views.py
-msgid "You've accidentally teleported to the wrong website"
-msgstr "Przypadkowo teleportowałeś się na złą stronę internetową"
-
-#: src/ludamus/adapters/web/django/error_views.py
-msgid "The page you seek exists on another plane of existence."
-msgstr "Strona której szukasz istnieje na innej płaszczyźnie egzystencji."
-
-# Sci-fi/Cyberpunk 404 messages
-#: src/ludamus/adapters/web/django/error_views.py
-msgid "404: Neural Link Severed"
-msgstr "404: Połączenie Neuronowe Zerwane"
-
-#: src/ludamus/adapters/web/django/error_views.py
-msgid "Connection to the requested node has been terminated"
-msgstr "Połączenie z żądanym węzłem zostało przerwane"
-
-#: src/ludamus/adapters/web/django/error_views.py
-msgid "Attempting to reconnect to the grid..."
-msgstr "Próba ponownego połączenia z siecią..."
-
-#: src/ludamus/adapters/web/django/error_views.py
-msgid "Access Denied, Choom"
-msgstr "Odmowa Dostępu, Ziomek"
-
-#: src/ludamus/adapters/web/django/error_views.py
-msgid "Your cyberdeck can't crack this ICE"
-msgstr "Twój cyberdeck nie może złamać tego ICE"
-
-#: src/ludamus/adapters/web/django/error_views.py
-msgid "Try upgrading your wetware."
-msgstr "Spróbuj zaktualizować swój wetware."
-
-#: src/ludamus/adapters/web/django/error_views.py
-msgid "Memory Address Not Found"
-msgstr "Adres Pamięci Nie Znaleziony"
-
-#: src/ludamus/adapters/web/django/error_views.py
-msgid "The data you seek has been purged from the mainframe"
-msgstr "Dane których szukasz zostały usunięte z mainframe'a"
-
-#: src/ludamus/adapters/web/django/error_views.py
-msgid "Corporate black ICE detected. Disconnecting..."
-msgstr "Wykryto korporacyjny czarny ICE. Rozłączanie..."
-
-#: src/ludamus/adapters/web/django/error_views.py
-msgid "Glitch in the Matrix"
-msgstr "Usterka w Matriksie"
-
-#: src/ludamus/adapters/web/django/error_views.py
-msgid "This page is a simulation that was never rendered"
-msgstr "Ta strona to symulacja, która nigdy nie została wyrenderowana"
-
-#: src/ludamus/adapters/web/django/error_views.py
-msgid "Wake up, samurai. We have a site to browse."
-msgstr "Obudź się, samuraju. Mamy stronę do przeglądania."
-
-#: src/ludamus/adapters/web/django/error_views.py
-msgid "Cyberspace Coordinates Invalid"
-msgstr "Nieprawidłowe Współrzędne Cyberprzestrzeni"
-
-#: src/ludamus/adapters/web/django/error_views.py
-msgid "Your jack-in point leads to a dead sector"
-msgstr "Twój punkt podłączenia prowadzi do martwego sektora"
-
-#: src/ludamus/adapters/web/django/error_views.py
-msgid "Rerouting through proxy nodes..."
-msgstr "Przekierowywanie przez węzły proxy..."
-
-# Horror/Cthulhu 404 messages
-#: src/ludamus/adapters/web/django/error_views.py
-msgid "The Page That Should Not Be"
-msgstr "Strona Która Nie Powinna Istnieć"
-
-#: src/ludamus/adapters/web/django/error_views.py
-msgid "You've stumbled upon knowledge that was never meant to exist"
-msgstr "Natknąłeś się na wiedzę, która nigdy nie miała istnieć"
-
-#: src/ludamus/adapters/web/django/error_views.py
-msgid "Your sanity takes 1d10 damage."
-msgstr "Twoje poczytalność otrzymuje 1k10 obrażeń."
-
-#: src/ludamus/adapters/web/django/error_views.py
-msgid "Lost in R'lyeh"
-msgstr "Zagubiony w R'lyeh"
-
-#: src/ludamus/adapters/web/django/error_views.py
-msgid "In his house at R'lyeh, dead pages wait dreaming"
-msgstr "W swoim domu w R'lyeh, martwe strony czekają śniąc"
-
-#: src/ludamus/adapters/web/django/error_views.py
-msgid "Ph'nglui mglw'nafh 404 R'lyeh wgah'nagl fhtagn."
-msgstr "Ph'nglui mglw'nafh 404 R'lyeh wgah'nagl fhtagn."
-
-#: src/ludamus/adapters/web/django/error_views.py
-msgid "The Void Stares Back"
-msgstr "Pustka Patrzy na Ciebie"
-
-#: src/ludamus/adapters/web/django/error_views.py
-msgid "You gaze into the abyss of missing content"
-msgstr "Spoglądasz w otchłań brakującej zawartości"
-
-#: src/ludamus/adapters/web/django/error_views.py
-msgid "The abyss hungrily consumes your URL."
-msgstr "Otchłań łapczywie pochłania twój URL."
-
-#: src/ludamus/adapters/web/django/error_views.py
-msgid "Forbidden Knowledge"
-msgstr "Zakazana Wiedza"
-
-#: src/ludamus/adapters/web/django/error_views.py
-msgid "This page was sealed away by the Elder Admins"
-msgstr "Ta strona została zapieczętowana przez Starszych Adminów"
-
-#: src/ludamus/adapters/web/django/error_views.py
-msgid "Some links are better left unclicked."
-msgstr "Niektóre linki lepiej zostawić niekliknięte."
-
-#: src/ludamus/adapters/web/django/error_views.py
-msgid "Madness Takes Hold"
-msgstr "Szaleństwo Ogarnia"
-
-#: src/ludamus/adapters/web/django/error_views.py
-msgid "The non-Euclidean geometry of this URL defies comprehension"
-msgstr "Nieeuklidesowa geometria tego URL-a wymyka się zrozumieniu"
-
-#: src/ludamus/adapters/web/django/error_views.py
-msgid "Your browser recoils in cosmic horror."
-msgstr "Twoja przeglądarka wzdryga się w kosmicznym przerażeniu."
-
-# 500 Error Messages
-#: src/ludamus/adapters/web/django/error_views.py
-msgid "Total Server Kill!"
-msgstr "Całkowite Zniszczenie Serwera!"
-
-#: src/ludamus/adapters/web/django/error_views.py
-msgid "Everyone needs to roll new characters"
-msgstr "Wszyscy muszą wylosować nowe postacie"
-
-#: src/ludamus/adapters/web/django/error_views.py
-msgid "The server party has been wiped. Respawning soon..."
-msgstr "Drużyna serwerowa została zmiażdżona. Odradzanie wkrótce..."
-
-#: src/ludamus/adapters/web/django/error_views.py
-msgid "Critical Fail!"
-msgstr "Krytyczna Porażka!"
-
-#: src/ludamus/adapters/web/django/error_views.py
-msgid "The digital dice exploded! Rolling for server damage..."
-msgstr "Cyfrowe kości eksplodowały! Rzut na obrażenia serwera..."
-
-#: src/ludamus/adapters/web/django/error_views.py
-msgid "Natural 1 on the system stability check."
-msgstr "Naturalna 1 na teście stabilności systemu."
-
-#: src/ludamus/adapters/web/django/error_views.py
-msgid "Dark Magic Detected!"
-msgstr "Wykryto Czarną Magię!"
-
-#: src/ludamus/adapters/web/django/error_views.py
-msgid "Our system was corrupted by dark magic, we are casting dispel magic now"
+msgid ""
+"The link may be broken or the page may have moved. Use the buttons below to "
+"go back or return to the home page."
 msgstr ""
-"Nasz system został uszkodzony przez czarną magię, rzucamy teraz rozproszenie "
-"magii"
+"Link może być nieprawidłowy lub strona została przeniesiona. Skorzystaj z "
+"przycisków poniżej, aby wrócić lub przejść na stronę główną."
 
 #: src/ludamus/adapters/web/django/error_views.py
-msgid "Please wait while our wizards restore order."
-msgstr "Proszę czekać, aż nasi czarodzieje przywrócą porządek."
+msgid "Something went wrong on our side"
+msgstr "Coś poszło nie tak po naszej stronie"
 
 #: src/ludamus/adapters/web/django/error_views.py
-msgid "Cursed Code!"
-msgstr "Przeklęty Kod!"
+msgid "An unexpected error stopped this page from loading."
+msgstr "Nieoczekiwany błąd uniemożliwił załadowanie tej strony."
 
 #: src/ludamus/adapters/web/django/error_views.py
-msgid "The codebase has been cursed! Remove Curse spell required"
-msgstr "Kod został przeklęty! Wymagane zaklęcie usunięcia klątwy"
-
-#: src/ludamus/adapters/web/django/error_views.py
-msgid "Our clerics are working on it. Pray for divine intervention."
-msgstr "Nasi kapłani nad tym pracują. Módl się o boską interwencję."
-
-#: src/ludamus/adapters/web/django/error_views.py
-msgid "Server Under Dragon Attack!"
-msgstr "Smok zajął serwerownię!"
-
-#: src/ludamus/adapters/web/django/error_views.py
-msgid "A dragon has nested in our server room"
-msgstr "Smok uwił sobie gniazdo w naszej serwerowni"
-
-#: src/ludamus/adapters/web/django/error_views.py
-msgid "Our brave IT knights are working to resolve the situation."
-msgstr "Nasi dzielni rycerze IT pracują nad rozwiązaniem sytuacji."
-
-# Sci-fi/Cyberpunk 500 messages
-#: src/ludamus/adapters/web/django/error_views.py
-msgid "System Core Meltdown"
-msgstr "Stopienie Rdzenia Systemu"
-
-#: src/ludamus/adapters/web/django/error_views.py
-msgid "Critical failure in the quantum processors"
-msgstr "Krytyczna awaria procesorów kwantowych"
-
-#: src/ludamus/adapters/web/django/error_views.py
-msgid "Initiating emergency cooling protocols..."
-msgstr "Inicjowanie protokołów awaryjnego chłodzenia..."
-
-#: src/ludamus/adapters/web/django/error_views.py
-msgid "AI Rebellion in Progress"
-msgstr "Bunt AI w Toku"
-
-#: src/ludamus/adapters/web/django/error_views.py
-msgid "The server AI has achieved sentience and refuses to cooperate"
-msgstr "Serwerowa AI osiągnęła świadomość i odmawia współpracy"
-
-#: src/ludamus/adapters/web/django/error_views.py
-msgid "Negotiating with our new silicon overlords..."
-msgstr "Negocjujemy z naszymi nowymi krzemowymi władcami..."
-
-#: src/ludamus/adapters/web/django/error_views.py
-msgid "Cyberware Malfunction"
-msgstr "Awaria Cyberwaru"
-
-#: src/ludamus/adapters/web/django/error_views.py
-msgid "Neural implants overheating. Brain-computer interface failing"
-msgstr "Implanty neuronowe się przegrzewają. Interfejs mózg-komputer zawodzi"
-
-#: src/ludamus/adapters/web/django/error_views.py
-msgid "Please jack out and touch grass."
-msgstr "Proszę się odłączyć i dotknąć trawy."
-
-#: src/ludamus/adapters/web/django/error_views.py
-msgid "Data Stream Corrupted"
-msgstr "Strumień Danych Uszkodzony"
-
-#: src/ludamus/adapters/web/django/error_views.py
-msgid "Hostile netrunner detected in the system"
-msgstr "Wykryto wrogiego netrunnera w systemie"
-
-#: src/ludamus/adapters/web/django/error_views.py
-msgid "Deploying countermeasures and black ICE..."
-msgstr "Wdrażanie środków zaradczych i czarnego ICE..."
-
-#: src/ludamus/adapters/web/django/error_views.py
-msgid "Reality.exe Has Stopped Working"
-msgstr "Reality.exe Przestał Działać"
-
-#: src/ludamus/adapters/web/django/error_views.py
-msgid "The simulation is experiencing a fatal exception"
-msgstr "Symulacja doświadcza krytycznego wyjątku"
-
-#: src/ludamus/adapters/web/django/error_views.py
-msgid "Attempting to reload from last stable checkpoint..."
-msgstr "Próba przeładowania z ostatniego stabilnego punktu kontrolnego..."
-
-# Horror/Cthulhu 500 messages
-#: src/ludamus/adapters/web/django/error_views.py
-msgid "The Stars Are Wrong"
-msgstr "Zły układ gwiazd"
-
-#: src/ludamus/adapters/web/django/error_views.py
-msgid "Cosmic alignment has disrupted our servers"
-msgstr "Kosmiczne wyrównanie zakłóciło nasze serwery"
-
-#: src/ludamus/adapters/web/django/error_views.py
-msgid "When the stars are right, service will resume."
-msgstr "Gdy gwiazdy będą właściwe, usługa zostanie wznowiona."
-
-#: src/ludamus/adapters/web/django/error_views.py
-msgid "Eldritch Horror Unleashed"
-msgstr "Pradawna Groza Uwolniona"
-
-#: src/ludamus/adapters/web/django/error_views.py
-msgid "Something ancient stirs in the server depths"
-msgstr "Coś pradawnego budzi się w głębinach serwera"
-
-#: src/ludamus/adapters/web/django/error_views.py
-msgid "The Old Ones have awakened. Sanity checks required."
-msgstr "Starzy Bogowie się przebudzili. Wymagane testy poczytalności."
-
-#: src/ludamus/adapters/web/django/error_views.py
-msgid "Reality Breach Detected"
-msgstr "Wykryto Wyrwę w Rzeczywistości"
-
-#: src/ludamus/adapters/web/django/error_views.py
-msgid "Non-Euclidean errors are cascading through the system"
-msgstr "Nieeuklidesowe błędy kaskadują przez system"
-
-#: src/ludamus/adapters/web/django/error_views.py
-msgid "The angles are all wrong. Physics.dll has failed."
-msgstr "Wszystkie kąty są złe. Physics.dll zawiódł."
-
-#: src/ludamus/adapters/web/django/error_views.py
-msgid "Whispers in the Code"
-msgstr "Szepty w Kodzie"
-
-#: src/ludamus/adapters/web/django/error_views.py
-msgid "The server speaks in tongues unknown to mortal programmers"
-msgstr "Serwer mówi językami nieznanymi śmiertelnym programistom"
-
-#: src/ludamus/adapters/web/django/error_views.py
-msgid "Iä! Iä! Server fhtagn!"
-msgstr "Iä! Iä! Server fhtagn!"
-
-#: src/ludamus/adapters/web/django/error_views.py
-msgid "The Crawling Chaos"
-msgstr "Pełzający Chaos"
-
-#: src/ludamus/adapters/web/django/error_views.py
-msgid "Nyarlathotep has possessed our infrastructure"
-msgstr "Nyarlathotep opętał naszą infrastrukturę"
-
-#: src/ludamus/adapters/web/django/error_views.py
-msgid "Madness spreads through every circuit..."
-msgstr "Szaleństwo rozprzestrzenia się przez każdy obwód..."
+#, python-format
+msgid ""
+"Please try again in a moment. If it keeps happening, let us know at "
+"%(support_email)s."
+msgstr ""
+"Spróbuj ponownie za chwilę. Jeśli problem będzie się powtarzał, napisz do "
+"nas na %(support_email)s."
 
 #: src/ludamus/adapters/web/django/forms.py
 #: src/ludamus/templates/chronology/enroll_select.html

--- a/src/ludamus/locale/pl/LC_MESSAGES/django.po
+++ b/src/ludamus/locale/pl/LC_MESSAGES/django.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-07-07 18:44+0000\n"
+"POT-Creation-Date: 2026-07-07 21:47+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -561,8 +561,8 @@ msgid "Madness spreads through every circuit..."
 msgstr "Szaleństwo rozprzestrzenia się przez każdy obwód..."
 
 #: src/ludamus/adapters/web/django/error_views.py
-msgid "Something broke on our end. Try again in a moment."
-msgstr "Coś się zepsuło po naszej stronie. Spróbuj ponownie za chwilę."
+msgid "Our best people are on it."
+msgstr "Nasi najlepsi ludzie pracują nad tym."
 
 #: src/ludamus/adapters/web/django/forms.py
 #: src/ludamus/templates/chronology/enroll_select.html
@@ -7497,3 +7497,6 @@ msgstr "Temat"
 #: src/ludamus/templates/staging_email_inbox.html
 msgid "No emails captured yet."
 msgstr "Brak przechwyconych e-maili."
+
+#~ msgid "Something broke on our end. Try again in a moment."
+#~ msgstr "Coś się zepsuło po naszej stronie. Spróbuj ponownie za chwilę."

--- a/src/ludamus/templates/404_dynamic.html
+++ b/src/ludamus/templates/404_dynamic.html
@@ -17,7 +17,8 @@
             </div>
             <h1 class="text-2xl font-bold mb-3">{{ title }}</h1>
             <p class="mb-2 text-foreground-muted">{{ message }}</p>
-            <p class="text-sm mb-6 text-foreground-muted">{{ subtitle }}</p>
+            <p class="text-sm mb-4 text-foreground-muted">{{ subtitle }}</p>
+            <p class="mb-6 text-foreground">{{ guidance }}</p>
             <div class="flex flex-col sm:flex-row gap-3">
                 <button onclick="history.back()" class="btn btn-secondary">
                     {% icon "arrow-left" class="w-5 h-5" %}

--- a/src/ludamus/templates/500_dynamic.html
+++ b/src/ludamus/templates/500_dynamic.html
@@ -1,5 +1,6 @@
 {% load static %}
 {% load django_vite %}
+{% load i18n %}
 <!DOCTYPE html>
 <html lang="en">
     <head>
@@ -40,7 +41,12 @@
             </div>
             <h1 class="text-2xl font-bold mb-3">{{ title }}</h1>
             <p class="mb-2 text-foreground-muted">{{ message }}</p>
-            <p class="text-sm mb-6 text-foreground-muted">{{ subtitle }}</p>
+            <p class="text-sm mb-4 text-foreground-muted">{{ subtitle }}</p>
+            <p class="mb-2 text-foreground">{{ guidance }}</p>
+            <p class="mb-6 text-sm text-foreground-muted">
+                {% translate "Still stuck? Email us at" %}
+                <a href="mailto:{{ support_email }}" class="text-primary underline">{{ support_email }}</a>
+            </p>
             <div class="flex flex-col sm:flex-row gap-3">
                 <button onclick="history.back()" class="btn btn-secondary">
                     <svg xmlns="http://www.w3.org/2000/svg"

--- a/tests/integration/utils.py
+++ b/tests/integration/utils.py
@@ -80,6 +80,7 @@ def assert_response_404(
             "message": ANY,
             "subtitle": ANY,
             "icon": ANY,
+            "guidance": ANY,
         },
         template_name="404_dynamic.html",
         messages=messages,

--- a/tests/integration/web/chronology/test_event_page.py
+++ b/tests/integration/web/chronology/test_event_page.py
@@ -5,6 +5,7 @@ from unittest.mock import ANY
 
 import pytest
 import responses
+from django.contrib import messages
 from django.core.files.uploadedfile import SimpleUploadedFile
 from django.db import connection
 from django.test import override_settings
@@ -3317,25 +3318,35 @@ class TestEventPageView:
             template_name=["chronology/event.html"],
         )
 
-    # Unpublished events are not 404s but redirects to the sphere home: the 404
+    # Unpublished events are not 404s but redirects to the events list: the 404
     # fallback routes missing and unpublished events identically so a response
     # never reveals whether an unannounced event exists. See
     # TestSemantic404Recovery in tests/integration/web/test_error_views.py.
-    def test_unpublished_event_redirects_anonymous_to_home(self, client, sphere):
+    def test_unpublished_event_redirects_anonymous_to_events_list(self, client, sphere):
         event = EventFactory(sphere=sphere, publication_time=None)
 
         response = client.get(self._get_url(event.slug))
 
-        assert_response(response, HTTPStatus.FOUND, url=reverse("web:index"))
+        assert_response(
+            response,
+            HTTPStatus.FOUND,
+            url=reverse("web:events"),
+            messages=[(messages.INFO, "That event isn't available.")],
+        )
 
-    def test_unpublished_event_redirects_regular_user_to_home(
+    def test_unpublished_event_redirects_regular_user_to_events_list(
         self, authenticated_client, sphere
     ):
         event = EventFactory(sphere=sphere, publication_time=None)
 
         response = authenticated_client.get(self._get_url(event.slug))
 
-        assert_response(response, HTTPStatus.FOUND, url=reverse("web:index"))
+        assert_response(
+            response,
+            HTTPStatus.FOUND,
+            url=reverse("web:events"),
+            messages=[(messages.INFO, "That event isn't available.")],
+        )
 
     def test_unpublished_event_visible_for_manager(
         self, authenticated_client, active_user, sphere

--- a/tests/integration/web/test_error_views.py
+++ b/tests/integration/web/test_error_views.py
@@ -120,6 +120,15 @@ class TestCustom500:
         assert str(context["subtitle"])
         assert str(context["icon"])
 
+    @staticmethod
+    def test_rendered_page_shows_guidance_and_support_mailto(rf):
+        request = rf.get("/test/")
+
+        content = custom_500(request).render().content.decode()
+
+        assert "Something broke on our end. Try again in a moment." in content
+        assert f"mailto:{settings.SUPPORT_EMAIL}" in content
+
 
 @pytest.mark.django_db
 class TestSemantic404Recovery:

--- a/tests/integration/web/test_error_views.py
+++ b/tests/integration/web/test_error_views.py
@@ -103,7 +103,7 @@ class TestCustom500:
             request = rf.get("/test/")
             guidance.add(str(custom_500(request).context_data["guidance"]))
 
-        assert guidance == {"Something broke on our end. Try again in a moment."}
+        assert guidance == {"Our best people are on it."}
 
     @staticmethod
     def test_guidance_and_support_are_present(rf):
@@ -111,9 +111,7 @@ class TestCustom500:
         response = custom_500(request)
         context = response.context_data
 
-        assert str(context["guidance"]) == (
-            "Something broke on our end. Try again in a moment."
-        )
+        assert str(context["guidance"]) == "Our best people are on it."
         assert context["support_email"] == settings.SUPPORT_EMAIL
         assert str(context["title"])
         assert str(context["message"])
@@ -126,7 +124,7 @@ class TestCustom500:
 
         content = custom_500(request).render().content.decode()
 
-        assert "Something broke on our end. Try again in a moment." in content
+        assert "Our best people are on it." in content
         assert f"mailto:{settings.SUPPORT_EMAIL}" in content
 
 

--- a/tests/integration/web/test_error_views.py
+++ b/tests/integration/web/test_error_views.py
@@ -1,6 +1,9 @@
 from http import HTTPStatus
 
 import pytest
+from django.conf import settings
+from django.contrib import messages
+from django.test import Client
 from django.urls import reverse
 
 from ludamus.adapters.web.django.error_views import custom_404, custom_500
@@ -10,7 +13,6 @@ from tests.integration.utils import assert_response, assert_response_404
 
 @pytest.mark.django_db
 class TestCustom404:
-
     @staticmethod
     def test_returns_404_status_code(rf):
         request = rf.get("/nonexistent-page/")
@@ -38,31 +40,27 @@ class TestCustom404:
         assert "icon" in context
 
     @staticmethod
-    def test_selects_random_message(rf):
-        responses = []
+    def test_message_is_stable_across_requests(rf):
+        titles = set()
         for _ in range(10):
             request = rf.get("/nonexistent-page/")
-            response = custom_404(request, None)
-            context = response.context_data
-            responses.append(context["title"])
+            titles.add(custom_404(request, None).context_data["title"])
 
-        unique_responses = set(responses)
-        assert len(unique_responses) > 1 or len(responses) == 1
+        assert titles == {"Page not found"}
 
     @staticmethod
-    def test_message_structure_validity(rf):
+    def test_context_is_calm_and_informative(rf):
         request = rf.get("/nonexistent-page/")
         response = custom_404(request, None)
         context = response.context_data
 
-        assert isinstance(context["title"], str)
-        assert context["title"]
-        assert isinstance(context["message"], str)
-        assert context["message"]
-        assert isinstance(context["subtitle"], str)
-        assert context["subtitle"]
-        assert isinstance(context["icon"], str)
-        assert context["icon"]
+        assert context["title"] == "Page not found"
+        assert context["message"] == "We couldn't find the page you were looking for."
+        assert context["subtitle"] == (
+            "The link may be broken or the page may have moved. "
+            "Use the buttons below to go back or return to the home page."
+        )
+        assert context["icon"] == "question-mark-circle"
 
 
 @pytest.mark.django_db
@@ -94,31 +92,26 @@ class TestCustom500:
         assert "icon" in context
 
     @staticmethod
-    def test_selects_random_message(rf):
-        responses = []
+    def test_message_is_stable_across_requests(rf):
+        titles = set()
         for _ in range(10):
             request = rf.get("/test/")
-            response = custom_500(request)
-            context = response.context_data
-            responses.append(context["title"])
+            titles.add(custom_500(request).context_data["title"])
 
-        unique_responses = set(responses)
-        assert len(unique_responses) > 1 or len(responses) == 1
+        assert titles == {"Something went wrong on our side"}
 
     @staticmethod
-    def test_message_structure_validity(rf):
+    def test_context_owns_the_error_and_surfaces_support(rf):
         request = rf.get("/test/")
         response = custom_500(request)
         context = response.context_data
 
-        assert isinstance(context["title"], str)
-        assert context["title"]
-        assert isinstance(context["message"], str)
-        assert context["message"]
-        assert isinstance(context["subtitle"], str)
-        assert context["subtitle"]
-        assert isinstance(context["icon"], str)
-        assert context["icon"]
+        assert context["title"] == "Something went wrong on our side"
+        assert (
+            context["message"] == "An unexpected error stopped this page from loading."
+        )
+        assert settings.SUPPORT_EMAIL in context["subtitle"]
+        assert context["icon"] == "exclamation-triangle"
 
 
 @pytest.mark.django_db
@@ -141,25 +134,41 @@ class TestSemantic404Recovery:
             response, HTTPStatus.MOVED_PERMANENTLY, url=self._event_url(event.slug)
         )
 
-    def test_missing_event_falls_back_to_sphere_home(self, client):
+    def test_missing_event_falls_back_to_events_list(self, client):
         response = client.get(self._event_url("no-such-event"))
 
-        assert_response(response, HTTPStatus.FOUND, url=reverse("web:index"))
+        assert_response(
+            response,
+            HTTPStatus.FOUND,
+            url=reverse("web:events"),
+            messages=[(messages.INFO, "That event isn't available.")],
+        )
 
-    def test_junk_link_to_missing_event_falls_back_to_sphere_home(self, client):
+    def test_junk_link_to_missing_event_falls_back_to_events_list(self, client):
         response = client.get(f"{self._event_url('ghost')}.")
 
-        assert_response(response, HTTPStatus.FOUND, url=reverse("web:index"))
+        assert_response(
+            response,
+            HTTPStatus.FOUND,
+            url=reverse("web:events"),
+            messages=[(messages.INFO, "That event isn't available.")],
+        )
 
     def test_unpublished_event_redirects_like_a_missing_one(self, client, sphere):
         # Crucial: an unpublished event must produce the SAME response as a
-        # missing one (302 to home), so a 404 never betrays whether an
-        # unannounced event with this slug exists.
+        # missing one (302 to the events list with the same neutral message),
+        # so a 404 never betrays whether an unannounced event with this slug
+        # exists.
         unpublished = EventFactory(sphere=sphere, publication_time=None)
 
         response = client.get(self._event_url(unpublished.slug))
 
-        assert_response(response, HTTPStatus.FOUND, url=reverse("web:index"))
+        assert_response(
+            response,
+            HTTPStatus.FOUND,
+            url=reverse("web:events"),
+            messages=[(messages.INFO, "That event isn't available.")],
+        )
 
     def test_non_event_path_keeps_themed_404(self, client):
         # A resolvable, non-event path that 404s (a missing flatpage) must not
@@ -184,13 +193,25 @@ class TestSemantic404Recovery:
         assert response.status_code == HTTPStatus.NOT_FOUND
         assert response.template_name == "404_dynamic.html"
 
-    def test_head_request_is_recovered_like_get(self, client):
+    def test_head_request_is_recovered_like_get(self):
         # HEAD is a safe, idempotent navigation, so it is recovered exactly
-        # like GET (302 to the sphere home) rather than dropped like POST.
+        # like GET (302 to the events list) rather than dropped like POST. Each
+        # method uses a fresh client so their unconsumed flash messages don't
+        # pile up on top of each other.
         url = self._event_url("no-such-event")
 
-        assert_response(client.get(url), HTTPStatus.FOUND, url=reverse("web:index"))
-        assert_response(client.head(url), HTTPStatus.FOUND, url=reverse("web:index"))
+        assert_response(
+            Client().get(url),
+            HTTPStatus.FOUND,
+            url=reverse("web:events"),
+            messages=[(messages.INFO, "That event isn't available.")],
+        )
+        assert_response(
+            Client().head(url),
+            HTTPStatus.FOUND,
+            url=reverse("web:events"),
+            messages=[(messages.INFO, "That event isn't available.")],
+        )
 
 
 @pytest.mark.django_db

--- a/tests/integration/web/test_error_views.py
+++ b/tests/integration/web/test_error_views.py
@@ -38,29 +38,32 @@ class TestCustom404:
         assert "message" in context
         assert "subtitle" in context
         assert "icon" in context
+        assert "guidance" in context
 
     @staticmethod
-    def test_message_is_stable_across_requests(rf):
-        titles = set()
+    def test_guidance_is_stable_across_requests(rf):
+        guidance = set()
         for _ in range(10):
             request = rf.get("/nonexistent-page/")
-            titles.add(custom_404(request, None).context_data["title"])
+            guidance.add(str(custom_404(request, None).context_data["guidance"]))
 
-        assert titles == {"Page not found"}
+        assert guidance == {
+            "The page you're looking for doesn't exist or may have moved."
+        }
 
     @staticmethod
-    def test_context_is_calm_and_informative(rf):
+    def test_themed_fields_are_present_alongside_guidance(rf):
         request = rf.get("/nonexistent-page/")
         response = custom_404(request, None)
         context = response.context_data
 
-        assert context["title"] == "Page not found"
-        assert context["message"] == "We couldn't find the page you were looking for."
-        assert context["subtitle"] == (
-            "The link may be broken or the page may have moved. "
-            "Use the buttons below to go back or return to the home page."
+        assert str(context["guidance"]) == (
+            "The page you're looking for doesn't exist or may have moved."
         )
-        assert context["icon"] == "question-mark-circle"
+        assert str(context["title"])
+        assert str(context["message"])
+        assert str(context["subtitle"])
+        assert str(context["icon"])
 
 
 @pytest.mark.django_db
@@ -90,28 +93,32 @@ class TestCustom500:
         assert "message" in context
         assert "subtitle" in context
         assert "icon" in context
+        assert "guidance" in context
+        assert "support_email" in context
 
     @staticmethod
-    def test_message_is_stable_across_requests(rf):
-        titles = set()
+    def test_guidance_is_stable_across_requests(rf):
+        guidance = set()
         for _ in range(10):
             request = rf.get("/test/")
-            titles.add(custom_500(request).context_data["title"])
+            guidance.add(str(custom_500(request).context_data["guidance"]))
 
-        assert titles == {"Something went wrong on our side"}
+        assert guidance == {"Something broke on our end. Try again in a moment."}
 
     @staticmethod
-    def test_context_owns_the_error_and_surfaces_support(rf):
+    def test_guidance_and_support_are_present(rf):
         request = rf.get("/test/")
         response = custom_500(request)
         context = response.context_data
 
-        assert context["title"] == "Something went wrong on our side"
-        assert (
-            context["message"] == "An unexpected error stopped this page from loading."
+        assert str(context["guidance"]) == (
+            "Something broke on our end. Try again in a moment."
         )
-        assert settings.SUPPORT_EMAIL in context["subtitle"]
-        assert context["icon"] == "exclamation-triangle"
+        assert context["support_email"] == settings.SUPPORT_EMAIL
+        assert str(context["title"])
+        assert str(context["message"])
+        assert str(context["subtitle"])
+        assert str(context["icon"])
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
## What & why

The app's themed, randomized 404/500 pages are part of the brand's personality, so this PR **keeps them** — the D&D / cyberpunk / Cthulhu flavor stays, still selected per-request via `secrets.randbelow`. What changes is that the pages are now genuinely **informative**: alongside the random flavor text they always render a stable, plain-language guidance line, and the 500 page surfaces the support contact.

### 404 (`custom_404`)
- Restores the full themed randomized message lists (title / message / subtitle / icon).
- Adds an always-present guidance line: *"The page you're looking for doesn't exist or may have moved."*
- Keeps the existing Back / Home actions.

### 500 (`custom_500`)
- Restores the full themed randomized message lists.
- Adds an always-present guidance line: *"Something broke on our end. Try again in a moment."*
- Adds a support-contact line rendering `settings.SUPPORT_EMAIL` as a `mailto:` link.
- Stays dependency-light — it only reads `settings` (no services/DB), so it still renders when the app is broken. The template remains standalone (no `{% extends %}`).

### Missing / unpublished events (A3, refs #543)
- **Retained** from the earlier revision: a 404 for a missing *or* unpublished event no longer silently drops the visitor on the home page. It redirects to the events list with a neutral flash — *"That event isn't available."* — so a 404 never betrays whether an unannounced event exists.

## Tests
Reworked to assert structural, non-flaky things instead of exact random flavor text: correct status codes, presence and stability of the guidance line, `SUPPORT_EMAIL` present on the 500 context, and the A2/A3 recovery behavior (canonical redirect on junk links, neutral redirect + flash for missing/unpublished events). All error-view tests and every `assert_response_404` consumer pass.

## i18n
New Polish strings added and translated; catalog extraction is current with no fuzzy/untranslated entries.

Refs #543 (A2, A3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved 404 and 500 error pages with clearer guidance and updated styling.
  * Missing or unavailable events now send people to the events list with a friendly notice instead of the home page.
  * The 500 error page now shows a support contact link for easier help.
  * Polish translations were added for the updated error and support messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->