### PR TITLE
docs: sync strangler next-step with migrated anonymous views

### DIFF
--- a/docs/refactors/glimpse-strangler.md
+++ b/docs/refactors/glimpse-strangler.md
@@ -24,10 +24,7 @@ views. What remains in `adapters/`:
 
 - **`adapters/web/django/views.py`** still hosts:
   - Public Event Pages — `EventPageView`, `EventsPageView`, `IndexRedirectView`
-  - Enrollment — `SessionEnrollPageView`,
-    `SessionEnrollmentAnonymousPageView`, `ProposalAcceptPageView`,
-    `EventAnonymousActivateActionView`, `AnonymousLoadActionView`,
-    `AnonymousResetActionView`
+  - Enrollment — `SessionEnrollPageView`, `ProposalAcceptPageView`
   - `DesignPageView`, error views
 - **`adapters/db/django/models.py`** is still the real ORM module;
   `links/db/django/repositories/` imports from it
@@ -41,8 +38,9 @@ views. What remains in `adapters/`:
   and `adapters.db.django.apps.DBMainConfig`.
 
 Already migrated into `gates/`: the whole **Panel** (chronology + multiverse),
-**Notice Board / Encounters**, the **CFP** wizard, and **Crowd** (both
-**Auth** and **Profile**).
+**Notice Board / Encounters**, the **CFP** wizard, **Crowd** (both **Auth**
+and **Profile**), and anonymous enrollment
+(`gates/web/django/chronology/anonymous.py`).
 
 ## Done so far
 
@@ -87,11 +85,13 @@ Already migrated into `gates/`: the whole **Panel** (chronology + multiverse),
 
 Migrate the remaining **Public Event Pages** and **Enrollment** views
 (`EventPageView`, `EventsPageView`, `IndexRedirectView`,
-`SessionEnrollmentAnonymousPageView`, `ProposalAcceptPageView`,
-`EventAnonymousActivateActionView`, `AnonymousLoadActionView`,
-`AnonymousResetActionView`) out of `adapters/web/django/views.py` into their
-`gates/web/django/chronology/` homes, lifting the remaining `request.di.uow`
-access onto `request.services`. Then relocate the ORM models
+`SessionEnrollPageView`, `ProposalAcceptPageView`) out of
+`adapters/web/django/views.py` into their `gates/web/django/chronology/`
+homes, lifting the remaining `request.di.uow` access onto
+`request.services`. Anonymous enrollment already moved —
+`SessionEnrollmentAnonymousPageView`, `EventAnonymousActivateActionView`,
+`AnonymousLoadActionView` and `AnonymousResetActionView` all live in
+`gates/web/django/chronology/anonymous.py`. Then relocate the ORM models
 (`adapters/db/django/models.py` → `links/db/django/`) so `adapters/` can be
 emptied and locked down with an importlinter contract.
 


### PR DESCRIPTION
## What was stale

`docs/refactors/glimpse-strangler.md` still listed
`SessionEnrollmentAnonymousPageView`, `EventAnonymousActivateActionView`,
`AnonymousLoadActionView` and `AnonymousResetActionView` as pending work in
both the "Current state" (`adapters/web/django/views.py` still hosts...) and
"Next step" sections. They already moved to
`src/ludamus/gates/web/django/chronology/anonymous.py`.

## How I verified each name

`grep -n "class <Name>" src/ludamus/adapters/web/django/views.py` and
`grep -rn "class <Name>" src/ludamus/gates/` for every view named in the doc:

- Removed (absent from `adapters`, present in
  `gates/web/django/chronology/anonymous.py`): `SessionEnrollmentAnonymousPageView`,
  `EventAnonymousActivateActionView`, `AnonymousLoadActionView`,
  `AnonymousResetActionView`.
- Kept (still present in `adapters/web/django/views.py`): `EventPageView`,
  `EventsPageView`, `IndexRedirectView`, `SessionEnrollPageView`,
  `ProposalAcceptPageView`.

`SessionEnrollPageView` was missing from the old Next-step list even though
it's still in `adapters/` — added it.

## Changes

- Trimmed the "Current state" bullet list to only the views still in
  `adapters/web/django/views.py`.
- Added anonymous enrollment to the "Already migrated into `gates/`" sentence.
- Rewrote "Next step" to name only the remaining views, plus a sentence
  noting anonymous enrollment already lives in
  `gates/web/django/chronology/anonymous.py`.
- Checked `docs/refactors/README.md` row 1's "Next step" cell — it's generic
  ("Migrate Public Event Pages + Enrollment views out of `views.py`") and
  doesn't name specific views, so it doesn't contradict the corrected
  sub-doc; left unchanged.

## Verification

- `mise exec -- markdownlint-cli2 docs/refactors/*.md` → 0 errors.
- Pre-commit hooks (markdownlint, codespell, etc.) passed on commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BsdvWh3G9h76W5egZ73iu9

---
_Generated by [Claude Code](https://claude.ai/code/session_01BsdvWh3G9h76W5egZ73iu9)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the GLIMPSE migration report to accurately reflect completed and remaining enrollment view migrations.
  * Clarified that anonymous enrollment views have already moved to the new location.
  * Revised the documented next steps for migrating remaining public event and enrollment pages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->