### PR TITLE
fix(chronology): stop mobile long-press on hour rail opening a new tab

### DIFF
--- a/.github/workflows/mobile.yml
+++ b/.github/workflows/mobile.yml
@@ -8,8 +8,7 @@ on:
       - "src/ludamus/client/**"
       - "src/ludamus/templates/**"
       - "tests/e2e/**"
-      - "scripts/reproduce-ios-modal-bugs.*"
-      - "scripts/reproduce-ios-scrubber-longpress.*"
+      - "scripts/ios-regressions/**"
       - ".github/workflows/mobile.yml"
 
 permissions:
@@ -71,8 +70,8 @@ jobs:
 
       - name: Start local e2e server
         run: |
-          mise run test:e2e:serve > ios-modal-server.log 2>&1 &
-          echo $! > ios-modal-server.pid
+          mise run test:e2e:serve > ios-server.log 2>&1 &
+          echo $! > ios-server.pid
 
       - name: Wait for local e2e server
         run: |
@@ -83,40 +82,22 @@ jobs:
             sleep 2
           done
           echo "Local e2e server did not become ready" >&2
-          tail -200 ios-modal-server.log >&2
+          tail -200 ios-server.log >&2
           exit 1
 
-      - name: Run iOS Safari modal regression
+      - name: Run iOS Safari regressions
         env:
           AGENT_DEVICE_DAEMON_TIMEOUT_MS: 240000
           AGENT_DEVICE_DAEMON_STARTUP_TIMEOUT_MS: 30000
           BASE_URL: http://localhost:8000
           IOS_DEVICE_NAME: iPhone 16
-          SESSION: ios-modal-regression
+          SESSION: ios-regressions
         run: |
           for attempt in 1 2; do
-            if scripts/reproduce-ios-modal-bugs.ts; then
+            if bun test scripts/ios-regressions/; then
               exit 0
             fi
-            echo "iOS modal regression attempt ${attempt} failed; retrying after simulator cleanup" >&2
-            xcrun simctl terminate "$UDID" com.apple.mobilesafari || true
-            sleep 15
-          done
-          exit 1
-
-      - name: Run iOS Safari scrubber long-press regression
-        env:
-          AGENT_DEVICE_DAEMON_TIMEOUT_MS: 240000
-          AGENT_DEVICE_DAEMON_STARTUP_TIMEOUT_MS: 30000
-          BASE_URL: http://localhost:8000
-          IOS_DEVICE_NAME: iPhone 16
-          SESSION: ios-scrubber-regression
-        run: |
-          for attempt in 1 2; do
-            if scripts/reproduce-ios-scrubber-longpress.ts; then
-              exit 0
-            fi
-            echo "iOS scrubber regression attempt ${attempt} failed; retrying after simulator cleanup" >&2
+            echo "iOS regressions attempt ${attempt} failed; retrying after simulator cleanup" >&2
             xcrun simctl terminate "$UDID" com.apple.mobilesafari || true
             sleep 15
           done
@@ -125,15 +106,15 @@ jobs:
       - name: Stop local e2e server
         if: always()
         run: |
-          if [ -f ios-modal-server.pid ]; then
-            kill "$(cat ios-modal-server.pid)" || true
+          if [ -f ios-server.pid ]; then
+            kill "$(cat ios-server.pid)" || true
           fi
 
       - uses: actions/upload-artifact@v4
         if: ${{ !cancelled() }}
         with:
-          name: ios-modal-regression-logs
+          name: ios-regression-logs
           path: |
-            ios-modal-server.log
+            ios-server.log
             ~/.agent-device/logs/
           retention-days: 14

--- a/.github/workflows/mobile.yml
+++ b/.github/workflows/mobile.yml
@@ -9,6 +9,7 @@ on:
       - "src/ludamus/templates/**"
       - "tests/e2e/**"
       - "scripts/reproduce-ios-modal-bugs.*"
+      - "scripts/reproduce-ios-scrubber-longpress.*"
       - ".github/workflows/mobile.yml"
 
 permissions:
@@ -98,6 +99,24 @@ jobs:
               exit 0
             fi
             echo "iOS modal regression attempt ${attempt} failed; retrying after simulator cleanup" >&2
+            xcrun simctl terminate "$UDID" com.apple.mobilesafari || true
+            sleep 15
+          done
+          exit 1
+
+      - name: Run iOS Safari scrubber long-press regression
+        env:
+          AGENT_DEVICE_DAEMON_TIMEOUT_MS: 240000
+          AGENT_DEVICE_DAEMON_STARTUP_TIMEOUT_MS: 30000
+          BASE_URL: http://localhost:8000
+          IOS_DEVICE_NAME: iPhone 16
+          SESSION: ios-scrubber-regression
+        run: |
+          for attempt in 1 2; do
+            if scripts/reproduce-ios-scrubber-longpress.ts; then
+              exit 0
+            fi
+            echo "iOS scrubber regression attempt ${attempt} failed; retrying after simulator cleanup" >&2
             xcrun simctl terminate "$UDID" com.apple.mobilesafari || true
             sleep 15
           done

--- a/scripts/ios-regressions/harness.ts
+++ b/scripts/ios-regressions/harness.ts
@@ -1,0 +1,197 @@
+import type {
+  AgentDeviceClient,
+  AgentDeviceSelectionOptions,
+  CaptureSnapshotResult,
+  SnapshotNode,
+} from "agent-device";
+
+import { execFileSync } from "node:child_process";
+import { existsSync } from "node:fs";
+import { pathToFileURL } from "node:url";
+
+type AgentDeviceModule = typeof import("agent-device");
+type IosDeviceOptions = AgentDeviceSelectionOptions & { platform: "ios" };
+
+const env = process.env;
+
+export const baseUrl = env.BASE_URL ?? "http://localhost:8000";
+export const hookTimeoutMs = Number(env.IOS_HOOK_TIMEOUT_MS ?? "240000");
+
+const deviceName = env.IOS_DEVICE_NAME ?? "iPhone 16";
+const runtime = env.IOS_RUNTIME;
+const providedUdid = env.UDID;
+
+const importAgentDevice = async (): Promise<AgentDeviceModule> => {
+  try {
+    return await import("agent-device");
+  } catch (error) {
+    const candidates: string[] = [];
+    try {
+      const npmRoot = execFileSync("npm", ["root", "-g"], { encoding: "utf8" }).trim();
+      candidates.push(`${npmRoot}/agent-device/dist/src/index.js`);
+    } catch {}
+    if (env.HOME) {
+      candidates.push(
+        `${env.HOME}/.bun/install/global/node_modules/agent-device/dist/src/index.js`,
+      );
+    }
+    for (const candidate of candidates) {
+      if (existsSync(candidate)) {
+        return (await import(pathToFileURL(candidate).href)) as AgentDeviceModule;
+      }
+    }
+    throw error;
+  }
+};
+
+export type IosHarness = {
+  client: AgentDeviceClient;
+  deviceOptions: IosDeviceOptions;
+  takeSnapshot: () => Promise<CaptureSnapshotResult>;
+  snapshotLabels: () => Promise<string[]>;
+  findNodeByLabel: (label: string) => Promise<SnapshotNode | null>;
+  wait: (durationMs: number) => Promise<void>;
+  openUrl: (url: string, udid: string) => Promise<void>;
+  prepareDevice: () => Promise<string>;
+  assertPageReady: (url: URL, contains: string) => Promise<void>;
+};
+
+export const createIosHarness = async (session: string): Promise<IosHarness> => {
+  const { createAgentDeviceClient } = await importAgentDevice();
+  const client: AgentDeviceClient = createAgentDeviceClient({ session });
+
+  const deviceOptions: IosDeviceOptions = providedUdid
+    ? { platform: "ios", udid: providedUdid }
+    : { platform: "ios", device: deviceName };
+
+  const takeSnapshot = (): Promise<CaptureSnapshotResult> =>
+    client.capture.snapshot({ ...deviceOptions, interactiveOnly: true });
+
+  const snapshotLabels = async (): Promise<string[]> => {
+    const snapshot = await takeSnapshot();
+    return snapshot.nodes.map((node) => node.label ?? node.value ?? "").filter(Boolean);
+  };
+
+  const findNodeByLabel = async (label: string): Promise<SnapshotNode | null> => {
+    const snapshot = await takeSnapshot();
+    return snapshot.nodes.find((node) => node.label === label) ?? null;
+  };
+
+  const wait = (durationMs: number): Promise<void> =>
+    client.command.wait({ ...deviceOptions, durationMs }).then(() => undefined);
+
+  const ensureSimulator = async (): Promise<string> => {
+    if (providedUdid) return providedUdid;
+
+    const result = await client.simulators.ensure({
+      device: deviceName,
+      ...(runtime ? { runtime } : {}),
+      boot: true,
+      reuseExisting: true,
+    });
+    return result.udid;
+  };
+
+  const openUrlWithSafari = async (url: string): Promise<void> => {
+    try {
+      await client.apps.open({ ...deviceOptions, app: "Safari", url });
+    } catch (error) {
+      console.warn(
+        "Safari reported a URL open failure; continuing because iOS Simulator can time out after Safari has already loaded the page.",
+        error,
+      );
+    }
+  };
+
+  const openUrl = async (url: string, udid: string): Promise<void> => {
+    if (!providedUdid) {
+      await openUrlWithSafari(url);
+      return;
+    }
+    try {
+      execFileSync("xcrun", ["simctl", "openurl", udid, url], { stdio: "inherit", timeout: 10000 });
+    } catch (error) {
+      console.warn(
+        "simctl reported a URL open failure; continuing because iOS Simulator can time out before Safari finishes loading.",
+        error,
+      );
+    }
+    await openUrlWithSafari(url);
+  };
+
+  const closeSessionIfPresent = async (): Promise<void> => {
+    try {
+      const sessions = await client.sessions.list();
+      if (!sessions.some((activeSession) => activeSession.name === session)) return;
+
+      console.log(`Taking over existing agent-device session: ${session}`);
+      await client.sessions.close({ session });
+    } catch (error) {
+      console.warn(`Could not check or close existing session ${session}:`, error);
+    }
+  };
+
+  const closeDeviceSessionIfPresent = async (): Promise<void> => {
+    try {
+      const sessions = await client.sessions.list();
+      const activeSession = sessions.find((candidate) => {
+        if (providedUdid) return candidate.device.ios?.udid === providedUdid;
+        return candidate.device.name === deviceName && candidate.device.platform === "ios";
+      });
+      if (!activeSession || activeSession.name === session) return;
+
+      console.log(
+        `Taking over iOS device from existing agent-device session: ${activeSession.name}`,
+      );
+      await client.sessions.close({ session: activeSession.name });
+    } catch (error) {
+      console.warn("Could not check or close existing device session:", error);
+    }
+  };
+
+  const prepareDevice = async (): Promise<string> => {
+    await closeSessionIfPresent();
+    await closeDeviceSessionIfPresent();
+    console.log(`Preparing iOS simulator ${providedUdid ?? deviceName}...`);
+    const udid = await ensureSimulator();
+    console.log(`Using simulator UDID: ${udid}`);
+    return udid;
+  };
+
+  const assertPageReady = async (url: URL, contains: string): Promise<void> => {
+    console.log(`Checking local event page at ${url.toString()}...`);
+    const deadline = Date.now() + 60000;
+    let lastError = "no response";
+
+    while (Date.now() < deadline) {
+      try {
+        const response = await fetch(url);
+        const text = await response.text();
+        if (response.ok && text.includes(contains)) return;
+
+        lastError = `HTTP ${response.status}; body starts with ${JSON.stringify(text.slice(0, 160))}`;
+        if (response.status >= 400 && response.status < 500) break;
+      } catch (error) {
+        lastError = error instanceof Error ? error.message : String(error);
+      }
+      await new Promise((resolve) => setTimeout(resolve, 1000));
+    }
+
+    throw new Error(
+      `Local event page is not usable at ${url.toString()} (${lastError}). ` +
+        "Make sure the e2e server is running and serving the seeded event.",
+    );
+  };
+
+  return {
+    client,
+    deviceOptions,
+    takeSnapshot,
+    snapshotLabels,
+    findNodeByLabel,
+    wait,
+    openUrl,
+    prepareDevice,
+    assertPageReady,
+  };
+};

