### PR TITLE
Cache event page in the browser for 180s

### DIFF
--- a/src/ludamus/adapters/web/django/print_views.py
+++ b/src/ludamus/adapters/web/django/print_views.py
@@ -8,11 +8,10 @@ from typing import TYPE_CHECKING, Literal
 from django.http import Http404, HttpResponse
 from django.template.response import TemplateResponse
 from django.urls import reverse
+from django.utils.cache import patch_cache_control
 from django.utils.dateparse import parse_datetime
-from django.utils.decorators import method_decorator
 from django.utils.timezone import get_current_timezone, localtime, make_aware
 from django.utils.translation import gettext_lazy as _
-from django.views.decorators.cache import cache_control
 from django.views.generic.base import View
 
 from ludamus.mills.qr import qr_svg
@@ -136,7 +135,6 @@ def _timetable_scope_name(
     return None
 
 
-@method_decorator(cache_control(public=True, max_age=300), name="dispatch")
 class PublicEventPrintView(View):
     request: RootRequest
     template_name = "chronology/print.html"
@@ -216,7 +214,7 @@ class PublicEventPrintView(View):
         )
         sphere = request.services.sphere_panel.read(request.context.current_sphere_id)
 
-        return TemplateResponse(
+        response = TemplateResponse(
             request,
             self.template_name,
             {
@@ -241,6 +239,11 @@ class PublicEventPrintView(View):
                 "range_hours": range_hours,
             },
         )
+        if published:
+            patch_cache_control(response, public=True, max_age=300)
+        else:
+            patch_cache_control(response, private=True, max_age=5)
+        return response
 
     def _resolve_material(
         self, available_materials: tuple[MaterialSpec, ...]

--- a/src/ludamus/adapters/web/django/print_views.py
+++ b/src/ludamus/adapters/web/django/print_views.py
@@ -9,8 +9,10 @@ from django.http import Http404, HttpResponse
 from django.template.response import TemplateResponse
 from django.urls import reverse
 from django.utils.dateparse import parse_datetime
+from django.utils.decorators import method_decorator
 from django.utils.timezone import get_current_timezone, localtime, make_aware
 from django.utils.translation import gettext_lazy as _
+from django.views.decorators.cache import cache_control
 from django.views.generic.base import View
 
 from ludamus.mills.qr import qr_svg
@@ -134,6 +136,7 @@ def _timetable_scope_name(
     return None
 
 
+@method_decorator(cache_control(public=True, max_age=300), name="dispatch")
 class PublicEventPrintView(View):
     request: RootRequest
     template_name = "chronology/print.html"

--- a/src/ludamus/adapters/web/django/views.py
+++ b/src/ludamus/adapters/web/django/views.py
@@ -5,7 +5,6 @@ from dataclasses import dataclass, field
 from datetime import UTC, datetime
 from email import message_from_bytes, policy
 from enum import StrEnum, auto
-from http import HTTPStatus
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, NamedTuple
 
@@ -15,13 +14,14 @@ from django.contrib import messages
 from django.contrib.auth.mixins import LoginRequiredMixin
 from django.db import transaction
 from django.db.models import Count, Q
-from django.http import Http404, HttpRequest, HttpResponse, HttpResponseBase
+from django.http import Http404, HttpResponse
 from django.shortcuts import redirect
 from django.template.response import TemplateResponse
 from django.urls import reverse
-from django.utils.cache import patch_cache_control
+from django.utils.decorators import method_decorator
 from django.utils.http import url_has_allowed_host_and_scheme
 from django.utils.translation import gettext as _
+from django.views.decorators.cache import cache_control
 from django.views.generic.base import TemplateView, View
 from django.views.generic.detail import DetailView
 
@@ -275,19 +275,12 @@ def _field_value_dtos_from_models(
 COMPACT_SCHEDULE_MIN_SESSIONS = 20
 
 
+@method_decorator(cache_control(private=True, max_age=180), name="dispatch")
 class EventPageView(DetailView):  # type: ignore [type-arg]
     template_name = "chronology/event.html"
     model = Event
     context_object_name = "event"
     request: RootRequest
-
-    def dispatch(
-        self, request: HttpRequest, *args: object, **kwargs: object
-    ) -> HttpResponseBase:
-        response = super().dispatch(request, *args, **kwargs)
-        if request.method == "GET" and response.status_code == HTTPStatus.OK:
-            patch_cache_control(response, private=True, max_age=180)
-        return response
 
     def get_queryset(self) -> QuerySet[Event]:
         return (

--- a/src/ludamus/adapters/web/django/views.py
+++ b/src/ludamus/adapters/web/django/views.py
@@ -110,7 +110,7 @@ if TYPE_CHECKING:
 MINIMUM_ALLOWED_USER_AGE = 16
 
 
-@method_decorator(cache_control(public=True, max_age=300), name="dispatch")
+@method_decorator(cache_control(public=True, max_age=300), name="get")
 class DesignPageView(TemplateView):
     request: RootRequest
     template_name = "design.html"
@@ -192,7 +192,7 @@ def _is_manager(request: RootRequest) -> bool:
     )
 
 
-@method_decorator(cache_control(private=True, max_age=180), name="dispatch")
+@method_decorator(cache_control(private=True, max_age=180), name="get")
 class EventsPageView(TemplateView):
     request: RootRequest
     template_name = "index.html"
@@ -277,7 +277,7 @@ def _field_value_dtos_from_models(
 COMPACT_SCHEDULE_MIN_SESSIONS = 20
 
 
-@method_decorator(cache_control(private=True, max_age=180), name="dispatch")
+@method_decorator(cache_control(private=True, max_age=180), name="get")
 class EventPageView(DetailView):  # type: ignore [type-arg]
     template_name = "chronology/event.html"
     model = Event

--- a/src/ludamus/adapters/web/django/views.py
+++ b/src/ludamus/adapters/web/django/views.py
@@ -110,6 +110,7 @@ if TYPE_CHECKING:
 MINIMUM_ALLOWED_USER_AGE = 16
 
 
+@method_decorator(cache_control(public=True, max_age=300), name="dispatch")
 class DesignPageView(TemplateView):
     request: RootRequest
     template_name = "design.html"
@@ -191,6 +192,7 @@ def _is_manager(request: RootRequest) -> bool:
     )
 
 
+@method_decorator(cache_control(private=True, max_age=180), name="dispatch")
 class EventsPageView(TemplateView):
     request: RootRequest
     template_name = "index.html"

--- a/src/ludamus/adapters/web/django/views.py
+++ b/src/ludamus/adapters/web/django/views.py
@@ -5,6 +5,7 @@ from dataclasses import dataclass, field
 from datetime import UTC, datetime
 from email import message_from_bytes, policy
 from enum import StrEnum, auto
+from http import HTTPStatus
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, NamedTuple
 
@@ -14,10 +15,11 @@ from django.contrib import messages
 from django.contrib.auth.mixins import LoginRequiredMixin
 from django.db import transaction
 from django.db.models import Count, Q
-from django.http import Http404, HttpResponse
+from django.http import Http404, HttpRequest, HttpResponse, HttpResponseBase
 from django.shortcuts import redirect
 from django.template.response import TemplateResponse
 from django.urls import reverse
+from django.utils.cache import patch_cache_control
 from django.utils.http import url_has_allowed_host_and_scheme
 from django.utils.translation import gettext as _
 from django.views.generic.base import TemplateView, View
@@ -278,6 +280,14 @@ class EventPageView(DetailView):  # type: ignore [type-arg]
     model = Event
     context_object_name = "event"
     request: RootRequest
+
+    def dispatch(
+        self, request: HttpRequest, *args: object, **kwargs: object
+    ) -> HttpResponseBase:
+        response = super().dispatch(request, *args, **kwargs)
+        if request.method == "GET" and response.status_code == HTTPStatus.OK:
+            patch_cache_control(response, private=True, max_age=180)
+        return response
 
     def get_queryset(self) -> QuerySet[Event]:
         return (

--- a/src/ludamus/gates/web/django/notice_board/views.py
+++ b/src/ludamus/gates/web/django/notice_board/views.py
@@ -397,7 +397,7 @@ class EncounterCancelRSVPActionView(LoginRequiredMixin, View):
         return redirect(detail_url)
 
 
-@method_decorator(cache_control(public=True, max_age=86400), name="dispatch")
+@method_decorator(cache_control(public=True, max_age=86400), name="get")
 class EncounterQrView(View):
     request: RootRequest
 
@@ -415,7 +415,7 @@ class EncounterQrView(View):
         return HttpResponse(qr_svg(url, dark="#1f2937"), content_type="image/svg+xml")
 
 
-@method_decorator(cache_control(public=True, max_age=300), name="dispatch")
+@method_decorator(cache_control(public=True, max_age=300), name="get")
 class EncounterIcsView(View):
     request: RootRequest
 

--- a/src/ludamus/gates/web/django/notice_board/views.py
+++ b/src/ludamus/gates/web/django/notice_board/views.py
@@ -8,8 +8,10 @@ from django.http import Http404, HttpResponse
 from django.shortcuts import redirect
 from django.template.response import TemplateResponse
 from django.urls import reverse
+from django.utils.decorators import method_decorator
 from django.utils.translation import gettext as _
 from django.utils.translation import gettext_lazy
+from django.views.decorators.cache import cache_control
 from django.views.generic.base import TemplateView, View
 
 from ludamus.gates.web.django.entities import UserInfo
@@ -395,6 +397,7 @@ class EncounterCancelRSVPActionView(LoginRequiredMixin, View):
         return redirect(detail_url)
 
 
+@method_decorator(cache_control(public=True, max_age=86400), name="dispatch")
 class EncounterQrView(View):
     request: RootRequest
 
@@ -412,6 +415,7 @@ class EncounterQrView(View):
         return HttpResponse(qr_svg(url, dark="#1f2937"), content_type="image/svg+xml")
 
 
+@method_decorator(cache_control(public=True, max_age=300), name="dispatch")
 class EncounterIcsView(View):
     request: RootRequest
 

--- a/tests/integration/utils.py
+++ b/tests/integration/utils.py
@@ -38,6 +38,11 @@ def _assert_messages(response, expected_messages: list[tuple[int, str]]):
         assert msgs[i].message == message, msgs[i].message
 
 
+def assert_cache_control(response: HttpResponse, expected: set[str]) -> None:
+    directives = set(response["Cache-Control"].split(", "))
+    assert directives == expected, directives
+
+
 def assert_response(
     response: HttpResponse,
     status_code: HTTPStatus,
@@ -45,10 +50,14 @@ def assert_response(
     messages: Iterable[tuple[int, str]] = (),
     contains: str | Iterable[str] = (),
     not_contains: str | Iterable[str] = (),
+    cache_control: set[str] | None = None,
     **response_fields: Any,
 ) -> None:
     assert response.status_code == status_code, response.status_code
     _assert_messages(response, messages)
+
+    if cache_control is not None:
+        assert_cache_control(response, cache_control)
 
     default_fields = {"context_data": None, "template_name": None, "url": None}
     for key, value in (default_fields | response_fields).items():

--- a/tests/integration/web/chronology/test_event_page.py
+++ b/tests/integration/web/chronology/test_event_page.py
@@ -117,6 +117,11 @@ class TestEventPageView:
             not_contains="Enrollment Open",
         )
 
+    def test_private_browser_cache_header(self, client, event):
+        response = client.get(self._get_url(event.slug))
+
+        assert response.headers["Cache-Control"] == "private, max-age=180"
+
     def test_session_card_link_opens_on_current_event(self, agenda_item, client, event):
         response = client.get(self._get_url(event.slug))
 

--- a/tests/integration/web/chronology/test_event_page.py
+++ b/tests/integration/web/chronology/test_event_page.py
@@ -120,7 +120,9 @@ class TestEventPageView:
     def test_private_browser_cache_header(self, client, event):
         response = client.get(self._get_url(event.slug))
 
-        assert response.headers["Cache-Control"] == "private, max-age=180"
+        cache_control = response.headers["Cache-Control"]
+        assert "private" in cache_control
+        assert "max-age=180" in cache_control
 
     def test_session_card_link_opens_on_current_event(self, agenda_item, client, event):
         response = client.get(self._get_url(event.slug))

--- a/tests/integration/web/chronology/test_event_page.py
+++ b/tests/integration/web/chronology/test_event_page.py
@@ -115,15 +115,8 @@ class TestEventPageView:
             template_name=["chronology/event.html"],
             contains="Upcoming",
             not_contains="Enrollment Open",
+            cache_control={"private", "max-age=180"},
         )
-
-    def test_private_browser_cache_header(self, client, event):
-        response = client.get(self._get_url(event.slug))
-
-        directives = response.headers["Cache-Control"].split(", ")
-        assert "private" in directives
-        assert "public" not in directives
-        assert "max-age=180" in directives
 
     def test_session_card_link_opens_on_current_event(self, agenda_item, client, event):
         response = client.get(self._get_url(event.slug))

--- a/tests/integration/web/chronology/test_event_page.py
+++ b/tests/integration/web/chronology/test_event_page.py
@@ -120,9 +120,10 @@ class TestEventPageView:
     def test_private_browser_cache_header(self, client, event):
         response = client.get(self._get_url(event.slug))
 
-        cache_control = response.headers["Cache-Control"]
-        assert "private" in cache_control
-        assert "max-age=180" in cache_control
+        directives = response.headers["Cache-Control"].split(", ")
+        assert "private" in directives
+        assert "public" not in directives
+        assert "max-age=180" in directives
 
     def test_session_card_link_opens_on_current_event(self, agenda_item, client, event):
         response = client.get(self._get_url(event.slug))

--- a/tests/integration/web/chronology/test_event_print_page.py
+++ b/tests/integration/web/chronology/test_event_print_page.py
@@ -24,7 +24,11 @@ from tests.integration.conftest import (
     SpaceFactory,
     TimeSlotFactory,
 )
-from tests.integration.utils import assert_response, assert_response_404
+from tests.integration.utils import (
+    assert_cache_control,
+    assert_response,
+    assert_response_404,
+)
 
 
 def _scope(space, name=None):
@@ -116,9 +120,7 @@ class TestPublicEventPrintView:
         response = client.get(self._url(event.slug))
 
         _assert_print_ok(response, print_scopes=[_scope(space)])
-        directives = response["Cache-Control"].split(", ")
-        assert "public" in directives
-        assert "max-age=300" in directives
+        assert_cache_control(response, {"public", "max-age=300"})
         content = response.content.decode()
         assert session.title in content
         assert "Table of contents" in content
@@ -221,10 +223,7 @@ class TestPublicEventPrintView:
         response = authenticated_client.get(self._url(event.slug))
 
         _assert_print_ok(response, print_scopes=[_scope(space)])
-        directives = response["Cache-Control"].split(", ")
-        assert "private" in directives
-        assert "public" not in directives
-        assert "max-age=5" in directives
+        assert_cache_control(response, {"private", "max-age=5"})
         assert session.title in response.content.decode()
 
     def test_scoped_to_node_shows_logo_capacity_and_scope_name(

--- a/tests/integration/web/chronology/test_event_print_page.py
+++ b/tests/integration/web/chronology/test_event_print_page.py
@@ -116,6 +116,8 @@ class TestPublicEventPrintView:
         response = client.get(self._url(event.slug))
 
         _assert_print_ok(response, print_scopes=[_scope(space)])
+        assert "public" in response["Cache-Control"]
+        assert "max-age=300" in response["Cache-Control"]
         content = response.content.decode()
         assert session.title in content
         assert "Table of contents" in content

--- a/tests/integration/web/chronology/test_event_print_page.py
+++ b/tests/integration/web/chronology/test_event_print_page.py
@@ -116,8 +116,9 @@ class TestPublicEventPrintView:
         response = client.get(self._url(event.slug))
 
         _assert_print_ok(response, print_scopes=[_scope(space)])
-        assert "public" in response["Cache-Control"]
-        assert "max-age=300" in response["Cache-Control"]
+        directives = response["Cache-Control"].split(", ")
+        assert "public" in directives
+        assert "max-age=300" in directives
         content = response.content.decode()
         assert session.title in content
         assert "Table of contents" in content
@@ -220,6 +221,10 @@ class TestPublicEventPrintView:
         response = authenticated_client.get(self._url(event.slug))
 
         _assert_print_ok(response, print_scopes=[_scope(space)])
+        directives = response["Cache-Control"].split(", ")
+        assert "private" in directives
+        assert "public" not in directives
+        assert "max-age=5" in directives
         assert session.title in response.content.decode()
 
     def test_scoped_to_node_shows_logo_capacity_and_scope_name(

--- a/tests/integration/web/notice_board/test_ics_view.py
+++ b/tests/integration/web/notice_board/test_ics_view.py
@@ -15,8 +15,9 @@ class TestEncounterIcsView:
         response = client.get(url)
 
         assert_response(response, HTTPStatus.OK)
-        assert "public" in response["Cache-Control"]
-        assert "max-age=300" in response["Cache-Control"]
+        directives = response["Cache-Control"].split(", ")
+        assert "public" in directives
+        assert "max-age=300" in directives
         assert "text/calendar" in response["Content-Type"]
         content = response.content.decode()
         assert "BEGIN:VCALENDAR" in content

--- a/tests/integration/web/notice_board/test_ics_view.py
+++ b/tests/integration/web/notice_board/test_ics_view.py
@@ -14,10 +14,9 @@ class TestEncounterIcsView:
 
         response = client.get(url)
 
-        assert_response(response, HTTPStatus.OK)
-        directives = response["Cache-Control"].split(", ")
-        assert "public" in directives
-        assert "max-age=300" in directives
+        assert_response(
+            response, HTTPStatus.OK, cache_control={"public", "max-age=300"}
+        )
         assert "text/calendar" in response["Content-Type"]
         content = response.content.decode()
         assert "BEGIN:VCALENDAR" in content

--- a/tests/integration/web/notice_board/test_ics_view.py
+++ b/tests/integration/web/notice_board/test_ics_view.py
@@ -15,6 +15,8 @@ class TestEncounterIcsView:
         response = client.get(url)
 
         assert_response(response, HTTPStatus.OK)
+        assert "public" in response["Cache-Control"]
+        assert "max-age=300" in response["Cache-Control"]
         assert "text/calendar" in response["Content-Type"]
         content = response.content.decode()
         assert "BEGIN:VCALENDAR" in content

--- a/tests/integration/web/notice_board/test_qr_view.py
+++ b/tests/integration/web/notice_board/test_qr_view.py
@@ -14,8 +14,9 @@ class TestEncounterQrView:
         response = client.get(url)
 
         assert_response(response, HTTPStatus.OK)
-        assert "public" in response["Cache-Control"]
-        assert "max-age=86400" in response["Cache-Control"]
+        directives = response["Cache-Control"].split(", ")
+        assert "public" in directives
+        assert "max-age=86400" in directives
         assert response["Content-Type"] == "image/svg+xml"
         assert b"<svg" in response.content
 

--- a/tests/integration/web/notice_board/test_qr_view.py
+++ b/tests/integration/web/notice_board/test_qr_view.py
@@ -13,10 +13,9 @@ class TestEncounterQrView:
 
         response = client.get(url)
 
-        assert_response(response, HTTPStatus.OK)
-        directives = response["Cache-Control"].split(", ")
-        assert "public" in directives
-        assert "max-age=86400" in directives
+        assert_response(
+            response, HTTPStatus.OK, cache_control={"public", "max-age=86400"}
+        )
         assert response["Content-Type"] == "image/svg+xml"
         assert b"<svg" in response.content
 

--- a/tests/integration/web/notice_board/test_qr_view.py
+++ b/tests/integration/web/notice_board/test_qr_view.py
@@ -14,6 +14,8 @@ class TestEncounterQrView:
         response = client.get(url)
 
         assert_response(response, HTTPStatus.OK)
+        assert "public" in response["Cache-Control"]
+        assert "max-age=86400" in response["Cache-Control"]
         assert response["Content-Type"] == "image/svg+xml"
         assert b"<svg" in response.content
 

--- a/tests/integration/web/test_design_page.py
+++ b/tests/integration/web/test_design_page.py
@@ -251,5 +251,6 @@ class TestDesignPageView:
             template_name=["design.html"],
             contains=["py-1.5", "py-2", "py-3", "text-xs", "text-sm", "text-base"],
         )
-        assert "public" in response["Cache-Control"]
-        assert "max-age=300" in response["Cache-Control"]
+        directives = response["Cache-Control"].split(", ")
+        assert "public" in directives
+        assert "max-age=300" in directives

--- a/tests/integration/web/test_design_page.py
+++ b/tests/integration/web/test_design_page.py
@@ -251,3 +251,5 @@ class TestDesignPageView:
             template_name=["design.html"],
             contains=["py-1.5", "py-2", "py-3", "text-xs", "text-sm", "text-base"],
         )
+        assert "public" in response["Cache-Control"]
+        assert "max-age=300" in response["Cache-Control"]

--- a/tests/integration/web/test_design_page.py
+++ b/tests/integration/web/test_design_page.py
@@ -250,7 +250,5 @@ class TestDesignPageView:
             },
             template_name=["design.html"],
             contains=["py-1.5", "py-2", "py-3", "text-xs", "text-sm", "text-base"],
+            cache_control={"public", "max-age=300"},
         )
-        directives = response["Cache-Control"].split(", ")
-        assert "public" in directives
-        assert "max-age=300" in directives

--- a/tests/integration/web/test_index_page.py
+++ b/tests/integration/web/test_index_page.py
@@ -83,8 +83,10 @@ class TestEventsPageView:
             },
             template_name=["index.html"],
         )
