### PR TITLE
Simplify #548: single atomic padded write for sheet export, no-op-free name update

### DIFF
--- a/src/ludamus/links/google_docs.py
+++ b/src/ludamus/links/google_docs.py
@@ -49,9 +49,6 @@ SHEETS_META_URL = (
 SHEETS_VALUES_URL = (
     "https://sheets.googleapis.com/v4/spreadsheets/{sheet_id}/values/{range}"
 )
-SHEETS_CLEAR_URL = (
-    "https://sheets.googleapis.com/v4/spreadsheets/{sheet_id}/values/{range}:clear"
-)
 SHEETS_UPDATE_URL = (
     "https://sheets.googleapis.com/v4/spreadsheets/{sheet_id}/values/{range}"
     "?valueInputOption=RAW"
@@ -398,6 +395,14 @@ def _a1_quote(title: str) -> str:
     return "'" + title.replace("'", "''") + "'"
 
 
+def _pad_to_extent(
+    *, rows: list[list[str]], height: int, width: int
+) -> list[list[str]]:
+    width = max([width, *(len(row) for row in rows)])
+    padded = [[*row, *[""] * (width - len(row))] for row in rows]
+    return padded + [[""] * width] * (height - len(padded))
+
+
 class GoogleSheetsWriter(SheetWriterProtocol):
     """Replaces the first tab of a spreadsheet with the given rows."""
 
@@ -413,46 +418,42 @@ class GoogleSheetsWriter(SheetWriterProtocol):
             raise SheetExportError(str(exc)) from exc
         # A1-quote the tab title: a bare title that parses as a cell reference
         # (a tab named "A1") or contains an apostrophe would otherwise be read
-        # as a range, clearing a single cell instead of the tab.
+        # as a range, writing a single cell instead of the tab.
         title = _a1_quote(self._first_tab_title(session, spreadsheet_id))
-        old_row_count = self._row_count(session, spreadsheet_id, title)
-        # Write first so a failed write never leaves the sheet empty.
+        height, width = self._old_extent(
+            session=session, spreadsheet_id=spreadsheet_id, title=title
+        )
+        # A single atomic write: padding with "" out to the previous data's
+        # extent overwrites stale cells left by a longer or wider export, and
+        # a failed request leaves the old data fully intact.
         self._call(
             what="Spreadsheet write",
             send=lambda: session.put(
                 SHEETS_UPDATE_URL.format(
                     sheet_id=spreadsheet_id, range=quote(f"{title}!A1", safe="")
                 ),
-                json={"values": rows},
+                json={"values": _pad_to_extent(rows=rows, height=height, width=width)},
                 timeout=30,
             ),
         )
-        if (new_row_count := len(rows)) < old_row_count:
-            trailing_range = f"{title}!A{new_row_count + 1}:ZZ{old_row_count}"
-            self._call(
-                what="Spreadsheet clear trailing rows",
-                send=lambda: session.post(
-                    SHEETS_CLEAR_URL.format(
-                        sheet_id=spreadsheet_id, range=quote(trailing_range, safe="")
-                    ),
-                    timeout=30,
-                ),
-            )
 
-    def _row_count(
-        self, session: AuthorizedSession, spreadsheet_id: str, title: str
-    ) -> int:
+    def _old_extent(
+        self, *, session: AuthorizedSession, spreadsheet_id: str, title: str
+    ) -> tuple[int, int]:
+        # A bare tab name (no A1 column bounds) returns the tab's whole data
+        # region, so the extent is not capped at column Z or cut short by
+        # blank cells in column A.
         response = self._call(
             what="Spreadsheet read",
             send=lambda: session.get(
                 SHEETS_VALUES_URL.format(
-                    sheet_id=spreadsheet_id, range=quote(f"{title}!A:A", safe="")
+                    sheet_id=spreadsheet_id, range=quote(title, safe="")
                 ),
                 timeout=10,
             ),
         )
         values = response.json().get("values") or []
-        return len(values)
+        return len(values), max((len(row) for row in values), default=0)
 
     def _first_tab_title(self, session: AuthorizedSession, spreadsheet_id: str) -> str:
         response = self._call(

--- a/src/ludamus/mills/enrollment.py
+++ b/src/ludamus/mills/enrollment.py
@@ -523,9 +523,9 @@ class AnonymousEnrollmentService(AnonymousEnrollmentServiceProtocol):
     def _update_name(self, user: UserDTO, name: str) -> None:
         if name:
             user.name = name
+            self._user_repository.update(user.slug, UserData(name=name))
         if not user.name:
             raise AnonymousEnrollmentError(AnonymousEnrollmentErrorCode.NAME_REQUIRED)
-        self._user_repository.update(user.slug, UserData(name=user.name))
 
 
 def _refresh_user_config_from_api(

--- a/tests/integration/links/test_google_docs.py
+++ b/tests/integration/links/test_google_docs.py
@@ -18,7 +18,6 @@ from pydantic import BaseModel
 from ludamus.links.google_docs import (
     FORMS_API_URL,
     SHEETS_API_URL,
-    SHEETS_CLEAR_URL,
     SHEETS_META_URL,
     SHEETS_UPDATE_URL,
     SHEETS_VALUES_URL,
@@ -751,24 +750,12 @@ class TestGoogleDocsProposalImporterFetchResponses:
 
 
 EXPORT_ROWS = [["Creator", "Accreditation type"], ["Alice", "Guest"]]
-_METADATA_AND_ROW_COUNT_GETS = 2
-
-
-def _writer_get(*, meta: MagicMock, old_row_count: int = 0):
-    row_values = MagicMock(ok=True, json=lambda: {"values": [["x"]] * old_row_count})
-
-    def get(url: str, **_kwargs: object) -> MagicMock:
-        if "A%3AA" in url:
-            return row_values
-        return meta
-
-    return get
 
 
 class TestGoogleSheetsWriter:
-    def test_writes_the_first_tab_without_clearing_when_not_shrinking(self, google):
-        google.session.get.side_effect = _writer_get(
-            meta=_meta_with_title(), old_row_count=len(EXPORT_ROWS)
+    def test_writes_the_first_tab_in_a_single_request(self, google):
+        google.session.get.side_effect = _route_get(
+            values=[["x", "y"]] * len(EXPORT_ROWS)
         )
         google.session.put.return_value = _resp(ok=True)
 
@@ -780,7 +767,6 @@ class TestGoogleSheetsWriter:
             {"type": "service_account"},
             scopes=["https://www.googleapis.com/auth/spreadsheets"],
         )
-        assert google.session.get.call_count == _METADATA_AND_ROW_COUNT_GETS
         google.session.get.assert_any_call(
             SHEETS_META_URL.format(sheet_id="sheet-1"), timeout=10
         )
@@ -793,55 +779,57 @@ class TestGoogleSheetsWriter:
             timeout=30,
         )
 
-    def test_clears_trailing_rows_when_new_export_is_shorter(self, google):
-        google.session.get.side_effect = _writer_get(
-            meta=_meta_with_title(), old_row_count=5
-        )
-        google.session.post.return_value = _resp(ok=True)
+    def test_pads_a_smaller_export_to_overwrite_the_old_extent(self, google):
+        # Previous export: 4 rows x 3 columns. The new 2x2 payload is padded
+        # with "" so the single write also blanks the stale row and column.
+        google.session.get.side_effect = _route_get(values=[["x", "y", "z"]] * 4)
         google.session.put.return_value = _resp(ok=True)
 
         GoogleSheetsWriter().write_rows(
             secret=SECRET, spreadsheet_id="sheet-1", rows=EXPORT_ROWS
         )
 
-        google.session.post.assert_called_once_with(
-            SHEETS_CLEAR_URL.format(
-                sheet_id="sheet-1", range="%27Form%20Responses%201%27%21A3%3AZZ5"
+        google.session.post.assert_not_called()
+        google.session.put.assert_called_once_with(
+            SHEETS_UPDATE_URL.format(
+                sheet_id="sheet-1", range="%27Form%20Responses%201%27%21A1"
             ),
+            json={
+                "values": [
+                    ["Creator", "Accreditation type", ""],
+                    ["Alice", "Guest", ""],
+                    ["", "", ""],
+                    ["", "", ""],
+                ]
+            },
             timeout=30,
         )
 
     def test_quotes_tab_title_that_looks_like_a_cell_reference(self, google):
-        google.session.get.side_effect = _writer_get(
-            meta=_meta_with_title("A1"), old_row_count=5
-        )
-        google.session.post.return_value = _resp(ok=True)
+        google.session.get.side_effect = _route_get(values=[], title="A1")
         google.session.put.return_value = _resp(ok=True)
 
         GoogleSheetsWriter().write_rows(
             secret=SECRET, spreadsheet_id="sheet-1", rows=EXPORT_ROWS
         )
 
-        google.session.post.assert_called_once_with(
-            SHEETS_CLEAR_URL.format(sheet_id="sheet-1", range="%27A1%27%21A3%3AZZ5"),
+        google.session.put.assert_called_once_with(
+            SHEETS_UPDATE_URL.format(sheet_id="sheet-1", range="%27A1%27%21A1"),
+            json={"values": EXPORT_ROWS},
             timeout=30,
         )
 
     def test_quotes_apostrophe_in_tab_title(self, google):
-        google.session.get.side_effect = _writer_get(
-            meta=_meta_with_title("It's"), old_row_count=5
-        )
-        google.session.post.return_value = _resp(ok=True)
+        google.session.get.side_effect = _route_get(values=[], title="It's")
         google.session.put.return_value = _resp(ok=True)
 
         GoogleSheetsWriter().write_rows(
             secret=SECRET, spreadsheet_id="sheet-1", rows=EXPORT_ROWS
         )
 
-        google.session.post.assert_called_once_with(
-            SHEETS_CLEAR_URL.format(
-                sheet_id="sheet-1", range="%27It%27%27s%27%21A3%3AZZ5"
-            ),
+        google.session.put.assert_called_once_with(
+            SHEETS_UPDATE_URL.format(sheet_id="sheet-1", range="%27It%27%27s%27%21A1"),
+            json={"values": EXPORT_ROWS},
             timeout=30,
         )
 
@@ -900,29 +888,25 @@ class TestGoogleSheetsWriter:
                 secret=SECRET, spreadsheet_id="sheet-1", rows=EXPORT_ROWS
             )
 
-    def test_clear_trailing_failure_raises_after_write(self, google):
-        google.session.get.side_effect = _writer_get(
-            meta=_meta_with_title(), old_row_count=5
-        )
-        google.session.put.return_value = _resp(ok=True)
-        google.session.post.return_value = _resp(
-            ok=False, status_code=403, text="no edit"
-        )
+    def test_extent_read_failure_raises_before_writing(self, google):
+        def get(url: str, **_kwargs: object) -> MagicMock:
+            if "/values/" in url:
+                return _resp(ok=False, status_code=403, text="deny")
+            return _meta_with_title()
+
+        google.session.get.side_effect = get
 
         with pytest.raises(
-            SheetExportError,
-            match="Spreadsheet clear trailing rows request failed with 403: no edit",
+            SheetExportError, match="Spreadsheet read request failed with 403: deny"
         ):
             GoogleSheetsWriter().write_rows(
                 secret=SECRET, spreadsheet_id="sheet-1", rows=EXPORT_ROWS
             )
 
-        google.session.put.assert_called_once()
+        google.session.put.assert_not_called()
 
-    def test_write_failure_raises_without_clearing(self, google):
-        google.session.get.side_effect = _writer_get(
-            meta=_meta_with_title(), old_row_count=5
-        )
+    def test_write_failure_raises(self, google):
+        google.session.get.side_effect = _route_get(values=[["x"]] * 5)
         google.session.put.return_value = _resp(ok=False, status_code=500, text="boom")
 
         with pytest.raises(
@@ -932,18 +916,12 @@ class TestGoogleSheetsWriter:
                 secret=SECRET, spreadsheet_id="sheet-1", rows=EXPORT_ROWS
             )
 
-        google.session.post.assert_not_called()
-
     def test_request_exception_raises(self, google):
-        google.session.get.side_effect = _writer_get(
-            meta=_meta_with_title(), old_row_count=5
-        )
-        google.session.put.return_value = _resp(ok=True)
-        google.session.post.side_effect = requests.RequestException("timeout")
+        google.session.get.side_effect = _route_get(values=[])
+        google.session.put.side_effect = requests.RequestException("timeout")
 
         with pytest.raises(
-            SheetExportError,
-            match="Spreadsheet clear trailing rows request failed: timeout",
+            SheetExportError, match="Spreadsheet write request failed: timeout"
         ):
             GoogleSheetsWriter().write_rows(
                 secret=SECRET, spreadsheet_id="sheet-1", rows=EXPORT_ROWS

--- a/tests/integration/web/panel/test_discounts_page.py
+++ b/tests/integration/web/panel/test_discounts_page.py
@@ -668,31 +668,19 @@ class TestDiscountDeleteActionView:
 SPREADSHEET_URL = "https://docs.google.com/spreadsheets/d/target-sheet/edit#gid=0"
 
 
-def _google_write_session(
-    *,
-    clear_ok=True,
-    clear_status=200,
-    clear_text="",
-    old_row_count=0,
-    write_ok=True,
-    write_status=200,
-    write_text="",
-):
+def _google_write_session(*, write_ok=True, write_status=200, write_text=""):
     meta = MagicMock(
         ok=True, json=lambda: {"sheets": [{"properties": {"title": "Sheet1"}}]}
     )
-    row_values = MagicMock(ok=True, json=lambda: {"values": [["x"]] * old_row_count})
+    old_values = MagicMock(ok=True, json=lambda: {"values": []})
 
     def get(url: str, **_kwargs: object) -> MagicMock:
-        if "A%3AA" in url:
-            return row_values
+        if "/values/" in url:
+            return old_values
         return meta
 
     session = MagicMock()
     session.get.side_effect = get
-    session.post.return_value = MagicMock(
-        ok=clear_ok, status_code=clear_status, text=clear_text
-    )
     session.put.return_value = MagicMock(
         ok=write_ok, status_code=write_status, text=write_text
     )

--- a/tests/unit/test_anonymous_enrollment_service.py
+++ b/tests/unit/test_anonymous_enrollment_service.py
@@ -4,7 +4,7 @@ from datetime import UTC, datetime
 import pytest
 
 from ludamus.mills.enrollment import AnonymousEnrollmentService
-from ludamus.pacts.crowd import UserData, UserDTO, UserType
+from ludamus.pacts.crowd import UserDTO, UserType
 from ludamus.pacts.enrollment import (
     AnonymousEnrollmentError,
     AnonymousEnrollmentErrorCode,
@@ -418,7 +418,7 @@ class TestCancel:
 
         service.cancel(_request(), "")
 
-        assert users.updated == [(_user().slug, UserData(name="Ala"))]
+        assert not users.updated
 
     def test_cancel_allowed_when_enrollment_closed(self):
         repo = FakeRepo(


### PR DESCRIPTION
## Summary

Follow-up to #548 (targets its branch) implementing the restructuring suggested in review. Both bug fixes from #548 are kept; this changes their *shape*: net **−33 lines**, one network call fewer per export, and a stronger guarantee.

### Google Sheets export: one atomic write instead of write-then-clear

#548 fixed "clear-then-write can empty the sheet" by writing first and conditionally clearing trailing rows. That still left a torn state: write succeeds → trailing clear fails → sheet holds fresh rows plus a stale tail while the organizer sees "Export failed". It also only handled *row* shrinkage (a narrower export left stale columns), and the `A:A` row count undercounted rows whose first cell is blank.

This PR replaces the flow with a single `values.update` request: the payload is padded with `""` out to the previous data's extent (read via a bare tab-name range, the same whole-data-region trick the importer in this file already uses). The export now either fully replaces the old data or leaves it untouched — there is no partial state to reason about.

Deleted along the way: `SHEETS_CLEAR_URL`, the clear POST and its conditional, the `ZZ` column bound, `_row_count`, and the URL-sniffing mock routers (`_writer_get`, `_METADATA_AND_ROW_COUNT_GETS`, the `A%3AA` dispatch in `_google_write_session`) that existed only to service the extra request. Writer tests now reuse the existing `_route_get` helper; `_google_write_session` drops its dead `clear_*` parameters.

Note: padded cells contain `""` rather than being truly blank (matters only to `ISBLANK()`-style formulas on the export tab, which Ludamus owns).

### Anonymous name update: skip the write when nothing was submitted

`_update_name` now touches the user repository only when a new name was actually posted. Cancelling without a name field performs **no** user update at all, instead of rewriting the unchanged name — the unit test's invariant tightens from "cancel rewrites the same name" to `assert not users.updated`.

## Validation

- Full suite: `pytest tests/integration tests/unit` — **2844 passed, 7 skipped**
- `ruff`, `black`, `mypy` (0 issues in 213 files), `pylint` (0 messages on touched files), `import-linter` (7 contracts kept), `ast-grep`, `codespell` — all clean

---
_Generated by [Claude Code](https://claude.ai/code/session_016ujU9oHmSW9ezXZmtMwaEc)_