### PR TITLE
fix(flaky): test_query_count_constant_in_session_count

### DIFF
--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -72,7 +72,7 @@ class UserFactory(DjangoModelFactory):
         skip_postgeneration_save = True
 
     username = Faker("user_name")
-    email = Faker("email")
+    email = Sequence(lambda n: f"user{n}@example.com")
     name = Faker("name")
     slug = LazyAttribute(lambda o: o.username)
     user_type = "active"  # Use the actual choice value

--- a/tests/integration/factories.py
+++ b/tests/integration/factories.py
@@ -10,7 +10,7 @@ class CompleteUserFactory(DjangoModelFactory):
     class Meta:
         model = User
 
-    email = factory.Faker("email")
+    email = factory.Sequence(lambda n: f"user{n}@example.com")
     name = factory.Faker("name")
     password = factory.LazyFunction(lambda: make_password(None))
     user_type = UserType.ACTIVE


### PR DESCRIPTION
## Summary

Weekly flaky-test scan of the last 7 days of `ci.yml` runs (211 runs: 151 success, 39 failure, 21 cancelled) found **one confirmed flaky test**:

`tests/integration/web/chronology/test_event_page.py::TestEventPageView::test_query_count_constant_in_session_count`

- Failed on attempt 1 of run [`28803776879`](https://github.com/zagrajmy/ludamus/actions/runs/28803776879) (branch `migrate-anonymous-enrollment-views`, 2026-07-06) with:
  ```
  django.db.utils.IntegrityError: UNIQUE constraint failed: index 'constraint_unique_email_lower_no_null'
  ```
- Passed on attempt 2 of the **same run/commit** after a GitHub "re-run failed jobs" (2026-07-07), confirming it's a flake and not a real regression.

## Root cause

The test itself doesn't touch email — it calls a `_add_scheduled_session` helper 8 times, each creating 2 `UserFactory()` users (16 users per test run). `UserFactory` (`tests/integration/conftest.py`) guarded `username` uniqueness via `django_get_or_create = ("username",)`, but left `email = Faker("email")` completely unguarded, even though the DB enforces a real unique (case-insensitive) constraint on email. Across a ~2,800-test suite creating many thousands of users from Faker's finite email corpus, a collision was only a matter of time — this test just has unusually high `UserFactory()` density, so it was where the collision surfaced.

`CompleteUserFactory` (`tests/integration/factories.py`) had the identical latent bug (unguarded `email = factory.Faker("email")`), just hadn't surfaced yet.

No CI-level retry/rerun logic exists in `ci.yml` or the pytest config, so this analysis should be a faithful signal — no other test showed a fail→pass flip on an identical commit in the window. (Every other failure in the window was on a distinct SHA with no rerun — e.g. WIP branch pushes fixed by a later commit — so those read as real bugs, not flakes.)

## Fix

Replace the unguarded `Faker("email")` with a `Sequence`-based guaranteed-unique email in both factories:

```python
email = Sequence(lambda n: f"user{n}@example.com")
```

## Verification

- Ran `tests/integration/web/chronology/test_event_page.py` 5x locally — all green (previously this was the file exhibiting the collision).
- Ran the full suite: `2865 passed, 7 skipped` (`pytest tests/integration tests/unit`).
- `mise run check` (lint/format/type/etc.) passes with no new issues.

## Test plan

- [x] `pytest tests/integration/web/chronology/test_event_page.py` — 5 consecutive runs, all pass
- [x] `pytest tests/integration tests/unit` — full suite passes
- [x] `mise run check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01Gdqh9eifRjPFHhC8ri2eaq)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved integration test reliability by generating predictable, sequential email addresses for factory-created users.
  * Reduced variability in test data, making test results easier to reproduce and diagnose.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->