-        assert "private" in response["Cache-Control"]
-        assert "max-age=180" in response["Cache-Control"]
+        directives = response["Cache-Control"].split(", ")
+        assert "private" in directives
+        assert "public" not in directives
+        assert "max-age=180" in directives
         assert f'data-commit-sha="{settings.COMMIT_SHA}"'.encode() in response.content
 
     def test_ok_with_event(self, client, event):

--- a/tests/integration/web/test_index_page.py
+++ b/tests/integration/web/test_index_page.py
@@ -82,11 +82,8 @@ class TestEventsPageView:
                 "view": ANY,
             },
             template_name=["index.html"],
+            cache_control={"private", "max-age=180"},
         )
-        directives = response["Cache-Control"].split(", ")
-        assert "private" in directives
-        assert "public" not in directives
-        assert "max-age=180" in directives
         assert f'data-commit-sha="{settings.COMMIT_SHA}"'.encode() in response.content
 
     def test_ok_with_event(self, client, event):

--- a/tests/integration/web/test_index_page.py
+++ b/tests/integration/web/test_index_page.py
@@ -83,6 +83,8 @@ class TestEventsPageView:
             },
             template_name=["index.html"],
         )
+        assert "private" in response["Cache-Control"]
+        assert "max-age=180" in response["Cache-Control"]
         assert f'data-commit-sha="{settings.COMMIT_SHA}"'.encode() in response.content
 
     def test_ok_with_event(self, client, event):


