### PR TITLE
docs(models): note superset-safe contract of conflicted_user_ids

### DIFF
--- a/src/ludamus/adapters/db/django/models.py
+++ b/src/ludamus/adapters/db/django/models.py
@@ -45,9 +45,8 @@ _SoftDeleteT = TypeVar("_SoftDeleteT", bound=models.Model)
 
 
 class AliveManager(models.Manager[_SoftDeleteT]):
-    # The default `objects` manager hides soft-deleted rows so every existing
-    # read (including reverse relations like `category.sessions`) excludes them
-    # automatically. Reach soft-deleted rows through `all_objects`.
+    # Default `objects` hides soft-deleted rows from every read, including reverse
+    # relations like `category.sessions`; use `all_objects` to reach them.
     def get_queryset(self) -> models.QuerySet[_SoftDeleteT]:
         return super().get_queryset().filter(deleted_at__isnull=True)
 
@@ -125,9 +124,8 @@ class User(AbstractBaseUser, PermissionsMixin):
         default=False,
         help_text=_("Use Gravatar instead of provider avatar"),
     )
-    # Single-use handle that lets the intended person sign in and take over a
-    # managed (connected) row as their own account. Mirrors the waitlist-offer
-    # claim_token pattern. Empty for active accounts.
+    # Single-use handle for the intended person to claim a managed (connected) row.
+    # Mirrors the waitlist-offer claim_token pattern; empty for active accounts.
     claim_token = models.CharField(max_length=64, blank=True, default="", db_index=True)
     shadowbanned: models.ManyToManyField[User, Shadowban] = models.ManyToManyField(
         "self",
@@ -768,6 +766,8 @@ class SessionManager(AliveManager["Session"]):
             return set()
         start = session.agenda_item.start_time
         end = session.agenda_item.end_time
+        # Superset-safe: never misses a genuine conflict; extra ids the join might
+        # return are harmless since callers only probe membership of their own user_ids.
         return set(
             self.get_queryset()
             .filter(


### PR DESCRIPTION
## Summary

Reviewer follow-up from PR #572: `SessionManager.conflicted_user_ids`
(`src/ludamus/adapters/db/django/models.py`) returns
`set(...values_list("session_participations__user_id", flat=True))` after a
single `.filter()` that constrains user+status on the same participation row.
The reviewer flagged that its correctness relies on subtle multi-valued-join
semantics, and without a comment a future maintainer could "optimize" it into
a broken form. This PR adds a two-line comment stating the exact contract:

```python
        # Superset-safe: never misses a genuine conflict; extra ids the join might
        # return are harmless since callers only probe membership of their own user_ids.
        return set(
```

No logic changes — comment only.

## tingle offset

`models.py` falls in the `legacy-loc` line-count range, so the +2 comment
lines needed an honest offset. I tightened two nearby comments in the same
file (same wording, fewer lines, no information lost):

- `AliveManager.get_queryset` comment: 3 lines → 2
- `User.claim_token` comment: 3 lines → 2

Net diff on the file: 6 insertions / 6 deletions (line count unchanged), so
`legacy-loc` is flat and `tingle check` exits 0.

## Test plan

- [x] `MISE_ENV=sandbox mise exec -- poetry run tingle check` → exit 0 (baseline refreshed via `git branch -f main origin/main`)
- [x] `mise run check` → exit 0 (ruff, pylint 10.00/10, black unchanged, impeccable layering, djlint, etc. all green)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BsdvWh3G9h76W5egZ73iu9

---
_Generated by [Claude Code](https://claude.ai/code/session_01BsdvWh3G9h76W5egZ73iu9)_