### PR TITLE
chore(tingle): fix mock-ANY mid-line and object-src false positives

### DIFF
--- a/tingle.toml
+++ b/tingle.toml
@@ -95,7 +95,8 @@ ranges = ["python-tests"]
 name = "mock-ANY"
 type = "regex_count"
 group = "testing"
-pattern = '(?!.*(view|form)).*\bANY\b.*'
+pattern = '^(?!.*(view|form|import)).*\bANY\b'
+flags = ["MULTILINE"]
 ranges = ["python-tests"]
 
 
@@ -149,7 +150,7 @@ ranges = ["python-src"]
 name = "type-object"
 type = "regex_count"
 group = "typing"
-pattern = '(?<![\.\w])object\b'
+pattern = '(?<![\.\w])object\b(?!-)'
 ranges = ["python-src"]
 
 [[metrics]]

--- a/tingle.toml
+++ b/tingle.toml
@@ -95,7 +95,7 @@ ranges = ["python-tests"]
 name = "mock-ANY"
 type = "regex_count"
 group = "testing"
-pattern = '^(?!.*(view|form|import)).*\bANY\b'
+pattern = '^(?!.*(?:\b|_)(view|form|import)\b).*\bANY\b'
 flags = ["MULTILINE"]
 ranges = ["python-tests"]
 


### PR DESCRIPTION
## Summary

Two false-positive patterns in `tingle.toml`.

### `mock-ANY` (line ~95)

**Before:** `'(?!.*(view|form)).*\bANY\b.*'`
**After:** `'^(?!.*(?:\b|_)(view|form|import)\b).*\bANY\b'` with `flags = ["MULTILINE"]`

`re.finditer` tries every start offset in the text, so the negative lookahead could begin matching *after* "view"/"form" already appeared earlier on the line — e.g. `"view": ANY,` no longer had "view" ahead of the match start, so the lookahead saw nothing to reject and the line got counted. It also counted the `from unittest.mock import ANY` line, which isn't a mock use at all.

Anchoring with `^` forces the match to start at the beginning of a line; `MULTILINE` is needed because tingle's non-diff `regex_count` matches over the whole file's text (with embedded `\n`), where plain `^` only anchors to offset 0 without that flag. tingle's diff mode (`regex_count_diff`, used by `tingle check`) already splits per line before matching, so it works with or without the flag there — but stat/report without `--diff` need it.

The exemption tokens are bounded with `(?:\b|_)(view|form|import)\b` rather than a plain `\b...\b` pair: a bare alternation would exempt any line containing the substrings (`preview`, `important`, `uniform`), while `\bform\b` alone would wrongly *count* the 11 sanctioned `"*_form": ANY` context keys — the underscore in `design_form` is a word character, so it kills the leading boundary. The `_` alternative keeps `_view`/`_form` suffixes exempt while `preview`/`important` now count.

I decided to exempt `import` lines along with `view`/`form`, since an import statement isn't a mock use — happy to revert that if the maintainer prefers imports stay counted.

### `type-object` (line ~150)

**Before:** `'(?<[\.\w])object\b'`
**After:** `'(?<[\.\w])object\b(?!-)'`

Matched inside the CSP directive string `"object-src"` in `src/ludamus/edges/settings.py:319`. A full string-literal exclusion isn't practical in regex, so this adds a lookahead refusing a following hyphen — cheap and sufficient for this one false positive.

## Verification

Confirmed tingle uses Python's stdlib `re` (via `tingle/mills/metrics/regex_count.py`), which supports both lookahead and lookbehind, so both patterns are valid.

`tingle stat` before/after (full-repo, non-diff counts):

| metric | before | after |
|---|---|---|
| mock-ANY | 335 | 42 |
| type-object | 112 | 111 |

The word-boundary tightening in the second commit left the mock-ANY count at 42 — nothing newly counted, nothing newly exempted on the current tree (verified by diffing per-line matches of both patterns across `tests/`).

Confirmed `src/ludamus/edges/settings.py:319` (`"object-src"`) no longer appears in `tingle report --metric type-object`; line 394 (`dict[str, object]`) still does.

Scratch tests (added, measured, then reverted — `git status` showed only `tingle.toml` at commit time):
- Appended `x_scratch_any_test = ANY` to a test file → mock-ANY count went 42 → 43, then reverted.
- After the boundary tightening: appended `x = ANY` and `{"preview": ANY}` → 42 → 44 (both the naked use and the previously substring-exempted `preview` line now count), then reverted.
- Appended `x_scratch_object_test: object = None` to `settings.py` → type-object count went 111 → 112, then reverted.

Branch-vs-main check (config changes move both sides of the diff equally):
```
$ git branch -f main origin/main
$ MISE_ENV=sandbox mise exec -- poetry run tingle check
# exit 0, no output
```

Also ran `mise exec -- taplo format --config=.taplo.toml` (no diff produced) and `MISE_ENV=sandbox mise run check` (exit 0).

## Test plan

- [x] `tingle stat --metric mock-ANY` / `--metric type-object` before/after comparison
- [x] Scratch add-then-revert tests proving both patterns still catch the naked case
- [x] Substring scratch test proving `"preview": ANY` is counted, not exempted
- [x] `MISE_ENV=sandbox mise exec -- poetry run tingle check` → exit 0
- [x] `mise exec -- taplo format --config=.taplo.toml` → no changes
- [x] `MISE_ENV=sandbox mise run check` → exit 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BsdvWh3G9h76W5egZ73iu9