### PR TITLE
Fix session env-file PATH order: mise shims must precede image uv tools

### DIFF
--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -42,10 +42,16 @@ export MISE_ENV=sandbox
 # activation from `_.python.venv`) at the shims' position in PATH. Appended
 # shims put the venv after the container's bare /usr/local/bin/python, and
 # every `mise run` task fails with "No module named 'django'".
+#
+# The shims line must come LAST so it lands FIRST in the final PATH: the
+# container image ships uv-tool builds of pytest/mypy/black/poetry in
+# ~/.local/bin, and if that dir precedes the shims, those plugin-less
+# binaries shadow the .venv ones inside every `mise run`/`mise x` (pytest
+# has no django, mypy has no mypy_django_plugin).
 if [ -n "${CLAUDE_ENV_FILE:-}" ]; then
-  echo "export PATH=\"$HOME/.local/share/mise/shims:\$PATH\"" >> "$CLAUDE_ENV_FILE"
   # ~/.local/bin carries the container image's user-level binaries.
   echo "export PATH=\"$HOME/.local/bin:\$PATH\"" >> "$CLAUDE_ENV_FILE"
+  echo "export PATH=\"$HOME/.local/share/mise/shims:\$PATH\"" >> "$CLAUDE_ENV_FILE"
   echo "export MISE_ENV=sandbox" >> "$CLAUDE_ENV_FILE"
 fi
 

--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -38,20 +38,18 @@ export MISE_ENV=sandbox
 # Persisted for the session via CLAUDE_ENV_FILE, together with MISE_ENV so
 # every later `mise` invocation keeps loading mise.sandbox.toml.
 #
-# PREPEND, don't append: mise inserts its managed paths (incl. the .venv
-# activation from `_.python.venv`) at the shims' position in PATH. Appended
-# shims put the venv after the container's bare /usr/local/bin/python, and
-# every `mise run` task fails with "No module named 'django'".
-#
-# The shims line must come LAST so it lands FIRST in the final PATH: the
-# container image ships uv-tool builds of pytest/mypy/black/poetry in
-# ~/.local/bin, and if that dir precedes the shims, those plugin-less
-# binaries shadow the .venv ones inside every `mise run`/`mise x` (pytest
-# has no django, mypy has no mypy_django_plugin).
+# PREPEND, don't append — and shims must precede ~/.local/bin: mise inserts
+# its managed paths (incl. the .venv activation from `_.python.venv`) at the
+# shims' position in PATH, while the container image ships uv-tool builds of
+# pytest/mypy/black/poetry in ~/.local/bin. If ~/.local/bin wins, those
+# plugin-less binaries shadow the .venv ones inside every `mise run`/`mise x`
+# (pytest has no django, mypy has no mypy_django_plugin); if the shims are
+# appended, the venv lands after the container's bare /usr/local/bin/python
+# and every `mise run` task fails with "No module named 'django'".
 if [ -n "${CLAUDE_ENV_FILE:-}" ]; then
   # ~/.local/bin carries the container image's user-level binaries.
-  echo "export PATH=\"$HOME/.local/bin:\$PATH\"" >> "$CLAUDE_ENV_FILE"
-  echo "export PATH=\"$HOME/.local/share/mise/shims:\$PATH\"" >> "$CLAUDE_ENV_FILE"
+  echo "export PATH=\"$HOME/.local/share/mise/shims:$HOME/.local/bin:\$PATH\"" \
+    >> "$CLAUDE_ENV_FILE"
   echo "export MISE_ENV=sandbox" >> "$CLAUDE_ENV_FILE"
 fi
 

--- a/PAPERCUTS.md
+++ b/PAPERCUTS.md
@@ -5,3 +5,11 @@ flaky commands, stale caches, misleading errors, non-obvious gotchas. One or two
 sentences each: what you were doing → what got in the way. See CLAUDE.md.
 
 <!-- Append new entries below, newest last. -->
+- 2026-07-10: session-start hook's `playwright install --with-deps` fails in
+  fresh sandboxes: apt-get update exits 100 because the image's ondrej/php PPA
+  changed its InRelease Label. Browsers are preinstalled at /opt/pw-browsers so
+  the failure is soft, but the WARN is misleading.
+- 2026-07-10: `mise run papercut -- <note>` garbles apostrophes in the note
+  (writes literal `'\''` sequences into PAPERCUTS.md) and doesn't wrap at 80
+  columns, so the very next commit trips markdownlint MD013 on the file it
+  just wrote.


### PR DESCRIPTION
## Problem

Session-parity testing of #556 (fresh-sandbox bootstrap of merged main, plus this live session) found `mise run test:py` failing with `No module named 'django'` and `lint:mypy` with `No module named 'mypy_django_plugin'`.

Root cause: the SessionStart hook wrote two prepend lines to `CLAUDE_ENV_FILE`, and the `~/.local/bin` line came last — so it landed **first** in every later shell's PATH. The container image ships plugin-less uv-tool builds of pytest/mypy/black/poetry in `~/.local/bin`, and mise splices its managed paths (including the project `.venv`) in at the *shims'* position, which sat behind them. The image's pytest (no django) and mypy (no django plugin) shadowed the venv ones inside every `mise run`/`mise x`.

## Changes

- `.claude/hooks/session-start.sh`: write a single `export PATH="…/mise/shims:…/.local/bin:$PATH"` line, stating the precedence left-to-right instead of encoding it in reverse write order (the inversion that caused the bug). Comment documents why shims must win.
- `PAPERCUTS.md`: two entries — `playwright install --with-deps` fails soft in fresh sandboxes (image's ondrej/php PPA broke `apt-get update`; browsers are preinstalled at `/opt/pw-browsers`), and `mise run papercut` garbles apostrophes / overruns MD013.

## Verification

Fresh clone of merged main bootstrapped via the real hook with an isolated `MISE_DATA_DIR`: zero mise errors; hk 1.48.0, shellcheck 0.11.0, actionlint 1.7.12, hadolint 2.14.0, dockerfmt all answer at pinned versions; `.venv` built from apt `/usr/bin/python3.14`. With the corrected PATH shape in this session: **2841 tests passed, 7 skipped**, `mise run check` fully green (mypy, pylint 10.00/10, hk linters), and the hk pre-commit hook fired on this PR's own commits — including once blocking a commit on MD013, as it should.

Thermo-nuclear code quality review: APPROVED (its one suggestion, the single-line PATH write, is applied in the second commit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012kT66eNRMiAnBMi6MwGZZ6

---
_Generated by [Claude Code](https://claude.ai/code/session_012kT66eNRMiAnBMi6MwGZZ6)_