### PR TITLE
Event page code-quality follow-up (thermo-nuclear review of #558)

### DIFF
--- a/src/ludamus/adapters/web/django/views.py
+++ b/src/ludamus/adapters/web/django/views.py
@@ -959,6 +959,10 @@ def _field_value_dtos_from_models(
     )
 
 
+# Above this many scheduled sessions, the card grid becomes unwieldy and the
+# event page switches to the compact schedule (a dense chronological list with
+# an hour scrubber). Tunable; not a business invariant, so it lives here rather
+# than in specs.
 COMPACT_SCHEDULE_MIN_SESSIONS = 20
 
 
@@ -1049,9 +1053,7 @@ class EventPageView(DetailView):  # type: ignore [type-arg]
                 sid: fake_full_card(data) for sid, data in sessions_data.items()
             }
 
-        compact_schedule = len(sessions_data) >= COMPACT_SCHEDULE_MIN_SESSIONS
-
-        if compact_schedule:
+        if compact_schedule := len(sessions_data) >= COMPACT_SCHEDULE_MIN_SESSIONS:
             self._set_bookmark_counts(sessions_data)
             if current_user_id:
                 self._set_user_bookmarks(sessions_data, current_user_id)

--- a/src/ludamus/client/src/event-timeline.ts
+++ b/src/ludamus/client/src/event-timeline.ts
@@ -73,9 +73,10 @@ const initScheduleRail = (rail: HTMLElement): void => {
   );
   for (const section of sections) observer.observe(section);
 
