### PR TITLE
fix(import): don't merge distinct sessions on truncated dedup slug

### DIFF
--- a/src/ludamus/mills/submissions/engine.py
+++ b/src/ludamus/mills/submissions/engine.py
@@ -13,6 +13,7 @@ from ludamus.mills.submissions.mapping import (
     RowSkippedError,
     cell,
     chosen_entities,
+    dedup_slug,
     extract_identity,
     field_name,
     field_setup,
@@ -388,7 +389,7 @@ class ImportEngine:
         identity = "-".join(
             row.get_value(col, "") for col in settings.unique_key_columns
         )
-        slug = slugify(f"e{event_id}-{identity}") or f"e{event_id}-row"
+        slug = dedup_slug(event_id=event_id, identity=identity)
         if (
             existing_id := self._repos.sessions.find_id_by_slug(event_id, slug)
         ) is not None:

--- a/src/ludamus/mills/submissions/mapping.py
+++ b/src/ludamus/mills/submissions/mapping.py
@@ -328,8 +328,7 @@ def dedup_slug(*, event_id: int, identity: str, max_length: int = 50) -> str:
     # readable slug when the whole identity fits; otherwise reserve the tail for
     # a deterministic digest of the *full* identity so distinct rows never
     # collide. Short (already-correct) imports keep their existing slug.
-    full = slugify(f"e{event_id}-{identity}", max_length=len(identity) + 32)
-    if not full:
+    if not (full := slugify(f"e{event_id}-{identity}", max_length=len(identity) + 32)):
         return f"e{event_id}-row"
     if len(full) <= max_length:
         return full

--- a/src/ludamus/mills/submissions/mapping.py
+++ b/src/ludamus/mills/submissions/mapping.py
@@ -2,6 +2,7 @@
 
 import re
 from dataclasses import dataclass
+from hashlib import blake2b
 from secrets import token_urlsafe
 from typing import TYPE_CHECKING, Literal, Never
 
@@ -317,6 +318,24 @@ def slugify(value: str, *, max_length: int = 50) -> str:
     transliterated = unidecode(value).lower()
     slug = re.sub(r"[^\w\s-]", "", transliterated)
     return re.sub(r"[-\s]+", "-", slug).strip("-")[:max_length].strip("-")
+
+
+def dedup_slug(*, event_id: int, identity: str, max_length: int = 50) -> str:
+    # Idempotency key for unique-key imports. Must fit the SlugField column, but
+    # `slugify`'s bare truncation drops the tail — so two rows sharing a long
+    # leading column (e.g. an identical session name) but differing in a later
+    # column (email/facilitator) collapsed to one slug and got merged. Keep the
+    # readable slug when the whole identity fits; otherwise reserve the tail for
+    # a deterministic digest of the *full* identity so distinct rows never
+    # collide. Short (already-correct) imports keep their existing slug.
+    full = slugify(f"e{event_id}-{identity}", max_length=len(identity) + 32)
+    if not full:
+        return f"e{event_id}-row"
+    if len(full) <= max_length:
+        return full
+    digest = blake2b(identity.encode(), digest_size=6).hexdigest()
+    head = full[: max_length - len(digest) - 1].rstrip("-")
+    return f"{head}-{digest}"
 
 
 class SlugCollisionError(Exception):

--- a/tests/unit/test_mills.py
+++ b/tests/unit/test_mills.py
@@ -25,6 +25,7 @@ from ludamus.mills.submissions.mapping import (
     cell,
     chosen_entities,
     decode_response,
+    dedup_slug,
     extract_identity,
     field_setup,
     generate_unique_slug,
@@ -2682,3 +2683,37 @@ class TestSlugify:
     def test_truncation_drops_trailing_dash(self):
         # 49 chars then a space+word so the cut lands on a separator
         assert not slugify(f"{'a' * 49} bb").endswith("-")
+
+
+class TestDedupSlug:
+    MAX_SLUG_LENGTH = 50
+
+    def test_short_identity_keeps_readable_slug(self):
+        slug = dedup_slug(event_id=7, identity="my-talk-a@x.z")
+
+        assert slug == "e7-my-talk-axz"
+
+    def test_blank_identity_falls_back(self):
+        assert dedup_slug(event_id=7, identity="") == "e7"
+
+    def test_long_identity_stays_within_column_width(self):
+        slug = dedup_slug(event_id=7, identity=f"{'name ' * 20}a@x.z")
+
+        assert len(slug) <= self.MAX_SLUG_LENGTH
+
+    def test_same_long_name_different_tail_do_not_collide(self):
+        # Regression: a long shared session name used to fill the 50-char slug,
+        # truncating the distinguishing email away so two distinct rows merged.
+        name = "A Very Long Session Title That Fills The Whole Slug Column"
+
+        first = dedup_slug(event_id=7, identity=f"{name}-alice@example.com")
+        second = dedup_slug(event_id=7, identity=f"{name}-bob@example.com")
+
+        assert first != second
+
+    def test_identity_is_deterministic(self):
+        identity = f"{'name ' * 20}a@x.z"
+
+        assert dedup_slug(event_id=7, identity=identity) == dedup_slug(
+            event_id=7, identity=identity
+        )


### PR DESCRIPTION
The unique-key dedup slug was `slugify("e{event}-{identity}")`, and slugify hard-truncates to the 50-char SlugField width. A long leading column (the session name, up to 255 chars) filled the slug and chopped off the trailing distinguishing columns (email/facilitator), so two distinct rows produced the same slug and the second was recorded as a duplicate of the first.

Introduce `dedup_slug`: keep the readable slug when the full identity fits (existing correct imports stay idempotent), otherwise reserve the tail for a deterministic blake2b digest of the full identity so distinct rows never collide after truncation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved import handling for rows with unique keys by generating stable, deterministic slugs.
  * Long values now stay readable while still avoiding collisions with a short hash-based suffix.

* **Bug Fixes**
  * Reduced the chance of duplicate-row conflicts when similar records share the same prefix.
  * Blank or missing identity values now fall back to a consistent event-based slug.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->