### PR TITLE
Self-heal sandbox tool installs and Playwright browsers on session start

### DIFF
--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -60,7 +60,10 @@ fi
 if ! command -v python3.14 > /dev/null 2>&1 \
   || ! command -v pipx > /dev/null 2>&1; then
   export DEBIAN_FRONTEND=noninteractive
-  apt-get update -q > /dev/null || echo "WARN: apt-get update failed"
+  # --allow-releaseinfo-change: image PPAs occasionally change their metadata
+  # (e.g. ondrej/php renamed its Label), which otherwise fails the update.
+  apt-get update -q --allow-releaseinfo-change > /dev/null \
+    || echo "WARN: apt-get update failed"
   apt-get install -y -q python3.14 python3.14-venv pipx > /dev/null \
     || echo "WARN: apt-get install python3.14/pipx failed; Python tooling may be unavailable"
 fi
@@ -70,6 +73,29 @@ fi
 # setup still runs.
 mise trust || echo "WARN: 'mise trust' failed"
 mise install || echo "WARN: 'mise install' failed; some tools may be unavailable"
+
+# The sandbox image pre-bakes GitHub-layout installs of some aliased tools
+# (shellcheck, actionlint, hadolint at last check). mise then skips installing
+# them, but their on-disk layout doesn't match the [tool_alias] backend, so
+# mise can't list their bin paths: no shims are generated and `mise run` tasks
+# drop them from PATH (hk dies with "actionlint: not found"). A missing shim
+# is the reliable symptom — purge the clashing install and re-run
+# `mise install` so the alias backend re-provisions it. Pre-baked installs
+# whose layout happens to satisfy the alias (hk) keep their shim and are left
+# alone, avoiding a pointless cargo rebuild.
+purged=""
+while IFS= read -r tool; do
+  if [ ! -e "$HOME/.local/share/mise/shims/$tool" ]; then
+    rm -rf "$HOME/.local/share/mise/installs/$tool"
+    purged="$purged $tool"
+  fi
+done < <(sed -n '/^\[tool_alias\]/,/^\[/s/^\([a-zA-Z0-9_-]\{1,\}\)[[:space:]]*=.*/\1/p' \
+  mise.sandbox.toml)
+if [ -n "$purged" ]; then
+  echo "Re-provisioning aliased tools with missing shims:$purged"
+  mise install \
+    || echo "WARN: 'mise install' retry failed; broken tools:$purged"
+fi
 
 mise bootstrap packages apply --yes || echo "WARN: 'mise bootstrap packages apply' failed"
 mise run bootstrap || echo "WARN: 'mise run bootstrap' failed; JS deps/build may be unavailable"
@@ -81,6 +107,10 @@ mise run bootstrap || echo "WARN: 'mise run bootstrap' failed; JS deps/build may
 mise exec -- hk install --mise || echo "WARN: 'hk install' failed; git hooks not installed"
 
 # Playwright backs the e2e suite and `aubx agent-browser` screenshots; both
-# share the Chromium it provisions.
+# share the Chromium it provisions. The task's `--with-deps` needs apt, which
+# breaks whenever an image PPA changes its metadata; the image already ships
+# every OS lib Chromium needs, so fall back to a dependency-less browser
+# download (the Playwright CDN is reachable through the egress proxy).
 mise run test:e2e:install \
+  || mise exec -- aube exec -C tests/e2e playwright install \
   || echo "WARN: Playwright install failed; e2e suite and agent-browser screenshots unavailable"

--- a/PAPERCUTS.md
+++ b/PAPERCUTS.md
@@ -13,3 +13,12 @@ sentences each: what you were doing → what got in the way. See CLAUDE.md.
   (writes literal `'\''` sequences into PAPERCUTS.md) and doesn't wrap at 80
   columns, so the very next commit trips markdownlint MD013 on the file it
   just wrote.
+- 2026-07-10: fresh sandbox: `mise run check` failed with actionlint/hadolint
+  not found. The image pre-bakes GitHub-layout installs of aliased tools; mise
+  then skips installing them but cannot list their bin paths, so no shims and
+  no task PATH entries. Fixed by purging installs without shims and rerunning
+  `mise install` in the session-start hook.
+- 2026-07-10: the pre-baked /opt/pw-browsers chromium build (1194) does not
+  match @playwright/test 1.58.2 (needs 1208), so e2e cannot launch a browser
+  and the preinstalled-browsers fallback is not real. Plain
+  `playwright install` without `--with-deps` works through the proxy.

