### PR TITLE
feat(panel): allow a bare top-level room in Venues

### DIFF
--- a/src/ludamus/gates/web/django/forms.py
+++ b/src/ludamus/gates/web/django/forms.py
@@ -406,7 +406,10 @@ class SpaceForm(forms.Form):
         required=False,
         min_value=1,
         label=_("Capacity"),
-        help_text=_("Only meaningful for the innermost spaces that hold sessions."),
+        help_text=_(
+            "Set the number of seats for a room that holds sessions, at any level."
+            " Leave empty for a space that only groups other spaces."
+        ),
         error_messages={"min_value": _("Capacity must be at least 1.")},
     )
     description = forms.CharField(

--- a/src/ludamus/locale/pl/LC_MESSAGES/django.po
+++ b/src/ludamus/locale/pl/LC_MESSAGES/django.po
@@ -2198,10 +2198,13 @@ msgid "Capacity"
 msgstr "Pojemność"
 
 #: src/ludamus/gates/web/django/forms.py
-msgid "Only meaningful for the innermost spaces that hold sessions."
+msgid ""
+"Set the number of seats for a room that holds sessions, at any level. Leave "
+"empty for a space that only groups other spaces."
 msgstr ""
-"Ma znaczenie tylko dla najbardziej wewnętrznych przestrzeni, które zawierają "
-"punkty programu."
+"Podaj liczbę miejsc dla sali, w której odbywają się punkty programu — na "
+"dowolnym poziomie. Zostaw puste dla przestrzeni, która tylko grupuje inne "
+"przestrzenie."
 
 #: src/ludamus/gates/web/django/forms.py
 msgid "Capacity must be at least 1."
@@ -7122,14 +7125,14 @@ msgstr "Czym są lokalizacje?"
 
 #: src/ludamus/templates/panel/spaces.html
 msgid ""
-"Organise the physical layout of your event as a tree: buildings contain "
-"floors or wings, which contain the individual rooms that hold sessions. Nest "
-"spaces as deeply as you need; only the innermost rooms take a capacity."
+"Organise the physical layout of your event. Add a single room on its own, or "
+"nest spaces as deeply as you need — a building with floors and rooms inside. "
+"Any space that holds sessions takes a capacity."
 msgstr ""
-"Zorganizuj fizyczny układ swojego wydarzenia jako drzewo: budynki zawierają "
-"piętra lub skrzydła, które zawierają poszczególne sale, gdzie odbywają się "
-"punkty programu. Zagnieżdżaj przestrzenie tak głęboko, jak potrzebujesz; "
-"tylko najbardziej wewnętrzne sale mają pojemność."
+"Zorganizuj fizyczny układ swojego wydarzenia. Dodaj pojedynczą salę albo "
+"zagnieżdżaj przestrzenie tak głęboko, jak potrzebujesz — budynek z piętrami "
+"i salami w środku. Każda przestrzeń, w której odbywają się punkty programu, "
+"ma pojemność."
 
 #: src/ludamus/templates/panel/spaces.html
 msgid "Physical Locations"
@@ -7144,11 +7147,10 @@ msgid "Could not save the new order. Reloading the page."
 msgstr "Nie udało się zapisać nowej kolejności. Ponowne ładowanie strony."
 
 #: src/ludamus/templates/panel/spaces.html
-msgid ""
-"No spaces yet. Add a top-level space to start building your event's layout."
+msgid "No spaces yet. Add a single room, or nest spaces to map a larger venue."
 msgstr ""
-"Brak przestrzeni. Dodaj przestrzeń najwyższego poziomu, aby rozpocząć "
-"budowanie układu swojego wydarzenia."
+"Brak przestrzeni. Dodaj pojedynczą salę albo zagnieżdżaj przestrzenie, aby "
+"odwzorować większy obiekt."
 
 #: src/ludamus/templates/panel/time-slot-create.html
 msgid "New Time Slot"

--- a/src/ludamus/templates/panel/spaces.html
+++ b/src/ludamus/templates/panel/spaces.html
@@ -10,7 +10,7 @@
 {% endblock page_title %}
 {% block page_title_adornment %}
     {% translate "What are venues?" as t_info_title %}
-    {% translate "Organise the physical layout of your event as a tree: buildings contain floors or wings, which contain the individual rooms that hold sessions. Nest spaces as deeply as you need; only the innermost rooms take a capacity." as t_info_body %}
+    {% translate "Organise the physical layout of your event. Add a single room on its own, or nest spaces as deeply as you need — a building with floors and rooms inside. Any space that holds sessions takes a capacity." as t_info_body %}
     {% include "components/info_popover.html" with title=t_info_title body=t_info_body %}
 {% endblock page_title_adornment %}
 {% block page_subtitle %}
@@ -42,7 +42,7 @@
             <div class="card p-8 text-center">
                 <div class="mb-4">{% icon "building-office-2" class="w-12 h-12 text-foreground-muted mx-auto" %}</div>
                 <p class="text-foreground-muted mb-4">
-                    {% translate "No spaces yet. Add a top-level space to start building your event's layout." %}
+                    {% translate "No spaces yet. Add a single room, or nest spaces to map a larger venue." %}
                 </p>
                 {% url 'panel:space-create' slug=current_event.slug as new_space_url %}
                 {% translate "New top-level space" as t_new_space %}

--- a/tests/integration/web/panel/test_spaces_tree.py
+++ b/tests/integration/web/panel/test_spaces_tree.py
@@ -144,6 +144,38 @@ class TestSpaceCreate:
         created = Space.objects.get(event=event, name="Hall")
         assert created.parent_id is None
 
+    def test_create_top_level_room_with_capacity(self, manager_client, event):
+        # A usable room (a leaf with seats) can be created at the top level with
+        # no Venue/Area wrappers, and shows up in the tree as a room.
+        capacity = 30
+
+        response = manager_client.post(
+            self._root_url(event), data={"name": "Main Hall", "capacity": str(capacity)}
+        )
+
+        assert_response(
+            response,
+            HTTPStatus.FOUND,
+            messages=[(messages.SUCCESS, "Space created successfully.")],
+            url=_venues_url(event),
+        )
+        room = Space.objects.get(event=event, name="Main Hall")
+        assert room.parent_id is None
+        assert room.capacity == capacity
+
+        tree_response = manager_client.get(_venues_url(event))
+
+        assert_response(
+            tree_response,
+            HTTPStatus.OK,
+            template_name="panel/spaces.html",
+            messages=[(messages.SUCCESS, "Space created successfully.")],
+            context_data={
+                **_base_context(event, rooms=1),
+                "tree": [_node(room, depth=1, is_leaf=True)],
+            },
+        )
+
     def test_create_child(self, manager_client, event):
         root = _root(event)
         capacity = 20


### PR DESCRIPTION
## What constrained it before

The Venues panel appeared to force a three-level hierarchy (Venue → Area → Room), so registering a single table meant creating three nested things (issue #543, finding P5).

The constraint turned out to be **copy, not data or code**. Since the venue/area drop (migration `0104_drop_venue_area`), `Space` is a self-referential tree, and the whole stack already accepts a top-level room:

- `Space` model — `parent` is nullable, `capacity` is a plain optional field, and `clean()` has no rule tying capacity to nesting. A parent-less leaf is a valid, bookable room.
- `SpaceForm` — already exposes an optional `capacity` field on the "New top-level space" flow.
- `SpaceCreatePageView` / `SpaceTreeService` / `SpaceTreeRepository` — already persist `capacity` with `parent_id=None`, and `list_tree` marks a childless node `is_leaf=True` (rendered as a room with a seat badge).

What actually pushed organizers toward nesting was the wording:

- the **Capacity** help text said it was *"Only meaningful for the innermost spaces that hold sessions"* — reads as "not for a top-level space";
- the **empty state** and **info popover** framed spaces purely as a nested layout to "build".

No schema migration was needed.

## The change

Reword the three strings so a single top-level room is a first-class option, while keeping nesting fully available:

- **Capacity help:** "Set the number of seats for a room that holds sessions, at any level. Leave empty for a space that only groups other spaces." — makes clear that a capacity turns *any* space (including a top-level one) into a room, and an empty capacity makes a grouping container.
- **Empty state:** "No spaces yet. Add a single room, or nest spaces to map a larger venue."
- **Info popover:** "Organise the physical layout of your event. Add a single room on its own, or nest spaces as deeply as you need — a building with floors and rooms inside. Any space that holds sessions takes a capacity."

Polish translations updated in `locale/pl` (hand-wrapped to match `xgettext` column widths, since `gettext` isn't available in this environment — run `mise run messages` if CI's wrapping differs).

Used the `product-design` skill (Copy mode) for the wording and Polish term conventions.

Refs #543 (P5)

## Testing

- New integration test `test_create_top_level_room_with_capacity` in `tests/integration/web/panel/test_spaces_tree.py`: POSTs a top-level space with a capacity, asserts it is saved with `parent_id is None` and the given capacity, then GETs the Venues page and asserts it appears in the tree as a leaf room (`is_leaf=True`, depth 1).
- `set -a; . ./.env.test; set +a; PYTHONPATH=src .venv/bin/pytest tests/integration/web/ -k "venue or space" -q` → **52 passed**.
- `mise run lint:import-linter` → 7 contracts kept.
- `pylint` on changed `.py` → **10.00/10** (no disables).
- `black --check` and `mise run lint:djlint` → clean.

Copy-only UI change on the existing Venues page (no new components), so no screenshots attached; the before/after strings are shown above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_017y1ivr5CqCWLA8eGDCGqZj)_