-  // Drag-to-scrub: treat the rail like a slider. Pointer capture keeps events
-  // flowing to the rail even when the finger strays off it, and we resolve the
-  // marker by vertical position so dragging glides smoothly between hours.
+  // Drag-to-scrub: treat the rail like a slider. Move/end listeners live on the
+  // window so the scrub keeps tracking when the pointer strays off the narrow
+  // rail, and the marker resolves by vertical position so dragging glides
+  // smoothly between hours.
   let dragging = false;
   const linkAtY = (clientY: number): HTMLAnchorElement | null => {
     let nearest: HTMLAnchorElement | null = null;
@@ -101,6 +102,7 @@ const initScheduleRail = (rail: HTMLElement): void => {
   };
 
   // A press only becomes a scrub after real movement; below the threshold the
+  // press stays an ordinary tap and the marker's click handler does the jump.
   const DRAG_THRESHOLD_PX = 6;
   let moved = false;
   let startY = 0;
@@ -133,14 +135,16 @@ const initScheduleRail = (rail: HTMLElement): void => {
   };
   globalThis.addEventListener("pointerup", endDrag);
   globalThis.addEventListener("pointercancel", endDrag);
-  globalThis.addEventListener("mouseup", endDrag);
 
   rail.addEventListener(
     "wheel",
     (event) => {
       if (!scrollRoot) return;
       event.preventDefault();
-      scrollRoot.scrollBy({ top: event.deltaY });
+      // Firefox reports line-based deltas for a mouse wheel; scale them to
+      // pixels or each notch would nudge the page by a few pixels only.
+      const scale = event.deltaMode === WheelEvent.DOM_DELTA_LINE ? 16 : 1;
+      scrollRoot.scrollBy({ top: event.deltaY * scale });
     },
     { passive: false },
   );

--- a/src/ludamus/client/src/index.css
+++ b/src/ludamus/client/src/index.css
@@ -188,8 +188,13 @@ body {
   cursor: grabbing;
 }
 
+/* Give every room lane a usable minimum width; the table then overflows into
+   its scroll container instead of crushing columns. --room-count is always set
+   inline by _room_lanes.html (no fallback on purpose — a missing value should
+   fail visibly, not silently clamp to a guess). 3.5rem covers the w-12 sticky
+   time column plus the border-spacing around it. */
 .room-lanes-table {
-  min-width: calc(3.5rem + var(--room-count, 4) * 10rem);
+  min-width: calc(3.5rem + var(--room-count) * 10rem);
 }
 
 /* Lock the page scroll while any modal is open. Freezing the container keeps its

--- a/src/ludamus/client/src/session-bookmarks.ts
+++ b/src/ludamus/client/src/session-bookmarks.ts
@@ -14,13 +14,22 @@ const BOOKMARKED_COLOR = ["text-coral-600", "dark:text-coral-400"];
 const bookmarkUrl = (template: string, sessionId: string): string =>
   template.replace(/0\/bookmark\/?$/, `${sessionId}/bookmark/`);
 
-const paint = (button: HTMLElement, bookmarked: boolean): void => {
+// The server's response carries the fresh count; the optimistic pre-response
+// flip (and its revert) has no count yet, so it nudges the displayed number
+// by ±1 until the real one arrives.
+const paint = (button: HTMLElement, bookmarked: boolean, serverCount?: number): void => {
   const wasBookmarked = button.getAttribute("aria-pressed") === "true";
   const count = button.querySelector<HTMLElement>(".bookmark-count");
-  if (count && wasBookmarked !== bookmarked) {
-    const next = Math.max(0, Number(count.textContent) + (bookmarked ? 1 : -1));
-    count.textContent = String(next);
-    count.classList.toggle("hidden", next === 0);
+  if (count) {
+    const next =
+      serverCount ??
+      (wasBookmarked === bookmarked
+        ? undefined
+        : Math.max(0, Number(count.textContent) + (bookmarked ? 1 : -1)));
+    if (next !== undefined) {
+      count.textContent = String(next);
+      count.classList.toggle("hidden", next === 0);
+    }
   }
   button.setAttribute("aria-pressed", String(bookmarked));
   button.classList.toggle(BOOKMARKED_COLOR[0], bookmarked);
@@ -56,11 +65,13 @@ const toggleBookmark = async (button: HTMLElement): Promise<void> => {
     if (
       typeof data !== "object" ||
       data === null ||
-      typeof (data as Record<string, unknown>).bookmarked !== "boolean"
+      typeof (data as Record<string, unknown>).bookmarked !== "boolean" ||
+      typeof (data as Record<string, unknown>).count !== "number"
     ) {
       throw new TypeError("Bookmark toggle: unexpected response");
     }
-    paint(button, (data as { bookmarked: boolean }).bookmarked);
+    const { bookmarked, count } = data as { bookmarked: boolean; count: number };
+    paint(button, bookmarked, count);
   } catch (error) {
     paint(button, previous); // Revert the optimistic flip.
     console.error(error);

--- a/src/ludamus/gates/web/django/chronology/views.py
+++ b/src/ludamus/gates/web/django/chronology/views.py
@@ -1002,11 +1002,11 @@ class SessionBookmarkToggleView(View):
             # fetch() call, not a browser navigation — a redirect would be
             # useless, so surface the auth failure as JSON for the client.
             return JsonResponse({"error": "auth"}, status=401)
-        state = request.services.bookmarks.toggle(
+        result = request.services.bookmarks.toggle(
             user_id=user_id,
             session_id=session_id,
             sphere_id=request.context.current_sphere_id,
         )
-        if state is None:
+        if result is None:
             return JsonResponse({"error": "not-found"}, status=404)
-        return JsonResponse({"bookmarked": state})
+        return JsonResponse({"bookmarked": result.bookmarked, "count": result.count})

--- a/src/ludamus/links/db/django/bookmarks.py
+++ b/src/ludamus/links/db/django/bookmarks.py
@@ -1,12 +1,14 @@
 from django.db.models import Count
 
 from ludamus.adapters.db.django.models import Session, SessionBookmark
-from ludamus.pacts.bookmarks import BookmarkRepositoryProtocol
+from ludamus.pacts.bookmarks import BookmarkRepositoryProtocol, BookmarkToggleDTO
 
 
 class BookmarkRepository(BookmarkRepositoryProtocol):
     @staticmethod
-    def toggle(*, user_id: int, session_id: int, sphere_id: int) -> bool | None:
+    def toggle(
+        *, user_id: int, session_id: int, sphere_id: int
+    ) -> BookmarkToggleDTO | None:
         # Resolve the session within the viewer's sphere so a bookmark can't be
         # forged against a session that isn't visible here.
         if not Session.objects.filter(
@@ -18,10 +20,16 @@ class BookmarkRepository(BookmarkRepositoryProtocol):
         deleted, __ = SessionBookmark.objects.filter(
             user_id=user_id, session_id=session_id
         ).delete()
-        if deleted:
-            return False
-        SessionBookmark.objects.get_or_create(user_id=user_id, session_id=session_id)
-        return True
+        if not deleted:
+            SessionBookmark.objects.get_or_create(
+                user_id=user_id, session_id=session_id
+            )
+        # The fresh total rides back so the client can paint the real number
+        # instead of guessing with ±1 arithmetic on the DOM.
+        return BookmarkToggleDTO(
+            bookmarked=not deleted,
+            count=SessionBookmark.objects.filter(session_id=session_id).count(),
+        )
 
     @staticmethod
     def bookmarked_session_ids(*, user_id: int, event_id: int) -> set[int]:

--- a/src/ludamus/mills/bookmarks.py
+++ b/src/ludamus/mills/bookmarks.py
@@ -5,7 +5,7 @@ from typing import TYPE_CHECKING
 from ludamus.pacts.bookmarks import BookmarkServiceProtocol
 
 if TYPE_CHECKING:
-    from ludamus.pacts.bookmarks import BookmarkRepositoryProtocol
+    from ludamus.pacts.bookmarks import BookmarkRepositoryProtocol, BookmarkToggleDTO
     from ludamus.pacts.services import TransactionProtocol
 
 
@@ -16,7 +16,9 @@ class BookmarkService(BookmarkServiceProtocol):
         self._transaction = transaction
         self._repo = repo
 
-    def toggle(self, *, user_id: int, session_id: int, sphere_id: int) -> bool | None:
+    def toggle(
+        self, *, user_id: int, session_id: int, sphere_id: int
+    ) -> BookmarkToggleDTO | None:
         with self._transaction.atomic():
             return self._repo.toggle(
                 user_id=user_id, session_id=session_id, sphere_id=sphere_id

--- a/src/ludamus/pacts/bookmarks.py
+++ b/src/ludamus/pacts/bookmarks.py
@@ -1,9 +1,18 @@
 from typing import Protocol
 
+from pydantic import BaseModel
+
+
+class BookmarkToggleDTO(BaseModel):
+    bookmarked: bool
+    count: int
+
 
 class BookmarkRepositoryProtocol(Protocol):
     @staticmethod
-    def toggle(*, user_id: int, session_id: int, sphere_id: int) -> bool | None: ...
+    def toggle(
+        *, user_id: int, session_id: int, sphere_id: int
+    ) -> BookmarkToggleDTO | None: ...
     @staticmethod
     def bookmarked_session_ids(*, user_id: int, event_id: int) -> set[int]: ...
     @staticmethod
@@ -13,6 +22,6 @@ class BookmarkRepositoryProtocol(Protocol):
 class BookmarkServiceProtocol(Protocol):
     def toggle(
         self, *, user_id: int, session_id: int, sphere_id: int
-    ) -> bool | None: ...
+    ) -> BookmarkToggleDTO | None: ...
     def bookmarked_session_ids(self, *, user_id: int, event_id: int) -> set[int]: ...
     def bookmark_counts(self, *, event_id: int) -> dict[int, int]: ...

--- a/src/ludamus/templates/chronology/_bookmark_toggle.html
+++ b/src/ludamus/templates/chronology/_bookmark_toggle.html
@@ -8,25 +8,32 @@
 {# bookmark instead of opening the detail modal. Anonymous viewers get a #}
 {# read-only count badge (popularity signal) instead of the button; zero #}
 {# counts stay hidden so quiet sessions carry no "0" noise. #}
-{% if current_user %}
-    <button type="button"
-            class="bookmark-toggle before:inset-0 before:-inset-y-2.5 before:absolute before:bg-transparent icon-btn icon-btn-clear relative z-20 shrink-0 self-center border border-transparent hover:border-border hover:bg-bg-tertiary gap-0.75 pointer-events-auto {% if data.user_bookmarked %}text-coral-600 dark:text-coral-400{% endif %}"
-            data-session-id="{{ data.session.pk }}"
-            aria-pressed="{% if data.user_bookmarked %}true{% else %}false{% endif %}">
-        {% if data.user_bookmarked %}
-            {% icon "bookmark" class="bookmark-icon-outline size-4 hidden" variant="outline" %}
-            {% icon "bookmark" class="bookmark-icon-solid size-4" variant="solid" %}
+{# This file owns the whole affordance, including whether it renders at all; #}
+{# callers position it via wrapper_class and pad for it with #}
+{# has-[.bookmark-affordance] variants instead of re-deriving visibility. #}
+{% if current_user or data.bookmark_count %}
+    <span class="bookmark-affordance {{ wrapper_class }}">
+        {% if current_user %}
+            <button type="button"
+                    class="bookmark-toggle before:inset-0 before:-inset-y-2.5 before:absolute before:bg-transparent icon-btn icon-btn-clear relative z-20 shrink-0 self-center border border-transparent hover:border-border hover:bg-bg-tertiary gap-0.75 pointer-events-auto {% if data.user_bookmarked %}text-coral-600 dark:text-coral-400{% endif %}"
+                    data-session-id="{{ data.session.pk }}"
+                    aria-pressed="{% if data.user_bookmarked %}true{% else %}false{% endif %}">
+                {% if data.user_bookmarked %}
+                    {% icon "bookmark" class="bookmark-icon-outline size-4 hidden" variant="outline" %}
+                    {% icon "bookmark" class="bookmark-icon-solid size-4" variant="solid" %}
+                {% else %}
+                    {% icon "bookmark" class="bookmark-icon-outline size-4" variant="outline" %}
+                    {% icon "bookmark" class="bookmark-icon-solid size-4 hidden" variant="solid" %}
+                {% endif %}
+                <span class="sr-only">{% translate "Bookmark session" %}</span>
+                <span class="bookmark-count text-xs tabular-nums {% if not data.bookmark_count %}hidden{% endif %}">{{ data.bookmark_count }}</span>
+            </button>
         {% else %}
-            {% icon "bookmark" class="bookmark-icon-outline size-4" variant="outline" %}
-            {% icon "bookmark" class="bookmark-icon-solid size-4 hidden" variant="solid" %}
+            <span class="relative z-20 inline-flex shrink-0 items-center self-center gap-0.75 p-1.5 text-xs text-foreground-secondary">
+                {% icon "bookmark" class="size-4" variant="outline" %}
+                <span class="tabular-nums" aria-hidden="true">{{ data.bookmark_count }}</span>
+                <span class="sr-only">{% blocktranslate count counter=data.bookmark_count %}Bookmarked by {{ counter }} person{% plural %}Bookmarked by {{ counter }} people{% endblocktranslate %}</span>
+            </span>
         {% endif %}
-        <span class="sr-only">{% translate "Bookmark session" %}</span>
-        <span class="bookmark-count text-xs tabular-nums {% if not data.bookmark_count %}hidden{% endif %}">{{ data.bookmark_count }}</span>
-    </button>
-{% elif data.bookmark_count %}
-    <span class="relative z-20 inline-flex shrink-0 items-center self-center gap-0.75 p-1.5 text-xs text-foreground-secondary">
-        {% icon "bookmark" class="size-4" variant="outline" %}
-        <span class="tabular-nums" aria-hidden="true">{{ data.bookmark_count }}</span>
-        <span class="sr-only">{% blocktranslate count counter=data.bookmark_count %}Bookmarked by {{ counter }} person{% plural %}Bookmarked by {{ counter }} people{% endblocktranslate %}</span>
     </span>
 {% endif %}

--- a/src/ludamus/templates/chronology/_compact_session_row.html
+++ b/src/ludamus/templates/chronology/_compact_session_row.html
@@ -7,7 +7,7 @@
 {# contract as _session_card.html so session-filters and the detail modal #}
 {# work unchanged. #}
 <article class="session-wrapper min-w-0">
-    <div class="session group/row relative flex flex-wrap items-center gap-x-2 rounded-lg px-2 py-2 max-sm:pl-12 sm:flex-nowrap sm:gap-x-3 transition-colors has-[a:hover]:duration-0 has-[a:hover]:bg-bg-tertiary [text-box:trim-start_cap_alphabetic] {% if current_user or data.bookmark_count %}max-sm:pr-11{% endif %} {% if data.user_enrolled %}bg-coral-50/60 dark:bg-coral-950/40{% endif %} {% if data.is_ended %}opacity-65 has-[a:hover]:opacity-100{% endif %}"
+    <div class="session group/row relative flex flex-wrap items-center gap-x-2 rounded-lg px-2 py-2 max-sm:pl-12 sm:flex-nowrap sm:gap-x-3 transition-colors has-[a:hover]:duration-0 has-[a:hover]:bg-bg-tertiary [text-box:trim-start_cap_alphabetic] max-sm:has-[.bookmark-affordance]:pr-11 {% if data.user_enrolled %}bg-coral-50/60 dark:bg-coral-950/40{% endif %} {% if data.is_ended %}opacity-65 has-[a:hover]:opacity-100{% endif %}"
          data-no-morph
          {% include "chronology/_session_data_attrs.html" %}>
         <a href="?session={{ data.session.pk }}"
@@ -18,7 +18,7 @@
         </a>
         {# Absolute on mobile so the stacked time centers against the whole #}
         {# two-line row instead of only the title line it shares a flex line with. #}
-        <span class="w-8 shrink-0 whitespace-nowrap text-[0.7rem] pt-1.5 tabular-nums text-foreground-secondary max-sm:absolute max-sm:left-2 max-sm:top-1/2 max-sm:-translate-y-1/2 sm:w-28 max-sm:row-span-full">{{ data.agenda_item.start_time|time:"H:i" }}<span class="hidden sm:inline">–</span><span class="block sm:inline">{{ data.agenda_item.end_time|time:"H:i" }}</span></span>
+        <span class="w-8 shrink-0 whitespace-nowrap text-[0.7rem] pt-1.5 tabular-nums text-foreground-secondary max-sm:absolute max-sm:left-2 max-sm:top-1/2 max-sm:-translate-y-1/2 sm:w-28">{{ data.agenda_item.start_time|time:"H:i" }}<span class="hidden sm:inline">–</span><span class="block sm:inline">{{ data.agenda_item.end_time|time:"H:i" }}</span></span>
         <span class="min-w-0 flex-1 truncate">
             <span class="text-sm font-semibold text-foreground [text-box:trim-start_cap_alphabetic]">{{ data.session.title }}</span>
             <span class="ml-1.5 text-xs text-foreground-muted [text-box:trim-start_cap_alphabetic]">{{ data.session.display_name }}</span>
@@ -37,14 +37,10 @@
                 {% include "chronology/_session_availability.html" %}
             {% endif %}
         </span>
-        {% if current_user or data.bookmark_count %}
-            {# On mobile the toggle leaves the flex flow and pins to the row's #}
-            {# right edge (the row is `relative`) instead of wrapping to a #}
-            {# third line after the basis-full meta span. #}
-            <span class="z-20 shrink-0 self-center pointer-events-auto max-sm:absolute max-sm:right-1 max-sm:top-1/2 max-sm:-translate-y-1/2">
-                {% include "chronology/_bookmark_toggle.html" %}
-            </span>
-        {% endif %}
+        {# On mobile the toggle leaves the flex flow and pins to the row's #}
+        {# right edge (the row is `relative`) instead of wrapping to a #}
+        {# third line after the basis-full meta span. #}
+        {% include "chronology/_bookmark_toggle.html" with wrapper_class="z-20 shrink-0 self-center pointer-events-auto max-sm:absolute max-sm:right-1 max-sm:top-1/2 max-sm:-translate-y-1/2" %}
         <span class="sr-only" data-session-description>{{ data.session.description }}</span>
     </div>
 </article>

--- a/src/ludamus/templates/chronology/_room_lane_tile.html
+++ b/src/ludamus/templates/chronology/_room_lane_tile.html
@@ -4,7 +4,7 @@
 {# Session tile inside a room-lane cell. Same .session / data-* contract #}
 {# as the ledger row, so filters, bookmarks, and the detail modal apply. #}
 <article class="session-wrapper min-w-0">
-    <div class="session relative flex flex-col gap-1.5 rounded-xl border border-border bg-bg-secondary p-2.5 transition-colors hover:border-neutral-300 dark:hover:border-neutral-600 {% if data.user_enrolled %}bg-coral-50/60 dark:bg-coral-950/40{% endif %} {% if data.is_ended %}opacity-65 hover:opacity-100{% endif %}"
+    <div class="session group/tile relative flex flex-col gap-1.5 rounded-xl border border-border bg-bg-secondary p-2.5 transition-colors hover:border-neutral-300 dark:hover:border-neutral-600 {% if data.user_enrolled %}bg-coral-50/60 dark:bg-coral-950/40{% endif %} {% if data.is_ended %}opacity-65 hover:opacity-100{% endif %}"
          {% include "chronology/_session_data_attrs.html" %}>
         <a href="?session={{ data.session.pk }}"
            class="session-link absolute inset-0 z-10 rounded-xl"
@@ -12,7 +12,7 @@
            aria-controls="session-{{ data.session.pk }}">
             <span class="sr-only">{% blocktranslate with title=data.session.title %}Open details for {{ title }}{% endblocktranslate %}</span>
         </a>
-        <h4 class="{% if current_user or data.bookmark_count %}pr-12{% endif %} text-sm font-semibold leading-snug text-foreground"
+        <h4 class="group-has-[.bookmark-affordance]/tile:pr-12 text-sm font-semibold leading-snug text-foreground"
             data-morph="title">
             {{ data.session.title }}
             <span class="text-xs font-normal text-foreground-muted" data-morph="host">{{ data.session.display_name }}</span>
@@ -27,10 +27,8 @@
             </span>
             <span class="shrink-0 whitespace-nowrap text-right">{% include "chronology/_session_availability.html" %}</span>
         </div>
-        {% if current_user or data.bookmark_count %}
-            {# .icon-btn pins position:relative, so a wrapper owns the corner. #}
-            <span class="absolute top-1 right-1 z-20 pointer-events-auto">{% include "chronology/_bookmark_toggle.html" %}</span>
-        {% endif %}
+        {# .icon-btn pins position:relative, so the wrapper owns the corner. #}
+        {% include "chronology/_bookmark_toggle.html" with wrapper_class="absolute top-1 right-1 z-20 pointer-events-auto" %}
         <span class="sr-only" data-session-description>{{ data.session.description }}</span>
     </div>
 </article>

--- a/tests/integration/web/chronology/test_session_bookmark.py
+++ b/tests/integration/web/chronology/test_session_bookmark.py
@@ -1,4 +1,5 @@
 from http import HTTPStatus
+from unittest.mock import ANY
 
 import pytest
 from django.urls import reverse
@@ -11,6 +12,7 @@ from tests.integration.conftest import (
     SphereFactory,
     UserFactory,
 )
+from tests.integration.utils import assert_response
 
 
 class TestSessionBookmarkToggleView:
@@ -27,18 +29,20 @@ class TestSessionBookmarkToggleView:
         assert not SessionBookmark.objects.exists()
 
     def test_toggle_on_then_off(self, authenticated_client, active_user, session):
+        SessionBookmark.objects.create(user=UserFactory(), session=session)
+
         response_on = authenticated_client.post(self._url(session.pk))
 
         assert response_on.status_code == HTTPStatus.OK
-        assert response_on.json() == {"bookmarked": True}
+        assert response_on.json() == {"bookmarked": True, "count": 2}
         bookmark = SessionBookmark.objects.get(user=active_user, session=session)
         assert str(bookmark) == f"{active_user.pk} bookmarked session {session.pk}"
 
         response_off = authenticated_client.post(self._url(session.pk))
 
         assert response_off.status_code == HTTPStatus.OK
-        assert response_off.json() == {"bookmarked": False}
-        assert not SessionBookmark.objects.exists()
+        assert response_off.json() == {"bookmarked": False, "count": 1}
+        assert not SessionBookmark.objects.filter(user=active_user).exists()
 
     def test_not_found_for_other_sphere_session(self, authenticated_client):
         other_event = EventFactory(sphere=SphereFactory())
@@ -81,19 +85,27 @@ class TestEventPageBookmarkCounts:
 
         response = client.get(self._url(event.slug))
 
-        assert response.status_code == HTTPStatus.OK
-        content = response.content.decode()
-        assert "Bookmarked by 2 people" in content
-        assert content.count("Bookmarked by") == 1
-        assert "bookmark-toggle" not in content
+        assert_response(
+            response,
+            HTTPStatus.OK,
+            context_data=ANY,
+            template_name=ANY,
+            contains="Bookmarked by 2 people",
+            not_contains=["bookmark-toggle", "Bookmarked by 0"],
+        )
 
     def test_anonymous_rooms_view_shows_count_badge(self, agenda_item, client, event):
         SessionBookmark.objects.create(user=UserFactory(), session=agenda_item.session)
 
         response = client.get(self._url(event.slug), {"view": "rooms"})
 
-        assert response.status_code == HTTPStatus.OK
-        assert "Bookmarked by 1 person" in response.content.decode()
+        assert_response(
+            response,
+            HTTPStatus.OK,
+            context_data=ANY,
+            template_name=ANY,
+            contains="Bookmarked by 1 person",
+        )
 
     def test_authenticated_toggle_shows_count_and_hides_zero(
         self, agenda_item, authenticated_client, event, space
@@ -105,12 +117,15 @@ class TestEventPageBookmarkCounts:
             session=SessionFactory(event=event, category=None), space=space
         )
 
-        scheduled_sessions = 2
-
         response = authenticated_client.get(self._url(event.slug))
 
-        assert response.status_code == HTTPStatus.OK
-        content = response.content.decode()
-        assert content.count("bookmark-toggle") == scheduled_sessions
-        assert ">3</span>" in content
-        assert "tabular-nums hidden" in content
+        # The class strings are the .bookmark-count contract with
+        # session-bookmarks.ts: a visible "3" on the bookmarked session and a
+        # hidden "0" inside the other session's toggle button.
+        assert_response(
+            response,
+            HTTPStatus.OK,
+            context_data=ANY,
+            template_name=ANY,
+            contains=['tabular-nums ">3</span>', 'tabular-nums hidden">0</span>'],
+        )

--- a/tests/unit/test_bookmarks_service.py
+++ b/tests/unit/test_bookmarks_service.py
@@ -1,6 +1,7 @@
 from contextlib import contextmanager
 
 from ludamus.mills.bookmarks import BookmarkService
+from ludamus.pacts.bookmarks import BookmarkToggleDTO
 
 
 @contextmanager
@@ -18,7 +19,7 @@ class FakeTransaction:
 
 
 class FakeRepo:
-    def __init__(self, *, toggle_result=True, bookmarked_ids=None, counts=None):
+    def __init__(self, *, toggle_result=None, bookmarked_ids=None, counts=None):
         self._toggle_result = toggle_result
         self._bookmarked_ids = set(bookmarked_ids or set())
         self._counts = dict(counts or {})
@@ -40,19 +41,20 @@ class FakeRepo:
 
 
 def test_toggle_runs_in_transaction_and_returns_repo_state():
-    repo = FakeRepo(toggle_result=False)
+    toggle_result = BookmarkToggleDTO(bookmarked=False, count=4)
+    repo = FakeRepo(toggle_result=toggle_result)
     transaction = FakeTransaction()
     service = BookmarkService(transaction, repo)
 
     result = service.toggle(user_id=7, session_id=42, sphere_id=3)
 
-    assert result is False
+    assert result == toggle_result
     assert transaction.entered == 1
     assert repo.toggle_calls == [(7, 42, 3)]
 
 
 def test_toggle_passes_through_missing_session_state():
-    repo = FakeRepo(toggle_result=None)
+    repo = FakeRepo()
     service = BookmarkService(FakeTransaction(), repo)
 
     result = service.toggle(user_id=7, session_id=42, sphere_id=3)


### PR DESCRIPTION
Follow-up to #558 applying the findings of a thermo-nuclear code-quality review. Behavior-preserving except where noted.

## Changes

### `_bookmark_toggle.html` owns its visibility and wrapper
The `current_user or data.bookmark_count` predicate lived in **five places across three templates** (two include guards, two padding conditionals, plus the partial's own if/elif) — while the partial's header comment asks callers to keep the affordance's logic in one file. The partial now renders its positioning wrapper itself (callers pass `wrapper_class`), and callers pad for it with `has-[.bookmark-affordance]` / `group-has-[...]` variants. The predicate now exists in exactly one file.

Also deletes the leftover `max-sm:row-span-full` on the ledger row's time span (a grid-child property on an absolutely-positioned flex child — a no-op from a WIP commit).

### Toggle endpoint returns the fresh bookmark count
The client derived the count from DOM state (`aria-pressed` comparison + ±1 arithmetic with a `Math.max(0, …)` clamp papering over "impossible" negatives). The repo is already in the DB at toggle time, so `toggle` now returns a `BookmarkToggleDTO { bookmarked, count }` through the pact → link → mill → gate chain, and the client paints the server's number verbatim (the optimistic pre-response flip keeps the ±1 nudge until the response lands). The displayed count stays honest under concurrent bookmarking.

### Hour-rail pointer plumbing cleanup
- The drag-to-scrub comment still described **pointer capture**, removed earlier in #558 — rewritten to describe the actual window-listener mechanism.
- The drag-threshold comment was cut off mid-sentence — completed.
- Dropped the window `mouseup` listener: it duplicates `pointerup` in every real browser, and its only motivation (Playwright's Firefox driver) is skipped in the e2e spec anyway.
- Line-based wheel deltas (Firefox) are now scaled to pixels, so a mouse wheel over the rail scrolls more than a few pixels per notch. *(Minor behavior fix.)*

### Smaller items
- Restored the rationale comment on `COMPACT_SCHEDULE_MIN_SESSIONS` that was deleted alongside the 60 → 20 change (heads-up: that threshold change is product-visible and rides silently in #558's description).
- Dropped the never-exercised `var(--room-count, 4)` fallback — `_room_lanes.html` always sets it, and a silent default would mask a broken template; documented the `3.5rem` instead.
- Converted the new event-page bookmark tests to `assert_response` per the repo testing rules, and anchored content checks on the `.bookmark-count` contract instead of bare `">3</span>"` / class-order strings.

## Verification

- `mise run check` green (djlint, ruff, mypy, pylint 10/10, import-linter, vulture, impeccable).
- Full Python suite: **2694 passed, 7 skipped**.
- e2e on chromium (`event-schedule-rail`, `event-details`, `event-filters`, `modal-surfaces`): **23 passed** — including the drag-scrub test, which validates the `mouseup` removal. (Firefox/WebKit unavailable in the sandbox; CI runs the full matrix.)
- Manually drove the dense-fixture event page (ledger + rooms views, anonymous badge with seeded counts, empty-affordance rows) — layout intact, badges render, no stray flex gaps.

## Review findings intentionally left for #558

- The branch is based on a pre-services-migration main and GitHub reports merge conflicts — worth a rebase before merging (`_set_bookmark_counts` ports cleanly onto today's `views.py`).
- Commits `8293459` ("gap1") / `0a1fa08` could be squashed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L8oceGpQSF4f9uaHUpFY6Q

---
_Generated by [Claude Code](https://claude.ai/code/session_01L8oceGpQSF4f9uaHUpFY6Q)_