--- a/PAPERCUTS.md
+++ b/PAPERCUTS.md
@@ -12,7 +12,8 @@ sentences each: what you were doing → what got in the way. See CLAUDE.md.
 - 2026-07-10: `mise run papercut -- <note>` garbles apostrophes in the note
   (writes literal `'\''` sequences into PAPERCUTS.md) and doesn't wrap at 80
   columns, so the very next commit trips markdownlint MD013 on the file it
-  just wrote.
+  just wrote. Fixed: the task now shlex-unquotes the note and wraps entries
+  at 80 columns.
 - 2026-07-10: fresh sandbox: `mise run check` failed with actionlint/hadolint
   not found. The image pre-bakes GitHub-layout installs of aliased tools; mise
   then skips installing them but cannot list their bin paths, so no shims and

--- a/docs/agents/sandbox.md
+++ b/docs/agents/sandbox.md
@@ -18,6 +18,20 @@ installs them from npm everywhere (the unscoped `aube` npm package is
 squatted — only `@endevco/aube` is ours; prod's `docker/mise.toml`
 intentionally keeps the GitHub pin).
 
+The sandbox image pre-bakes GitHub-layout installs of some of these tools.
+When such an install clashes with the alias backend, mise skips installing it
+but cannot list its bin paths — no shim, absent from `mise run` task PATH, hk
+dies with "actionlint: not found". The hook self-heals: any aliased tool
+without a shim after `mise install` gets its install purged and reinstalled
+through the alias. Pre-baked layouts that happen to satisfy the alias (hk)
+are kept as is.
+
+Playwright browsers: the image's `/opt/pw-browsers` build can lag the
+`@playwright/test` pin, so the hook runs `mise run test:e2e:install`; when its
+`--with-deps` apt step breaks (image PPA metadata drift), it falls back to a
+plain `playwright install` — the Playwright CDN is reachable through the
+proxy and the image already ships Chromium's OS libs.
+
 After that, `mise install` is green, `mise run` tasks work unchanged, and hk
 runs as the pre-commit hook. Laptops never load `mise.sandbox.toml` — nothing
 here activates without `MISE_ENV=sandbox`. If a session ever looks

--- a/mise.toml
+++ b/mise.toml
@@ -408,8 +408,23 @@ arg "<note>" var=#true help="One or two sentences: what you were doing -> what g
 '''
 run = '''
 set -eu
-note="${usage_note:-}"
-[ -n "$note" ] || { echo "usage: mise run papercut -- <note>" >&2; exit 2; }
-printf -- '- %s: %s\n' "$(date +%F)" "$note" >> PAPERCUTS.md
+[ -n "${usage_note:-}" ] || { echo "usage: mise run papercut -- <note>" >&2; exit 2; }
+# usage passes the variadic note as a shell-quoted join, so apostrophes arrive
+# as '\'' sequences — shlex.split undoes that. textwrap keeps markdownlint
+# MD013 (80 columns) happy with the same hanging indent as hand-written
+# entries.
+python - <<'EOF'
+import datetime
+import os
+import shlex
+import textwrap
+
+note = " ".join(shlex.split(os.environ["usage_note"])).strip()
+entry = textwrap.fill(
+    f"- {datetime.date.today():%Y-%m-%d}: {note}", width=80, subsequent_indent="  "
+)
+with open("PAPERCUTS.md", "a", encoding="utf-8") as file:
+    file.write(entry + "\n")
+EOF
 echo "logged to PAPERCUTS.md"
 '''


### PR DESCRIPTION
Fresh sandboxes came up with `mise run check` broken: the image pre-bakes
GitHub-layout installs of shellcheck/actionlint/hadolint, so mise skips
installing them through the mise.sandbox.toml [tool_alias] backends but
cannot list their bin paths — no shims, dropped from `mise run` task PATH,
and hk dies with "actionlint: not found". The hook now purges any aliased
tool without a shim after `mise install` and reinstalls it via the alias;
pre-baked layouts that satisfy the alias (hk) are left alone.

The e2e suite was also unusable: /opt/pw-browsers ships chromium build 1194
while @playwright/test 1.58.2 needs 1208, and `playwright install
--with-deps` dies on apt (ondrej/php PPA renamed its InRelease Label). Fall
back to a dependency-less `playwright install` (CDN is reachable through
the proxy; the image already ships Chromium's OS libs) and let apt tolerate
release-info changes.

Co-authored-by: hasparus <hasparus@gmail.com>