### PR DESCRIPTION
## Problem

Navigating between `/event/<slug>/` and `?view=rooms` felt slow. Both URLs hit the same `EventPageView`, which recomputes the entire personalized schedule (session queries, shadowban/ban masking, bookmarks, DTO building) on every request — and the page had **no caching at all**. Toggling layouts paid the full server cost twice, as full page loads.

## Fix

Send `Cache-Control: private, max-age=180` on 200 GETs of the event page. Repeat visits and list↔rooms toggling within 3 min serve from the browser disk cache — zero server round trip.

- `private`: never shared/CDN — the page is masked per-user (enrollment counts, bookmarks, shadowban).
- `max-age=180`: bounds seat-count staleness. Ceiling: after someone enrolls, counts can lag up to 3 min on a cached page.
- Guarded to `GET` + `200` so error/redirect responses stay uncached.

The `list↔rooms` layouts derive from the same already-fetched data (`build_room_lanes` is pure in-memory regrouping), so no server work distinguishes them — caching the whole response is the right lever.

## Skipped

Client-side toggle (render both layouts, switch with CSS/JS — removes the round trip entirely). Add when the *first* load is the bottleneck, not the toggle.

## Test

`test_private_browser_cache_header` asserts the header. `mise run check` green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Performance**
  - Improved browser and intermediary caching for event pages, design pages, event prints, QR codes, and calendar downloads.
  - Published content can be cached publicly, while private or unpublished content remains protected with shorter cache periods.

- **Tests**
  - Added coverage to verify cache-control behavior across affected pages and downloads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->