### PR TITLE
Build SessionData DTOs once on the event page

### DIFF
--- a/src/ludamus/adapters/web/django/views.py
+++ b/src/ludamus/adapters/web/django/views.py
@@ -337,9 +337,10 @@ class EventPageView(DetailView):  # type: ignore [type-arg]
                 self.request.services.shadowban.banned_user_ids(current_user_id)
             )
 
-        hour_data = dict(self._get_hour_data(event_sessions, shadowbanned_ids))
-        # Get session data objects that include enrollment status
+        # Get session data objects that include enrollment status; the
+        # hour grouping reuses them instead of rebuilding every DTO.
         sessions_data = self._get_session_data(event_sessions, shadowbanned_ids)
+        hour_data = dict(self._get_hour_data(event_sessions, sessions_data))
 
         # Hard event ban: a banned viewer sees every session as full (with
         # simulacra participants) and gets no Enroll action, so the event looks
@@ -637,15 +638,12 @@ class EventPageView(DetailView):  # type: ignore [type-arg]
         for sid, data in sessions_data.items():
             data.user_bookmarked = sid in bookmarked_ids
 
+    @staticmethod
     def _get_hour_data(
-        self,
-        event_sessions: QuerySet[Session],
-        shadowbanned_ids: frozenset[int] = frozenset(),
+        event_sessions: QuerySet[Session], sessions_data: dict[int, SessionData]
     ) -> dict[datetime, list[SessionData]]:
         # Expects a scheduled-only queryset (agenda_item__isnull=False): the
         # grouping below dereferences each session's agenda item.
-        sessions_data = self._get_session_data(event_sessions, shadowbanned_ids)
-
         sessions_by_hour: dict[datetime, list[SessionData]] = defaultdict(list)
         for session in event_sessions:
             sessions_by_hour[session.agenda_item.start_time].append(


### PR DESCRIPTION
## What

`EventPageView.get_context_data` built every `SessionData` DTO twice: once inside `_get_hour_data` (which called `_get_session_data` internally) and once directly two lines later with identical inputs. On a 120-session event that duplicates ~1000 Pydantic validations per request.

Now `sessions_data` is built once and `_get_hour_data` is a pure grouping step (a `@staticmethod` over the prebuilt mapping, grouped by `agenda_item.start_time`).

## Why

Profiling the live Kapitularz 2025 event page (111 sessions, ~1.5 s TTFB) showed the request is CPU-bound, not query-bound (19 SQL queries, 7 ms). The duplicate DTO pass was worth ~6% of request time (measured locally: 536 → 503 ms median on a seeded 120-session × 8-participant event). Larger follow-ups (lazy modal fragments, markdown caching) are tracked separately.

## Behavior

Identical by construction: same context keys, `fake_full_card` rebinding for event-banned viewers still happens after `hour_data` is derived, and `_get_pending_sessions_context`'s direct `_get_session_data` call is untouched. No UI change, so no screenshots.

## Checks

- `mise run test:py`: 2881 passed, 7 skipped
- `mise run lint`: clean (ruff, mypy, pylint 10.00/10, djlint)
- `tingle check`: no debt growth

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WvkAUHaGTotQx3DimwPZLD

---
_Generated by [Claude Code](https://claude.ai/code/session_01WvkAUHaGTotQx3DimwPZLD)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved event session grouping to ensure sessions are consistently organized by start time.
  * Prevented duplicate session data processing when displaying event information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->