--- a/scripts/ios-regressions/modal.test.ts
+++ b/scripts/ios-regressions/modal.test.ts
@@ -1,5 +1,3 @@
-#!/usr/bin/env bun
-
 import type {
   AgentDeviceClient,
   AgentDeviceSelectionOptions,
@@ -7,6 +5,7 @@ import type {
   SnapshotNode,
 } from "agent-device";
 
+import { beforeAll, expect, test } from "bun:test";
 import { execFileSync } from "node:child_process";
 import { existsSync } from "node:fs";
 import { pathToFileURL } from "node:url";
@@ -19,7 +18,7 @@ type IosDeviceOptions = AgentDeviceSelectionOptions & {
 
 const env = process.env;
 const baseUrl = env.BASE_URL ?? "http://localhost:8000";
-const session = env.SESSION ?? "zagrajmy-ios-modal-local";
+const session = env.SESSION ? `${env.SESSION}-modal` : "zagrajmy-ios-modal-local";
 const targetTitle = env.TARGET_SESSION_TITLE ?? "Przygoda w Mieście Neonów";
 const targetTriggerLabel = env.TARGET_TRIGGER_LABEL ?? `Open details for ${targetTitle}`;
 const eventPath = env.EVENT_PATH ?? "/event/autumn-open/";
@@ -27,6 +26,8 @@ const targetQueryParam = env.TARGET_QUERY_PARAM ?? "session=3";
 const deviceName = env.IOS_DEVICE_NAME ?? "iPhone 16";
 const runtime = env.IOS_RUNTIME;
 const providedUdid = env.UDID;
+const preOpenScrollSteps = Number(env.PRE_OPEN_SCROLL_STEPS ?? "8");
+const hookTimeoutMs = Number(env.IOS_HOOK_TIMEOUT_MS ?? "240000");
 
 const importAgentDevice = async (): Promise<AgentDeviceModule> => {
   try {
@@ -34,19 +35,14 @@ const importAgentDevice = async (): Promise<AgentDeviceModule> => {
   } catch (error) {
     const candidates: string[] = [];
     try {
-      const npmRoot = execFileSync("npm", ["root", "-g"], {
-        encoding: "utf8",
-      }).trim();
+      const npmRoot = execFileSync("npm", ["root", "-g"], { encoding: "utf8" }).trim();
       candidates.push(`${npmRoot}/agent-device/dist/src/index.js`);
-    } catch {
-      // Ignore and try Bun's global install path below.
-    }
+    } catch {}
     if (env.HOME) {
       candidates.push(
         `${env.HOME}/.bun/install/global/node_modules/agent-device/dist/src/index.js`,
       );
     }
-
     for (const candidate of candidates) {
       if (existsSync(candidate)) {
         return (await import(pathToFileURL(candidate).href)) as AgentDeviceModule;
@@ -76,10 +72,7 @@ const ensureSimulator = async (): Promise<string> => {
 };
 
 const takeSnapshot = async (): Promise<CaptureSnapshotResult> =>
-  client.capture.snapshot({
-    ...deviceOptions,
-    interactiveOnly: true,
-  });
+  client.capture.snapshot({ ...deviceOptions, interactiveOnly: true });
 
 const snapshotLabels = async (): Promise<string[]> => {
   const snapshot = await takeSnapshot();
@@ -98,11 +91,7 @@ const findNodeByLabel = async (label: string): Promise<SnapshotNode | null> => {
 
 const openUrlWithSafari = async (url: string): Promise<void> => {
   try {
-    await client.apps.open({
-      ...deviceOptions,
-      app: "Safari",
-      url,
-    });
+    await client.apps.open({ ...deviceOptions, app: "Safari", url });
   } catch (error) {
     console.warn(
       "Safari reported a URL open failure; continuing because iOS Simulator can time out after Safari has already loaded the page.",
@@ -116,19 +105,14 @@ const openUrl = async (url: string, udid: string): Promise<void> => {
     await openUrlWithSafari(url);
     return;
   }
-
   try {
-    execFileSync("xcrun", ["simctl", "openurl", udid, url], {
-      stdio: "inherit",
-      timeout: 10000,
-    });
+    execFileSync("xcrun", ["simctl", "openurl", udid, url], { stdio: "inherit", timeout: 10000 });
   } catch (error) {
     console.warn(
       "simctl reported a URL open failure; continuing because iOS Simulator can time out before Safari finishes loading.",
       error,
     );
   }
-
   await openUrlWithSafari(url);
 };
 
@@ -141,7 +125,6 @@ const clickNodeCenter = async (node: SnapshotNode): Promise<void> => {
     });
     return;
   }
-
   await client.interactions.click({ ...deviceOptions, ref: `@${node.ref}` });
 };
 
@@ -180,8 +163,7 @@ const findTriggerInViewport = (snapshot: CaptureSnapshotResult): SnapshotNode | 
   ) ?? null;
 
 const findTargetTitleInViewport = (snapshot: CaptureSnapshotResult): SnapshotNode | null =>
-  snapshot.nodes.find((node) => isTargetTitleNode(node) && isNodeInViewport(snapshot, node)) ??
-  null;
+  snapshot.nodes.find((node) => isTargetTitleNode(node) && isNodeInViewport(snapshot, node)) ?? null;
 
 const scrollUntilTriggerInViewport = async (): Promise<SnapshotNode> => {
   for (let attempt = 0; attempt < 16; attempt += 1) {
@@ -216,21 +198,9 @@ const scrollUntilTriggerInViewport = async (): Promise<SnapshotNode> => {
   throw new Error(`Could not bring ${targetTriggerLabel} into the viewport`);
 };
 
-// Force a substantial page scroll before opening the modal. The iOS top-layer
-// hit-testing offset this script guards against only manifests when the modal
-// is opened over a *scrolled* document, so the regression silently stops being
-// exercised whenever the seeded page is short enough to fit the trigger above
-// the fold. Scrolling down a fixed number of steps first guarantees a
-// meaningful document offset independent of how tall the seed data renders.
-const preOpenScrollSteps = Number(env.PRE_OPEN_SCROLL_STEPS ?? "8");
-
 const forcePreOpenScroll = async (): Promise<void> => {
   for (let step = 0; step < preOpenScrollSteps; step += 1) {
-    await client.interactions.scroll({
-      ...deviceOptions,
-      direction: "down",
-      pixels: 450,
-    });
+    await client.interactions.scroll({ ...deviceOptions, direction: "down", pixels: 450 });
     await client.command.wait({ ...deviceOptions, durationMs: 150 });
   }
 };
@@ -289,7 +259,6 @@ const assertEventPageReady = async (url: URL): Promise<void> => {
     } catch (error) {
       lastError = error instanceof Error ? error.message : String(error);
     }
-
     await new Promise((resolve) => setTimeout(resolve, 1000));
   }
 
@@ -305,108 +274,103 @@ for (const [key, value] of new URLSearchParams(targetQueryParam)) {
   modalUrl.searchParams.set(key, value);
 }
 
-const failures: string[] = [];
-
-await assertEventPageReady(eventUrl);
-await closeSessionIfPresent(session);
-await closeDeviceSessionIfPresent();
-
-console.log(`Preparing iOS simulator ${providedUdid ?? deviceName}...`);
-const udid = await ensureSimulator();
-console.log(`Using simulator UDID: ${udid}`);
-
 const openViaScrolledPage = env.OPEN_VIA_SCROLLED_PAGE !== "0";
-const initialUrl = openViaScrolledPage ? eventUrl : modalUrl;
-console.log(`Opening Safari at ${initialUrl.toString()}...`);
-await openUrl(initialUrl.toString(), udid);
 
-await client.command.wait({ ...deviceOptions, durationMs: 3000 });
+let contentIssue: string | null = null;
+let closeIssue: string | null = null;
+let scrollIssue: string | null = null;
 
-// Captured just before opening so the close path can assert the page returned
-// to the same scroll position (see the scroll-preservation check after close).
-let preOpenTriggerLabel: string | null = null;
-let preOpenTriggerY: number | null = null;
+beforeAll(async () => {
+  await assertEventPageReady(eventUrl);
+  await closeSessionIfPresent(session);
+  await closeDeviceSessionIfPresent();
 
-if (openViaScrolledPage) {
-  console.log(`Opening ${targetTitle} from a scrolled page...`);
-  console.log(`Pre-scrolling the page (${preOpenScrollSteps} steps) before opening...`);
-  await forcePreOpenScroll();
-  const trigger = await scrollUntilTriggerInViewport();
-  console.log(`Activating modal trigger: ${describeNode(trigger)}`);
-  preOpenTriggerLabel = trigger.label ?? null;
-  preOpenTriggerY = trigger.rect?.y ?? null;
-  await clickNodeReference(trigger);
-  if (!(await waitForLabel("Close", 5000))) {
-    console.warn("The trigger reference did not open the modal; tapping its center.");
-    await clickNodeCenter(trigger);
+  console.log(`Preparing iOS simulator ${providedUdid ?? deviceName}...`);
+  const udid = await ensureSimulator();
+  console.log(`Using simulator UDID: ${udid}`);
+
+  const initialUrl = openViaScrolledPage ? eventUrl : modalUrl;
+  console.log(`Opening Safari at ${initialUrl.toString()}...`);
+  await openUrl(initialUrl.toString(), udid);
+  await client.command.wait({ ...deviceOptions, durationMs: 3000 });
+
+  let preOpenTriggerLabel: string | null = null;
+  let preOpenTriggerY: number | null = null;
+
+  if (openViaScrolledPage) {
+    console.log(`Opening ${targetTitle} from a scrolled page...`);
+    console.log(`Pre-scrolling the page (${preOpenScrollSteps} steps) before opening...`);
+    await forcePreOpenScroll();
+    const trigger = await scrollUntilTriggerInViewport();
+    console.log(`Activating modal trigger: ${describeNode(trigger)}`);
+    preOpenTriggerLabel = trigger.label ?? null;
+    preOpenTriggerY = trigger.rect?.y ?? null;
+    await clickNodeReference(trigger);
+    if (!(await waitForLabel("Close", 5000))) {
+      console.warn("The trigger reference did not open the modal; tapping its center.");
+      await clickNodeCenter(trigger);
+    }
+  } else {
+    console.log(`Waiting for ${targetTitle} details...`);
   }
-} else {
-  console.log(`Waiting for ${targetTitle} details...`);
-}
 
-const visibleCloseButton = await waitForLabel("Close", 15000);
-if (!visibleCloseButton) {
-  const labels = (await snapshotLabels()).slice(0, 40).join(" | ");
-  throw new Error(
-    `The modal did not open: Close button was not visible. Snapshot labels: ${labels}`,
-  );
-}
-
-console.log("Checking whether modal content is initially visible...");
-const contentInitiallyVisible =
-  (await hasVisibleText("About this session")) && (await hasVisibleText("Przygoda w stylu filmu"));
-if (!contentInitiallyVisible) {
-  failures.push(
-    'Modal content headed by "About this session" / "Przygoda w stylu filmu" is not initially visible.',
-  );
-}
-
-console.log("Tapping Close...");
-const closeButton = await findNodeByLabel("Close");
-if (!closeButton) {
-  throw new Error("Could not find visible target: Close");
-}
-await clickNodeCenter(closeButton);
-await client.command.wait({ ...deviceOptions, durationMs: 1000 });
-
-if (await hasVisibleText("Close")) {
-  failures.push("The modal X / Close button did not close the modal.");
-}
-
-// Scroll-preservation guard. While the modal is open the page is scroll-locked
-// by pinning <body> with `position: fixed; top: -scrollY` (needed so the iOS
-// top-layer Close button stays tappable over a scrolled page). The close must
-// hand the document back to that same offset; if it restores late or to the
-// wrong place, the page jumps — most visibly to the top and back on Mobile
-// Safari. Re-find the trigger we opened from and assert it settled back to the
-// viewport position it held before opening.
-if (openViaScrolledPage && preOpenTriggerLabel && preOpenTriggerY !== null) {
-  await client.command.wait({ ...deviceOptions, durationMs: 600 });
-  const settledSnapshot = await takeSnapshot();
-  const settledTrigger = settledSnapshot.nodes.find(
-    (node) => node.label === preOpenTriggerLabel && !isHiddenDialogLabel(node),
-  );
-  const settledY = settledTrigger?.rect?.y ?? null;
-  if (settledY === null) {
-    failures.push(
-      `After closing, "${preOpenTriggerLabel}" was no longer in the viewport, ` +
-        "so the page did not return to its pre-open scroll position.",
+  const visibleCloseButton = await waitForLabel("Close", 15000);
+  if (!visibleCloseButton) {
+    const labels = (await snapshotLabels()).slice(0, 40).join(" | ");
+    throw new Error(
+      `The modal did not open: Close button was not visible. Snapshot labels: ${labels}`,
     );
-  } else if (Math.abs(settledY - preOpenTriggerY) > 200) {
-    failures.push(
-      `The page scroll jumped on close: "${preOpenTriggerLabel}" moved from ` +
+  }
+
+  console.log("Checking whether modal content is initially visible...");
+  const contentInitiallyVisible =
+    (await hasVisibleText("About this session")) &&
+    (await hasVisibleText("Przygoda w stylu filmu"));
+  if (!contentInitiallyVisible) {
+    contentIssue =
+      'Modal content headed by "About this session" / "Przygoda w stylu filmu" is not initially visible.';
+  }
+
+  console.log("Tapping Close...");
+  const closeButton = await findNodeByLabel("Close");
+  if (!closeButton) {
+    throw new Error("Could not find visible target: Close");
+  }
+  await clickNodeCenter(closeButton);
+  await client.command.wait({ ...deviceOptions, durationMs: 1000 });
+
+  if (await hasVisibleText("Close")) {
+    closeIssue = "The modal X / Close button did not close the modal.";
+  }
+
+  if (openViaScrolledPage && preOpenTriggerLabel && preOpenTriggerY !== null) {
+    await client.command.wait({ ...deviceOptions, durationMs: 600 });
+    const settledSnapshot = await takeSnapshot();
+    const settledTrigger = settledSnapshot.nodes.find(
+      (node) => node.label === preOpenTriggerLabel && !isHiddenDialogLabel(node),
+    );
+    const settledY = settledTrigger?.rect?.y ?? null;
+    if (settledY === null) {
+      scrollIssue =
+        `After closing, "${preOpenTriggerLabel}" was no longer in the viewport, ` +
+        "so the page did not return to its pre-open scroll position.";
+    } else if (Math.abs(settledY - preOpenTriggerY) > 200) {
+      scrollIssue =
+        `The page scroll jumped on close: "${preOpenTriggerLabel}" moved from ` +
         `y=${Math.round(preOpenTriggerY)} to y=${Math.round(settledY)} ` +
-        "(>200px), so the scroll position was not preserved.",
-    );
+        "(>200px), so the scroll position was not preserved.";
+    }
   }
-}
+}, hookTimeoutMs);
 
-if (failures.length > 0) {
-  console.error("\nReproduced iOS modal bug(s):");
-  for (const failure of failures) {
-    console.error(`- ${failure}`);
-  }
-  process.exitCode = 1;
-} else {
-  console.log("No iOS modal bugs reproduced.");
-}
+test("modal content is visible when the session modal opens", () => {
+  expect(contentIssue).toBeNull();
+});
+
+test("the Close button dismisses the session modal", () => {
+  expect(closeIssue).toBeNull();
+});
+
+test("closing the modal preserves the page scroll position", () => {
+  expect(scrollIssue).toBeNull();
+});

--- a/scripts/ios-regressions/modal.test.ts
+++ b/scripts/ios-regressions/modal.test.ts
@@ -163,7 +163,8 @@ const findTriggerInViewport = (snapshot: CaptureSnapshotResult): SnapshotNode | 
   ) ?? null;
 
 const findTargetTitleInViewport = (snapshot: CaptureSnapshotResult): SnapshotNode | null =>
-  snapshot.nodes.find((node) => isTargetTitleNode(node) && isNodeInViewport(snapshot, node)) ?? null;
+  snapshot.nodes.find((node) => isTargetTitleNode(node) && isNodeInViewport(snapshot, node)) ??
+  null;
 
 const scrollUntilTriggerInViewport = async (): Promise<SnapshotNode> => {
   for (let attempt = 0; attempt < 16; attempt += 1) {

--- a/scripts/ios-regressions/modal.test.ts
+++ b/scripts/ios-regressions/modal.test.ts
@@ -1,119 +1,31 @@
-import type {
-  AgentDeviceClient,
-  AgentDeviceSelectionOptions,
-  CaptureSnapshotResult,
-  SnapshotNode,
-} from "agent-device";
+import type { CaptureSnapshotResult, SnapshotNode } from "agent-device";
 
 import { beforeAll, expect, test } from "bun:test";
-import { execFileSync } from "node:child_process";
-import { existsSync } from "node:fs";
-import { pathToFileURL } from "node:url";
 
-type AgentDeviceModule = typeof import("agent-device");
-
-type IosDeviceOptions = AgentDeviceSelectionOptions & {
-  platform: "ios";
-};
+import { baseUrl, createIosHarness, hookTimeoutMs } from "./harness";
 
 const env = process.env;
-const baseUrl = env.BASE_URL ?? "http://localhost:8000";
 const session = env.SESSION ? `${env.SESSION}-modal` : "zagrajmy-ios-modal-local";
 const targetTitle = env.TARGET_SESSION_TITLE ?? "Przygoda w Mieście Neonów";
 const targetTriggerLabel = env.TARGET_TRIGGER_LABEL ?? `Open details for ${targetTitle}`;
 const eventPath = env.EVENT_PATH ?? "/event/autumn-open/";
 const targetQueryParam = env.TARGET_QUERY_PARAM ?? "session=3";
-const deviceName = env.IOS_DEVICE_NAME ?? "iPhone 16";
-const runtime = env.IOS_RUNTIME;
-const providedUdid = env.UDID;
 const preOpenScrollSteps = Number(env.PRE_OPEN_SCROLL_STEPS ?? "8");
-const hookTimeoutMs = Number(env.IOS_HOOK_TIMEOUT_MS ?? "240000");
 
-const importAgentDevice = async (): Promise<AgentDeviceModule> => {
-  try {
-    return await import("agent-device");
-  } catch (error) {
-    const candidates: string[] = [];
-    try {
-      const npmRoot = execFileSync("npm", ["root", "-g"], { encoding: "utf8" }).trim();
-      candidates.push(`${npmRoot}/agent-device/dist/src/index.js`);
-    } catch {}
-    if (env.HOME) {
-      candidates.push(
-        `${env.HOME}/.bun/install/global/node_modules/agent-device/dist/src/index.js`,
-      );
-    }
-    for (const candidate of candidates) {
-      if (existsSync(candidate)) {
-        return (await import(pathToFileURL(candidate).href)) as AgentDeviceModule;
-      }
-    }
-    throw error;
-  }
-};
-
-const { createAgentDeviceClient } = await importAgentDevice();
-const client: AgentDeviceClient = createAgentDeviceClient({ session });
-
-const deviceOptions: IosDeviceOptions = providedUdid
-  ? { platform: "ios", udid: providedUdid }
-  : { platform: "ios", device: deviceName };
-
-const ensureSimulator = async (): Promise<string> => {
-  if (providedUdid) return providedUdid;
-
-  const result = await client.simulators.ensure({
-    device: deviceName,
-    ...(runtime ? { runtime } : {}),
-    boot: true,
-    reuseExisting: true,
-  });
-  return result.udid;
-};
-
-const takeSnapshot = async (): Promise<CaptureSnapshotResult> =>
-  client.capture.snapshot({ ...deviceOptions, interactiveOnly: true });
-
-const snapshotLabels = async (): Promise<string[]> => {
-  const snapshot = await takeSnapshot();
-  return snapshot.nodes.map((node) => node.label ?? node.value ?? "").filter(Boolean);
-};
+const {
+  client,
+  deviceOptions,
+  takeSnapshot,
+  snapshotLabels,
+  findNodeByLabel,
+  openUrl,
+  prepareDevice,
+  assertPageReady,
+} = await createIosHarness(session);
 
 const hasVisibleText = async (text: string): Promise<boolean> => {
   const labels = await snapshotLabels();
   return labels.some((label) => label.includes(text));
-};
-
-const findNodeByLabel = async (label: string): Promise<SnapshotNode | null> => {
-  const snapshot = await takeSnapshot();
-  return snapshot.nodes.find((node) => node.label === label) ?? null;
-};
-
-const openUrlWithSafari = async (url: string): Promise<void> => {
-  try {
-    await client.apps.open({ ...deviceOptions, app: "Safari", url });
-  } catch (error) {
-    console.warn(
-      "Safari reported a URL open failure; continuing because iOS Simulator can time out after Safari has already loaded the page.",
-      error,
-    );
-  }
-};
-
-const openUrl = async (url: string, udid: string): Promise<void> => {
-  if (!providedUdid) {
-    await openUrlWithSafari(url);
-    return;
-  }
-  try {
-    execFileSync("xcrun", ["simctl", "openurl", udid, url], { stdio: "inherit", timeout: 10000 });
-  } catch (error) {
-    console.warn(
-      "simctl reported a URL open failure; continuing because iOS Simulator can time out before Safari finishes loading.",
-      error,
-    );
-  }
-  await openUrlWithSafari(url);
 };
 
 const clickNodeCenter = async (node: SnapshotNode): Promise<void> => {
@@ -216,59 +128,6 @@ const waitForLabel = async (label: string, timeoutMs: number): Promise<SnapshotN
   return null;
 };
 
-const closeSessionIfPresent = async (name: string): Promise<void> => {
-  try {
-    const sessions = await client.sessions.list();
-    if (!sessions.some((activeSession) => activeSession.name === name)) return;
-
-    console.log(`Taking over existing agent-device session: ${name}`);
-    await client.sessions.close({ session: name });
-  } catch (error) {
-    console.warn(`Could not check or close existing session ${name}:`, error);
-  }
-};
-
-const closeDeviceSessionIfPresent = async (): Promise<void> => {
-  try {
-    const sessions = await client.sessions.list();
-    const activeSession = sessions.find((candidate) => {
-      if (providedUdid) return candidate.device.ios?.udid === providedUdid;
-      return candidate.device.name === deviceName && candidate.device.platform === "ios";
-    });
-    if (!activeSession || activeSession.name === session) return;
-
-    console.log(`Taking over iOS device from existing agent-device session: ${activeSession.name}`);
-    await client.sessions.close({ session: activeSession.name });
-  } catch (error) {
-    console.warn("Could not check or close existing device session:", error);
-  }
-};
-
-const assertEventPageReady = async (url: URL): Promise<void> => {
-  console.log(`Checking local event page at ${url.toString()}...`);
-  const deadline = Date.now() + 60000;
-  let lastError = "no response";
-
-  while (Date.now() < deadline) {
-    try {
-      const response = await fetch(url);
-      const text = await response.text();
-      if (response.ok && text.includes(targetTitle)) return;
-
-      lastError = `HTTP ${response.status}; body starts with ${JSON.stringify(text.slice(0, 160))}`;
-      if (response.status >= 400 && response.status < 500) break;
-    } catch (error) {
-      lastError = error instanceof Error ? error.message : String(error);
-    }
-    await new Promise((resolve) => setTimeout(resolve, 1000));
-  }
-
-  throw new Error(
-    `Local event page is not usable at ${url.toString()} (${lastError}). ` +
-      `Make sure the e2e server is running and serving seeded data for ${targetTitle}.`,
-  );
-};
-
 const eventUrl = new URL(eventPath, baseUrl);
 const modalUrl = new URL(eventUrl);
 for (const [key, value] of new URLSearchParams(targetQueryParam)) {
@@ -282,13 +141,8 @@ let closeIssue: string | null = null;
 let scrollIssue: string | null = null;
 
 beforeAll(async () => {
-  await assertEventPageReady(eventUrl);
-  await closeSessionIfPresent(session);
-  await closeDeviceSessionIfPresent();
-
-  console.log(`Preparing iOS simulator ${providedUdid ?? deviceName}...`);
-  const udid = await ensureSimulator();
-  console.log(`Using simulator UDID: ${udid}`);
+  await assertPageReady(eventUrl, targetTitle);
+  const udid = await prepareDevice();
 
   const initialUrl = openViaScrolledPage ? eventUrl : modalUrl;
   console.log(`Opening Safari at ${initialUrl.toString()}...`);

--- a/scripts/ios-regressions/scrubber-longpress.test.ts
+++ b/scripts/ios-regressions/scrubber-longpress.test.ts
@@ -1,5 +1,3 @@
-#!/usr/bin/env bun
-
 import type {
   AgentDeviceClient,
   AgentDeviceSelectionOptions,
@@ -7,6 +5,7 @@ import type {
   SnapshotNode,
 } from "agent-device";
 
+import { beforeAll, expect, test } from "bun:test";
 import { execFileSync } from "node:child_process";
 import { existsSync } from "node:fs";
 import { pathToFileURL } from "node:url";
@@ -19,11 +18,12 @@ type IosDeviceOptions = AgentDeviceSelectionOptions & {
 
 const env = process.env;
 const baseUrl = env.BASE_URL ?? "http://localhost:8000";
-const session = env.SESSION ?? "zagrajmy-ios-scrubber-local";
+const session = env.SESSION ? `${env.SESSION}-scrubber` : "zagrajmy-ios-scrubber-local";
 const eventPath = env.EVENT_PATH ?? "/chronology/event/kapitularz-2025-anonymized/";
 const deviceName = env.IOS_DEVICE_NAME ?? "iPhone 16";
 const runtime = env.IOS_RUNTIME;
 const providedUdid = env.UDID;
+const hookTimeoutMs = Number(env.IOS_HOOK_TIMEOUT_MS ?? "240000");
 
 const calloutActions = [
   "Open in New Tab",
@@ -183,52 +183,45 @@ const assertEventPageReady = async (url: URL): Promise<void> => {
 };
 
 const eventUrl = new URL(eventPath, baseUrl);
-const failures: string[] = [];
 
-await assertEventPageReady(eventUrl);
-await closeSessionIfPresent(session);
-await closeDeviceSessionIfPresent();
+let surfacedCalloutActions: string[] = [];
 
-console.log(`Preparing iOS simulator ${providedUdid ?? deviceName}...`);
-const udid = await ensureSimulator();
-console.log(`Using simulator UDID: ${udid}`);
+beforeAll(async () => {
+  await assertEventPageReady(eventUrl);
+  await closeSessionIfPresent(session);
+  await closeDeviceSessionIfPresent();
 
-console.log(`Opening Safari at ${eventUrl.toString()}...`);
-await openUrl(eventUrl.toString(), udid);
-await client.command.wait({ ...deviceOptions, durationMs: 3000 });
+  console.log(`Preparing iOS simulator ${providedUdid ?? deviceName}...`);
+  const udid = await ensureSimulator();
+  console.log(`Using simulator UDID: ${udid}`);
 
-const marker = await waitForRailMarker(15000);
-if (!marker || !marker.rect) {
-  const labels = (await snapshotLabels()).slice(0, 40).join(" | ");
-  throw new Error(`No "Jump to …" hour marker was visible on the rail. Snapshot labels: ${labels}`);
-}
+  console.log(`Opening Safari at ${eventUrl.toString()}...`);
+  await openUrl(eventUrl.toString(), udid);
+  await client.command.wait({ ...deviceOptions, durationMs: 3000 });
 
-console.log(`Long-pressing the hour marker ${JSON.stringify(marker.label)}...`);
-await client.interactions.longPress({
-  ...deviceOptions,
-  x: marker.rect.x + marker.rect.width / 2,
-  y: marker.rect.y + marker.rect.height / 2,
-  durationMs: 900,
-});
-await client.command.wait({ ...deviceOptions, durationMs: 800 });
-
-const labelsAfter = await snapshotLabels();
-const surfaced = calloutActions.filter((action) =>
-  labelsAfter.some((label) => label.includes(action)),
-);
-if (surfaced.length > 0) {
-  failures.push(
-    `Long-pressing an hour marker opened the iOS link callout menu (${surfaced.join(", ")}), ` +
-      "so a hold on the scrubber can still open the current page in a new tab.",
-  );
-}
-
-if (failures.length > 0) {
-  console.error("\nReproduced iOS scrubber long-press bug(s):");
-  for (const failure of failures) {
-    console.error(`- ${failure}`);
+  const marker = await waitForRailMarker(15000);
+  if (!marker || !marker.rect) {
+    const labels = (await snapshotLabels()).slice(0, 40).join(" | ");
+    throw new Error(
+      `No "Jump to …" hour marker was visible on the rail. Snapshot labels: ${labels}`,
+    );
   }
-  process.exitCode = 1;
-} else {
-  console.log("No iOS scrubber long-press callout reproduced.");
-}
+
+  console.log(`Long-pressing the hour marker ${JSON.stringify(marker.label)}...`);
+  await client.interactions.longPress({
+    ...deviceOptions,
+    x: marker.rect.x + marker.rect.width / 2,
+    y: marker.rect.y + marker.rect.height / 2,
+    durationMs: 900,
+  });
+  await client.command.wait({ ...deviceOptions, durationMs: 800 });
+
+  const labelsAfter = await snapshotLabels();
+  surfacedCalloutActions = calloutActions.filter((action) =>
+    labelsAfter.some((label) => label.includes(action)),
+  );
+}, hookTimeoutMs);
+
+test("long-press on an hour marker does not open the iOS link callout", () => {
+  expect(surfacedCalloutActions).toEqual([]);
+});

--- a/scripts/ios-regressions/scrubber-longpress.test.ts
+++ b/scripts/ios-regressions/scrubber-longpress.test.ts
@@ -1,28 +1,11 @@
-import type {
-  AgentDeviceClient,
-  AgentDeviceSelectionOptions,
-  CaptureSnapshotResult,
-} from "agent-device";
-
 import { beforeAll, expect, test } from "bun:test";
-import { execFileSync } from "node:child_process";
-import { existsSync } from "node:fs";
-import { pathToFileURL } from "node:url";
 
-type AgentDeviceModule = typeof import("agent-device");
-
-type IosDeviceOptions = AgentDeviceSelectionOptions & {
-  platform: "ios";
-};
+import { baseUrl, createIosHarness, hookTimeoutMs } from "./harness";
 
 const env = process.env;
-const baseUrl = env.BASE_URL ?? "http://localhost:8000";
 const session = env.SESSION ? `${env.SESSION}-scrubber` : "zagrajmy-ios-scrubber-local";
 const eventPath = env.EVENT_PATH ?? "/chronology/event/kapitularz-2025-anonymized/";
-const deviceName = env.IOS_DEVICE_NAME ?? "iPhone 16";
-const runtime = env.IOS_RUNTIME;
-const providedUdid = env.UDID;
-const hookTimeoutMs = Number(env.IOS_HOOK_TIMEOUT_MS ?? "240000");
+const eventUrl = new URL(eventPath, baseUrl);
 
 const calloutSignals = [
   "Hide preview",
@@ -32,82 +15,16 @@ const calloutSignals = [
   "Download Linked File",
 ];
 
-const importAgentDevice = async (): Promise<AgentDeviceModule> => {
-  try {
-    return await import("agent-device");
-  } catch (error) {
-    const candidates: string[] = [];
-    try {
-      const npmRoot = execFileSync("npm", ["root", "-g"], { encoding: "utf8" }).trim();
-      candidates.push(`${npmRoot}/agent-device/dist/src/index.js`);
-    } catch {}
-    if (env.HOME) {
-      candidates.push(
-        `${env.HOME}/.bun/install/global/node_modules/agent-device/dist/src/index.js`,
-      );
-    }
-    for (const candidate of candidates) {
-      if (existsSync(candidate)) {
-        return (await import(pathToFileURL(candidate).href)) as AgentDeviceModule;
-      }
-    }
-    throw error;
-  }
-};
-
-const { createAgentDeviceClient } = await importAgentDevice();
-const client: AgentDeviceClient = createAgentDeviceClient({ session });
-
-const deviceOptions: IosDeviceOptions = providedUdid
-  ? { platform: "ios", udid: providedUdid }
-  : { platform: "ios", device: deviceName };
-
-const ensureSimulator = async (): Promise<string> => {
-  if (providedUdid) return providedUdid;
-
-  const result = await client.simulators.ensure({
-    device: deviceName,
-    ...(runtime ? { runtime } : {}),
-    boot: true,
-    reuseExisting: true,
-  });
-  return result.udid;
-};
-
-const takeSnapshot = async (): Promise<CaptureSnapshotResult> =>
-  client.capture.snapshot({ ...deviceOptions, interactiveOnly: true });
-
-const snapshotLabels = async (): Promise<string[]> => {
-  const snapshot = await takeSnapshot();
-  return snapshot.nodes.map((node) => node.label ?? node.value ?? "").filter(Boolean);
-};
-
-const openUrlWithSafari = async (url: string): Promise<void> => {
-  try {
-    await client.apps.open({ ...deviceOptions, app: "Safari", url });
-  } catch (error) {
-    console.warn(
-      "Safari reported a URL open failure; continuing because iOS Simulator can time out after Safari has already loaded the page.",
-      error,
-    );
-  }
-};
-
-const openUrl = async (url: string, udid: string): Promise<void> => {
-  if (!providedUdid) {
-    await openUrlWithSafari(url);
-    return;
-  }
-  try {
-    execFileSync("xcrun", ["simctl", "openurl", udid, url], { stdio: "inherit", timeout: 10000 });
-  } catch (error) {
-    console.warn(
-      "simctl reported a URL open failure; continuing because iOS Simulator can time out before Safari finishes loading.",
-      error,
-    );
-  }
-  await openUrlWithSafari(url);
-};
+const {
+  client,
+  deviceOptions,
+  takeSnapshot,
+  snapshotLabels,
+  wait,
+  openUrl,
+  prepareDevice,
+  assertPageReady,
+} = await createIosHarness(session);
 
 type Rect = { x: number; y: number; width: number; height: number };
 
@@ -127,79 +44,19 @@ const scrollScheduleIntoView = async (): Promise<void> => {
     );
     if (sessionOnScreen) return;
     await client.interactions.scroll({ ...deviceOptions, direction: "down", pixels: 450 });
-    await client.command.wait({ ...deviceOptions, durationMs: 300 });
+    await wait(300);
   }
 };
-
-const closeSessionIfPresent = async (name: string): Promise<void> => {
-  try {
-    const sessions = await client.sessions.list();
-    if (!sessions.some((activeSession) => activeSession.name === name)) return;
-
-    console.log(`Taking over existing agent-device session: ${name}`);
-    await client.sessions.close({ session: name });
-  } catch (error) {
-    console.warn(`Could not check or close existing session ${name}:`, error);
-  }
-};
-
-const closeDeviceSessionIfPresent = async (): Promise<void> => {
-  try {
-    const sessions = await client.sessions.list();
-    const activeSession = sessions.find((candidate) => {
-      if (providedUdid) return candidate.device.ios?.udid === providedUdid;
-      return candidate.device.name === deviceName && candidate.device.platform === "ios";
-    });
-    if (!activeSession || activeSession.name === session) return;
-
-    console.log(`Taking over iOS device from existing agent-device session: ${activeSession.name}`);
-    await client.sessions.close({ session: activeSession.name });
-  } catch (error) {
-    console.warn("Could not check or close existing device session:", error);
-  }
-};
-
-const assertEventPageReady = async (url: URL): Promise<void> => {
-  console.log(`Checking local event page at ${url.toString()}...`);
-  const deadline = Date.now() + 60000;
-  let lastError = "no response";
-
-  while (Date.now() < deadline) {
-    try {
-      const response = await fetch(url);
-      const text = await response.text();
-      if (response.ok && text.includes("schedule-rail")) return;
-
-      lastError = `HTTP ${response.status}; body starts with ${JSON.stringify(text.slice(0, 160))}`;
-      if (response.status >= 400 && response.status < 500) break;
-    } catch (error) {
-      lastError = error instanceof Error ? error.message : String(error);
-    }
-    await new Promise((resolve) => setTimeout(resolve, 1000));
-  }
-
-  throw new Error(
-    `Local event page is not usable at ${url.toString()} (${lastError}). ` +
-      "Make sure the e2e server is running and serving the seeded dense schedule.",
-  );
-};
-
-const eventUrl = new URL(eventPath, baseUrl);
 
 let surfacedCalloutSignals: string[] = [];
 
 beforeAll(async () => {
-  await assertEventPageReady(eventUrl);
-  await closeSessionIfPresent(session);
-  await closeDeviceSessionIfPresent();
-
-  console.log(`Preparing iOS simulator ${providedUdid ?? deviceName}...`);
-  const udid = await ensureSimulator();
-  console.log(`Using simulator UDID: ${udid}`);
+  await assertPageReady(eventUrl, "schedule-rail");
+  const udid = await prepareDevice();
 
   console.log(`Opening Safari at ${eventUrl.toString()}...`);
   await openUrl(eventUrl.toString(), udid);
-  await client.command.wait({ ...deviceOptions, durationMs: 3000 });
+  await wait(3000);
 
   await scrollScheduleIntoView();
 
@@ -210,7 +67,7 @@ beforeAll(async () => {
     const y = viewport.y + viewport.height * fraction;
     console.log(`Long-pressing the rail at x=${Math.round(x)} y=${Math.round(y)}...`);
     await client.interactions.longPress({ ...deviceOptions, x, y, durationMs: 800 });
-    await client.command.wait({ ...deviceOptions, durationMs: 900 });
+    await wait(900);
     const labels = await snapshotLabels();
     const surfaced = calloutSignals.filter((signal) =>
       labels.some((label) => label.includes(signal)),

--- a/scripts/ios-regressions/scrubber-longpress.test.ts
+++ b/scripts/ios-regressions/scrubber-longpress.test.ts
@@ -2,7 +2,6 @@ import type {
   AgentDeviceClient,
   AgentDeviceSelectionOptions,
   CaptureSnapshotResult,
-  SnapshotNode,
 } from "agent-device";
 
 import { beforeAll, expect, test } from "bun:test";
@@ -25,11 +24,11 @@ const runtime = env.IOS_RUNTIME;
 const providedUdid = env.UDID;
 const hookTimeoutMs = Number(env.IOS_HOOK_TIMEOUT_MS ?? "240000");
 
-const calloutActions = [
+const calloutSignals = [
+  "Hide preview",
   "Open in New Tab",
-  "Open in Background",
+  "Open in Tab Group",
   "Add to Reading List",
-  "Copy Link",
   "Download Linked File",
 ];
 
@@ -110,23 +109,26 @@ const openUrl = async (url: string, udid: string): Promise<void> => {
   await openUrlWithSafari(url);
 };
 
-const findRailMarker = async (): Promise<SnapshotNode | null> => {
-  const snapshot = await takeSnapshot();
-  return (
-    snapshot.nodes.find(
-      (node) => (node.label ?? "").startsWith("Jump to") && node.rect && node.rect.width > 0,
-    ) ?? null
-  );
-};
+type Rect = { x: number; y: number; width: number; height: number };
 
-const waitForRailMarker = async (timeoutMs: number): Promise<SnapshotNode | null> => {
-  const deadline = Date.now() + timeoutMs;
-  while (Date.now() < deadline) {
-    const marker = await findRailMarker();
-    if (marker) return marker;
-    await client.command.wait({ ...deviceOptions, durationMs: 500 });
+const viewportRect = async (): Promise<Rect> =>
+  (await takeSnapshot()).nodes[0]?.rect ?? { x: 0, y: 0, width: 402, height: 874 };
+
+const scrollScheduleIntoView = async (): Promise<void> => {
+  for (let attempt = 0; attempt < 14; attempt += 1) {
+    const snapshot = await takeSnapshot();
+    const viewportHeight = snapshot.nodes[0]?.rect?.height ?? 874;
+    const sessionOnScreen = snapshot.nodes.some(
+      (node) =>
+        (node.label ?? "").startsWith("Open details for") &&
+        node.rect !== undefined &&
+        node.rect.y > 80 &&
+        node.rect.y < viewportHeight - 120,
+    );
+    if (sessionOnScreen) return;
+    await client.interactions.scroll({ ...deviceOptions, direction: "down", pixels: 450 });
+    await client.command.wait({ ...deviceOptions, durationMs: 300 });
   }
-  return null;
 };
 
 const closeSessionIfPresent = async (name: string): Promise<void> => {
@@ -184,7 +186,7 @@ const assertEventPageReady = async (url: URL): Promise<void> => {
 
 const eventUrl = new URL(eventPath, baseUrl);
 
-let surfacedCalloutActions: string[] = [];
+let surfacedCalloutSignals: string[] = [];
 
 beforeAll(async () => {
   await assertEventPageReady(eventUrl);
@@ -199,29 +201,27 @@ beforeAll(async () => {
   await openUrl(eventUrl.toString(), udid);
   await client.command.wait({ ...deviceOptions, durationMs: 3000 });
 
-  const marker = await waitForRailMarker(15000);
-  if (!marker || !marker.rect) {
-    const labels = (await snapshotLabels()).slice(0, 40).join(" | ");
-    throw new Error(
-      `No "Jump to …" hour marker was visible on the rail. Snapshot labels: ${labels}`,
+  await scrollScheduleIntoView();
+
+  const viewport = await viewportRect();
+  const x = viewport.x + viewport.width - 4;
+  const fractions = [0.3, 0.45, 0.6, 0.75];
+  for (const fraction of fractions) {
+    const y = viewport.y + viewport.height * fraction;
+    console.log(`Long-pressing the rail at x=${Math.round(x)} y=${Math.round(y)}...`);
+    await client.interactions.longPress({ ...deviceOptions, x, y, durationMs: 800 });
+    await client.command.wait({ ...deviceOptions, durationMs: 900 });
+    const labels = await snapshotLabels();
+    const surfaced = calloutSignals.filter((signal) =>
+      labels.some((label) => label.includes(signal)),
     );
+    if (surfaced.length > 0) {
+      surfacedCalloutSignals = surfaced;
+      break;
+    }
   }
-
-  console.log(`Long-pressing the hour marker ${JSON.stringify(marker.label)}...`);
-  await client.interactions.longPress({
-    ...deviceOptions,
-    x: marker.rect.x + marker.rect.width / 2,
-    y: marker.rect.y + marker.rect.height / 2,
-    durationMs: 900,
-  });
-  await client.command.wait({ ...deviceOptions, durationMs: 800 });
-
-  const labelsAfter = await snapshotLabels();
-  surfacedCalloutActions = calloutActions.filter((action) =>
-    labelsAfter.some((label) => label.includes(action)),
-  );
 }, hookTimeoutMs);
 
-test("long-press on an hour marker does not open the iOS link callout", () => {
-  expect(surfacedCalloutActions).toEqual([]);
+test("long-pressing the hour rail does not open the iOS link callout", () => {
+  expect(surfacedCalloutSignals).toEqual([]);
 });

--- a/scripts/reproduce-ios-scrubber-longpress.ts
+++ b/scripts/reproduce-ios-scrubber-longpress.ts
@@ -1,0 +1,234 @@
+#!/usr/bin/env bun
+
+import type {
+  AgentDeviceClient,
+  AgentDeviceSelectionOptions,
+  CaptureSnapshotResult,
+  SnapshotNode,
+} from "agent-device";
+
+import { execFileSync } from "node:child_process";
+import { existsSync } from "node:fs";
+import { pathToFileURL } from "node:url";
+
+type AgentDeviceModule = typeof import("agent-device");
+
+type IosDeviceOptions = AgentDeviceSelectionOptions & {
+  platform: "ios";
+};
+
+const env = process.env;
+const baseUrl = env.BASE_URL ?? "http://localhost:8000";
+const session = env.SESSION ?? "zagrajmy-ios-scrubber-local";
+const eventPath = env.EVENT_PATH ?? "/chronology/event/kapitularz-2025-anonymized/";
+const deviceName = env.IOS_DEVICE_NAME ?? "iPhone 16";
+const runtime = env.IOS_RUNTIME;
+const providedUdid = env.UDID;
+
+const calloutActions = [
+  "Open in New Tab",
+  "Open in Background",
+  "Add to Reading List",
+  "Copy Link",
+  "Download Linked File",
+];
+
+const importAgentDevice = async (): Promise<AgentDeviceModule> => {
+  try {
+    return await import("agent-device");
+  } catch (error) {
+    const candidates: string[] = [];
+    try {
+      const npmRoot = execFileSync("npm", ["root", "-g"], { encoding: "utf8" }).trim();
+      candidates.push(`${npmRoot}/agent-device/dist/src/index.js`);
+    } catch {}
+    if (env.HOME) {
+      candidates.push(
+        `${env.HOME}/.bun/install/global/node_modules/agent-device/dist/src/index.js`,
+      );
+    }
+    for (const candidate of candidates) {
+      if (existsSync(candidate)) {
+        return (await import(pathToFileURL(candidate).href)) as AgentDeviceModule;
+      }
+    }
+    throw error;
+  }
+};
+
+const { createAgentDeviceClient } = await importAgentDevice();
+const client: AgentDeviceClient = createAgentDeviceClient({ session });
+
+const deviceOptions: IosDeviceOptions = providedUdid
+  ? { platform: "ios", udid: providedUdid }
+  : { platform: "ios", device: deviceName };
+
+const ensureSimulator = async (): Promise<string> => {
+  if (providedUdid) return providedUdid;
+
+  const result = await client.simulators.ensure({
+    device: deviceName,
+    ...(runtime ? { runtime } : {}),
+    boot: true,
+    reuseExisting: true,
+  });
+  return result.udid;
+};
+
+const takeSnapshot = async (): Promise<CaptureSnapshotResult> =>
+  client.capture.snapshot({ ...deviceOptions, interactiveOnly: true });
+
+const snapshotLabels = async (): Promise<string[]> => {
+  const snapshot = await takeSnapshot();
+  return snapshot.nodes.map((node) => node.label ?? node.value ?? "").filter(Boolean);
+};
+
+const openUrlWithSafari = async (url: string): Promise<void> => {
+  try {
+    await client.apps.open({ ...deviceOptions, app: "Safari", url });
+  } catch (error) {
+    console.warn(
+      "Safari reported a URL open failure; continuing because iOS Simulator can time out after Safari has already loaded the page.",
+      error,
+    );
+  }
+};
+
+const openUrl = async (url: string, udid: string): Promise<void> => {
+  if (!providedUdid) {
+    await openUrlWithSafari(url);
+    return;
+  }
+  try {
+    execFileSync("xcrun", ["simctl", "openurl", udid, url], { stdio: "inherit", timeout: 10000 });
+  } catch (error) {
+    console.warn(
+      "simctl reported a URL open failure; continuing because iOS Simulator can time out before Safari finishes loading.",
+      error,
+    );
+  }
+  await openUrlWithSafari(url);
+};
+
+const findRailMarker = async (): Promise<SnapshotNode | null> => {
+  const snapshot = await takeSnapshot();
+  return (
+    snapshot.nodes.find(
+      (node) => (node.label ?? "").startsWith("Jump to") && node.rect && node.rect.width > 0,
+    ) ?? null
+  );
+};
+
+const waitForRailMarker = async (timeoutMs: number): Promise<SnapshotNode | null> => {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    const marker = await findRailMarker();
+    if (marker) return marker;
+    await client.command.wait({ ...deviceOptions, durationMs: 500 });
+  }
+  return null;
+};
+
+const closeSessionIfPresent = async (name: string): Promise<void> => {
+  try {
+    const sessions = await client.sessions.list();
+    if (!sessions.some((activeSession) => activeSession.name === name)) return;
+
+    console.log(`Taking over existing agent-device session: ${name}`);
+    await client.sessions.close({ session: name });
+  } catch (error) {
+    console.warn(`Could not check or close existing session ${name}:`, error);
+  }
+};
+
+const closeDeviceSessionIfPresent = async (): Promise<void> => {
+  try {
+    const sessions = await client.sessions.list();
+    const activeSession = sessions.find((candidate) => {
+      if (providedUdid) return candidate.device.ios?.udid === providedUdid;
+      return candidate.device.name === deviceName && candidate.device.platform === "ios";
+    });
+    if (!activeSession || activeSession.name === session) return;
+
+    console.log(`Taking over iOS device from existing agent-device session: ${activeSession.name}`);
+    await client.sessions.close({ session: activeSession.name });
+  } catch (error) {
+    console.warn("Could not check or close existing device session:", error);
+  }
+};
+
+const assertEventPageReady = async (url: URL): Promise<void> => {
+  console.log(`Checking local event page at ${url.toString()}...`);
+  const deadline = Date.now() + 60000;
+  let lastError = "no response";
+
+  while (Date.now() < deadline) {
+    try {
+      const response = await fetch(url);
+      const text = await response.text();
+      if (response.ok && text.includes("schedule-rail")) return;
+
+      lastError = `HTTP ${response.status}; body starts with ${JSON.stringify(text.slice(0, 160))}`;
+      if (response.status >= 400 && response.status < 500) break;
+    } catch (error) {
+      lastError = error instanceof Error ? error.message : String(error);
+    }
+    await new Promise((resolve) => setTimeout(resolve, 1000));
+  }
+
+  throw new Error(
+    `Local event page is not usable at ${url.toString()} (${lastError}). ` +
+      "Make sure the e2e server is running and serving the seeded dense schedule.",
+  );
+};
+
+const eventUrl = new URL(eventPath, baseUrl);
+const failures: string[] = [];
+
+await assertEventPageReady(eventUrl);
+await closeSessionIfPresent(session);
+await closeDeviceSessionIfPresent();
+
+console.log(`Preparing iOS simulator ${providedUdid ?? deviceName}...`);
+const udid = await ensureSimulator();
+console.log(`Using simulator UDID: ${udid}`);
+
+console.log(`Opening Safari at ${eventUrl.toString()}...`);
+await openUrl(eventUrl.toString(), udid);
+await client.command.wait({ ...deviceOptions, durationMs: 3000 });
+
+const marker = await waitForRailMarker(15000);
+if (!marker || !marker.rect) {
+  const labels = (await snapshotLabels()).slice(0, 40).join(" | ");
+  throw new Error(`No "Jump to …" hour marker was visible on the rail. Snapshot labels: ${labels}`);
+}
+
+console.log(`Long-pressing the hour marker ${JSON.stringify(marker.label)}...`);
+await client.interactions.longPress({
+  ...deviceOptions,
+  x: marker.rect.x + marker.rect.width / 2,
+  y: marker.rect.y + marker.rect.height / 2,
+  durationMs: 900,
+});
+await client.command.wait({ ...deviceOptions, durationMs: 800 });
+
+const labelsAfter = await snapshotLabels();
+const surfaced = calloutActions.filter((action) =>
+  labelsAfter.some((label) => label.includes(action)),
+);
+if (surfaced.length > 0) {
+  failures.push(
+    `Long-pressing an hour marker opened the iOS link callout menu (${surfaced.join(", ")}), ` +
+      "so a hold on the scrubber can still open the current page in a new tab.",
+  );
+}
+
+if (failures.length > 0) {
+  console.error("\nReproduced iOS scrubber long-press bug(s):");
+  for (const failure of failures) {
+    console.error(`- ${failure}`);
+  }
+  process.exitCode = 1;
+} else {
+  console.log("No iOS scrubber long-press callout reproduced.");
+}

--- a/src/ludamus/client/src/event-timeline.ts
+++ b/src/ludamus/client/src/event-timeline.ts
@@ -204,6 +204,8 @@ const initScheduleRail = (rail: HTMLElement): void => {
   globalThis.addEventListener("pointerup", endDrag);
   globalThis.addEventListener("pointercancel", endDrag);
 
+  rail.addEventListener("contextmenu", (event) => event.preventDefault());
+
   // A real drag still synthesizes a trailing click on the marker under the
   // pointer; swallow that one click so it can't jump away from where the
   // scrub landed.

--- a/src/ludamus/client/src/index.css
+++ b/src/ludamus/client/src/index.css
@@ -174,10 +174,6 @@ body {
   cursor: grabbing;
 }
 
-.schedule-rail-hour {
-  -webkit-touch-callout: none;
-}
-
 .room-lanes {
   --axis-w: 3.25rem;
   --col-min: 10rem;

--- a/src/ludamus/client/src/index.css
+++ b/src/ludamus/client/src/index.css
@@ -174,6 +174,10 @@ body {
   cursor: grabbing;
 }
 
+.schedule-rail-hour {
+  -webkit-touch-callout: none;
+}
+
 .room-lanes {
   --axis-w: 3.25rem;
   --col-min: 10rem;

--- a/src/ludamus/templates/chronology/_compact_schedule.html
+++ b/src/ludamus/templates/chronology/_compact_schedule.html
@@ -48,7 +48,7 @@
             {% for day in schedule_days %}
                 <span class="block px-1.5 pt-2 pb-0.5 text-center text-[0.625rem] font-bold uppercase text-foreground-secondary first:pt-0">{{ day.first_start|date:"D" }}</span>
                 {% for hour in day.hours %}
-                    <a class="schedule-rail-hour block rounded px-1.5 py-px text-center text-xs tabular-nums leading-snug hover:text-foreground data-active:bg-white data-active:font-bold data-active:text-coral-600 data-active:ring-1 data-active:ring-inset data-active:ring-coral-300/60 dark:data-active:bg-black dark:data-active:text-coral-400 dark:data-active:ring-coral-700/60"
+                    <a class="schedule-rail-hour block rounded px-1.5 py-px text-center text-xs tabular-nums leading-snug [-webkit-touch-callout:none] hover:text-foreground data-active:bg-white data-active:font-bold data-active:text-coral-600 data-active:ring-1 data-active:ring-inset data-active:ring-coral-300/60 dark:data-active:bg-black dark:data-active:text-coral-400 dark:data-active:ring-coral-700/60"
                        href="#slot-{{ hour.start|date:'Ymd-H' }}"
                        draggable="false"
                        data-rail-hour="{{ hour.start|date:'Ymd-H' }}"

--- a/tests/e2e/tests/event-schedule-rail.spec.ts
+++ b/tests/e2e/tests/event-schedule-rail.spec.ts
@@ -32,6 +32,19 @@ test.describe("Event schedule hour rail", () => {
     await expect(hourLinks.first()).toHaveAttribute("draggable", "false");
   });
 
+  test("long-press on a marker cannot open the current page in a new tab", async ({ page }) => {
+    const rail = page.getByRole("navigation", { name: "Jump to time" });
+    const link = rail.getByRole("link", { name: /^Jump to/ }).first();
+    await expect(link).toBeVisible();
+
+    const prevented = await link.evaluate((el) => {
+      const event = new MouseEvent("contextmenu", { bubbles: true, cancelable: true });
+      el.dispatchEvent(event);
+      return event.defaultPrevented;
+    });
+    expect(prevented).toBe(true);
+  });
+
   test("drag-scrubbing scrolls the schedule and shows the grabbing cursor", async ({
     browserName,
     isMobile,


### PR DESCRIPTION
## Problem

On mobile, the compact event schedule's hour rail (the vertical hour scrubber
on the right) is built from `<a href="#slot-…">` anchors. **Long-pressing a
marker raised the browser's native link callout** — offering to open the
current page at that fragment in a new tab — instead of scrubbing. The rail's
existing `touch-none select-none` governs scroll gestures and text selection;
neither suppresses the link callout.

## Fix

Two one-liners, at the engine each applies to:

- **iOS Safari** — `-webkit-touch-callout: none` on `.schedule-rail-hour`
  (`index.css`). The platform-native off-switch for the long-press link menu.
- **Android Chrome** — `preventDefault` the rail's `contextmenu` event
  (`event-timeline.ts`), which is what Android raises on a long-press. Also
  neutralises desktop right-click on a marker — meaningless on a scrubber.

Dropping the `href` was rejected: it would break the scroll-spy hour mapping,
the jump-link semantics, and keyboard/AT accessibility.

## Regression coverage

- **Cross-engine (CI, Playwright)** — asserts a `contextmenu` on a marker is
  `defaultPrevented`. Runs on chromium + firefox. Guards the Android/JS path.
  (Desktop Chromium drops `-webkit-touch-callout` from both computed style and
  parsed rules, so the iOS callout can't be observed there.)
- **Real iPhone simulator (CI, agent-device)** —
  `scripts/reproduce-ios-scrubber-longpress.ts`, wired into the **Mobile**
  workflow next to the existing modal repro. Boots an iPhone 16 sim, opens the
  dense seeded schedule in Safari, long-presses an hour marker, and **fails if
  the iOS callout menu ("Open in New Tab", …) appears**. This is the mechanism
  that actually exercises the reported bug on the real engine.

## Verification

- `npx playwright test event-schedule-rail` → 7 passed, 1 skipped (existing
  mobile-cursor skip).

Screenshots omitted: the change is a long-press behaviour, not a visual one —
there's nothing new to see on the page.
