### PR TITLE
perf(tests): cut Python test suite from 329s to 57s

### DIFF
--- a/docs/TESTING_STRATEGY.md
+++ b/docs/TESTING_STRATEGY.md
@@ -47,6 +47,46 @@ Rules:
 - assert all mock calls
 - assert all side effects
 
+### Database fixtures
+
+Default is `db` (autouse in `tests/integration/conftest.py`): wraps the test in
+a transaction, rolls back. Nothing commits.
+
+`transactional_db` (identical to `@pytest.mark.django_db(transaction=True)`)
+does the opposite of its name: **no** wrapping transaction, writes really
+commit, teardown truncates every table and re-emits `post_migrate`. Reach for
+it only when the test asserts real transaction behavior:
+
+- `transaction.on_commit()` callbacks — never fire under `db`
+- `select_for_update()` row locking (also needs `@pytest.mark.postgres`)
+- a second connection or thread must see the data (live server)
+- asserting a failed `atomic()` block rolled back
+
+Apply it to the whole test class, not one method — mark the class with
+`@pytest.mark.usefixtures("transactional_db")` so a sibling test added later
+inherits the transaction semantics its neighbours already rely on.
+
+Cost is not only speed. The teardown flush deletes rows seeded by data
+migrations (`0002_default_site`), then `post_migrate` re-creates whatever it
+would create against an empty table. Later tests in the same run see a
+different database than migrations built — `example.com` appears, the
+`ROOT_DOMAIN` site vanishes. Tests that pass only because an earlier
+transactional test flushed the table fail the moment they run first.
+
+For `on_commit` prefer `django_capture_on_commit_callbacks(execute=True)` over
+`transactional_db`: it runs the callbacks without real commits, keeping the
+rollback path.
+
+```python
+with django_capture_on_commit_callbacks(execute=True):
+    call_command("send_printables_reminders")
+
+assert len(mailoutbox) == 1
+```
+
+Wrap **negative** assertions in it too. `assert mailoutbox == []` under `db`
+passes unconditionally — the callback never ran, so the check cannot fail.
+
 ### Views and commands
 
 Verify view→template **context contract**: views produce the right data for

--- a/mise.toml
+++ b/mise.toml
@@ -159,18 +159,18 @@ run = ["pip-audit .", "deptry src tests"]
 
 [tasks."test:unit"]
 description = "Run unit tests"
-run = "pytest tests/unit"
+run = "pytest -n auto tests/unit"
 env = { _.file = '.env.test' }
 
 [tasks."test:unit:cov"]
 description = "Run unit tests"
-run = "pytest tests/unit --cov=tests.unit --cov=ludamus"
+run = "pytest -n auto tests/unit --cov=tests.unit --cov=ludamus"
 env = { _.file = '.env.test' }
 
 [tasks."test:int:cov:diff"]
 description = "Show test coverage of integration tests for lines changed since main"
 run = [
-    "pytest tests/integration --cov=ludamus.gates --cov=ludamus.links --cov=ludamus.adapters.web --cov=src/ludamus/templates/",
+    "pytest -n auto tests/integration --cov=ludamus.gates --cov=ludamus.links --cov=ludamus.adapters.web --cov=src/ludamus/templates/",
     "coverage xml",
     "diff-cover coverage.xml --compare-branch=main",
 ]
@@ -178,18 +178,18 @@ env = { _.file = '.env.test' }
 
 [tasks."test:int"]
 description = "Run integration tests"
-run = "pytest tests/integration"
+run = "pytest -n auto tests/integration"
 env = { _.file = '.env.test' }
 
 [tasks."test:int:cov"]
 description = "Run integration tests"
-run = "pytest tests/integration --cov=tests.integration --cov=ludamus"
+run = "pytest -n auto tests/integration --cov=tests.integration --cov=ludamus"
 env = { _.file = '.env.test' }
 
 [tasks."test:unit:cov:diff"]
 description = "Show test coverage of unit tests for lines changed since main"
 run = [
-    "pytest tests/unit --cov=ludamus.mills",
+    "pytest -n auto tests/unit --cov=ludamus.mills",
     "coverage xml",
     "diff-cover coverage.xml --compare-branch=main",
 ]
@@ -197,12 +197,12 @@ env = { _.file = '.env.test' }
 
 [tasks."test:py"]
 description = "Run all Python tests"
-run = "pytest tests/integration tests/unit"
+run = "pytest -n auto tests/integration tests/unit"
 env = { _.file = '.env.test', COVERAGE_FILE = "{{ config_root }}/.coverage.unit" }
 
 [tasks."test:py:cov"]
 description = "Run all Python tests"
-run = "pytest tests/integration tests/unit --cov"
+run = "pytest -n auto tests/integration tests/unit --cov"
 env = { _.file = '.env.test', COVERAGE_FILE = "{{ config_root }}/.coverage.unit" }
 
 ### End-to-End tests

--- a/poetry.lock
+++ b/poetry.lock
@@ -1137,6 +1137,21 @@ files = [
 dev = ["mypy (>=1.15)"]
 
 [[package]]
+name = "execnet"
+version = "2.1.2"
+description = "execnet: rapid multi-Python deployment"
+optional = false
+python-versions = ">=3.8"
+groups = ["dev"]
+files = [
+    {file = "execnet-2.1.2-py3-none-any.whl", hash = "sha256:67fba928dd5a544b783f6056f449e5e3931a5c378b128bc18501f7ea79e296ec"},
+    {file = "execnet-2.1.2.tar.gz", hash = "sha256:63d83bfdd9a23e35b9c6a3261412324f964c2ec8dcd8d3c6916ee9373e0befcd"},
+]
+
+[package.extras]
+testing = ["hatch", "pre-commit", "pytest", "tox"]
+
+[[package]]
 name = "executing"
 version = "2.2.1"
 description = "Get the currently executing AST node of a frame, and other information"
@@ -3174,14 +3189,14 @@ diagrams = ["jinja2", "railroad-diagrams"]
 
 [[package]]
 name = "pytest"
-version = "9.1.1"
+version = "9.0.2"
 description = "pytest: simple powerful testing with Python"
 optional = false
 python-versions = ">=3.10"
 groups = ["dev"]
 files = [
-    {file = "pytest-9.1.1-py3-none-any.whl", hash = "sha256:37a86b45efb9a47a61a36449063e8e18d0cab3161329fc099eb21783169c4f0c"},
-    {file = "pytest-9.1.1.tar.gz", hash = "sha256:1088fbde8f2b49d95a549a195707afa7a76a3ce9bcadc26b6d71f0ffda5fe313"},
+    {file = "pytest-9.0.2-py3-none-any.whl", hash = "sha256:711ffd45bf766d5264d487b917733b453d917afd2b0ad65223959f59089f875b"},
+    {file = "pytest-9.0.2.tar.gz", hash = "sha256:75186651a92bd89611d1d9fc20f0b4345fd827c41ccd5c299a868a05d70edf11"},
 ]
 
 [package.dependencies]
@@ -3282,6 +3297,27 @@ pytest = ">=7.0.0"
 
 [package.extras]
 docs = ["mkdocs (>=1.5.0)", "mkdocs-material[imaging] (>=9.0.0)", "mkdocs-minify-plugin (>=0.7.0)", "mkdocstrings[python] (>=0.24.0)"]
+
+[[package]]
+name = "pytest-xdist"
+version = "3.8.0"
+description = "pytest xdist plugin for distributed testing, most importantly across multiple CPUs"
+optional = false
+python-versions = ">=3.9"
+groups = ["dev"]
+files = [
+    {file = "pytest_xdist-3.8.0-py3-none-any.whl", hash = "sha256:202ca578cfeb7370784a8c33d6d05bc6e13b4f25b5053c30a152269fd10f0b88"},
+    {file = "pytest_xdist-3.8.0.tar.gz", hash = "sha256:7e578125ec9bc6050861aa93f2d59f1d8d085595d6551c2c90b6f4fad8d3a9f1"},
+]
+
+[package.dependencies]
+execnet = ">=2.1"
+pytest = ">=7.0.0"
+
+[package.extras]
+psutil = ["psutil (>=3.0)"]
+setproctitle = ["setproctitle"]
+testing = ["filelock"]
 
 [[package]]
 name = "python-dateutil"
@@ -4352,4 +4388,4 @@ dev = ["doc8", "flake8", "flake8-import-order", "rstcheck[sphinx]", "ruff", "sph
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.14.0,<3.15"
-content-hash = "e3462c709a9743c5c409ed7d52dc2120201cb079e67255512e0217f9c07e5b55"
+content-hash = "c42b23d8dd9fd6194d72f5f45931d52c671a21a85041e421a5050b8e1eb62c5d"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -81,6 +81,7 @@ django-coverage-plugin = "^3.2.2"
 yamllint = "1.38.0"
 taplo = "^0.9.3"
 tingle = "^0.1.0"
+pytest-xdist = "^3.8.0"
 
 [tool.black]
 line-length = 88

--- a/tests/integration/cli/test_send_printables_reminders.py
+++ b/tests/integration/cli/test_send_printables_reminders.py
@@ -19,11 +19,14 @@ def _event_starting_in(sphere, delta):
 
 
 class TestSendPrintablesReminders:
-    def test_reminds_organizers_within_lead_time(self, sphere, active_user, mailoutbox):
+    def test_reminds_organizers_within_lead_time(
+        self, sphere, active_user, mailoutbox, django_capture_on_commit_callbacks
+    ):
         sphere.managers.add(active_user)
         event = _event_starting_in(sphere, timedelta(days=1))
 
-        call_command("send_printables_reminders")
+        with django_capture_on_commit_callbacks(execute=True):
+            call_command("send_printables_reminders")
 
         assert len(mailoutbox) == 1
         email = mailoutbox[0]
@@ -36,51 +39,64 @@ class TestSendPrintablesReminders:
         event.refresh_from_db()
         assert event.printables_reminder_sent_at is not None
 
-    def test_skips_event_already_printed(self, sphere, active_user, mailoutbox):
+    def test_skips_event_already_printed(
+        self, sphere, active_user, mailoutbox, django_capture_on_commit_callbacks
+    ):
         sphere.managers.add(active_user)
         event = _event_starting_in(sphere, timedelta(days=1))
         event.printables_last_printed_at = datetime.now(UTC)
         event.save(update_fields=["printables_last_printed_at"])
 
-        call_command("send_printables_reminders")
+        with django_capture_on_commit_callbacks(execute=True):
+            call_command("send_printables_reminders")
 
         assert mailoutbox == []
         event.refresh_from_db()
         assert event.printables_reminder_sent_at is None
 
-    def test_skips_event_already_reminded(self, sphere, active_user, mailoutbox):
+    def test_skips_event_already_reminded(
+        self, sphere, active_user, mailoutbox, django_capture_on_commit_callbacks
+    ):
         sphere.managers.add(active_user)
         event = _event_starting_in(sphere, timedelta(days=1))
         event.printables_reminder_sent_at = datetime.now(UTC)
         event.save(update_fields=["printables_reminder_sent_at"])
 
-        call_command("send_printables_reminders")
+        with django_capture_on_commit_callbacks(execute=True):
+            call_command("send_printables_reminders")
 
         assert mailoutbox == []
 
-    def test_skips_event_outside_lead_time(self, sphere, active_user, mailoutbox):
+    def test_skips_event_outside_lead_time(
+        self, sphere, active_user, mailoutbox, django_capture_on_commit_callbacks
+    ):
         sphere.managers.add(active_user)
         _event_starting_in(sphere, timedelta(days=5))
 
-        call_command("send_printables_reminders")
+        with django_capture_on_commit_callbacks(execute=True):
+            call_command("send_printables_reminders")
 
         assert mailoutbox == []
 
-    def test_skips_event_that_already_started(self, sphere, active_user, mailoutbox):
+    def test_skips_event_that_already_started(
+        self, sphere, active_user, mailoutbox, django_capture_on_commit_callbacks
+    ):
         sphere.managers.add(active_user)
         _event_starting_in(sphere, timedelta(hours=-1))
 
-        call_command("send_printables_reminders")
+        with django_capture_on_commit_callbacks(execute=True):
+            call_command("send_printables_reminders")
 
         assert mailoutbox == []
 
     def test_skips_managers_without_email_and_leaves_event_unmarked(
-        self, sphere, mailoutbox
+        self, sphere, mailoutbox, django_capture_on_commit_callbacks
     ):
         sphere.managers.add(UserFactory(username="no-email", email=""))
         event = _event_starting_in(sphere, timedelta(days=1))
 
-        call_command("send_printables_reminders")
+        with django_capture_on_commit_callbacks(execute=True):
+            call_command("send_printables_reminders")
 
         assert mailoutbox == []
         event.refresh_from_db()

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -38,7 +38,7 @@ register(AnonymousUserFactory)
 
 
 @pytest.fixture(autouse=True)
-def _django_db(transactional_db):
+def _django_db(db):
     pass
 
 
@@ -349,7 +349,7 @@ def agenda_item(session, space):
 
 
 @pytest.fixture(autouse=True, name="sphere")
-def sphere_fixture(settings, transactional_db):  # noqa: ARG001
+def sphere_fixture(settings, db):  # noqa: ARG001
     site, __ = Site.objects.update_or_create(
         domain=settings.ROOT_DOMAIN, defaults={"name": settings.ROOT_DOMAIN}
     )

--- a/tests/integration/utils.py
+++ b/tests/integration/utils.py
@@ -98,6 +98,16 @@ def assert_response_404(
     )
 
 
+def checkbox_tag(content: str, name: str, pk: int) -> str:
+    # The single <input> tag for a multi-value checkbox (name repeats per row,
+    # value carries the pk), so a test can check its checked state without
+    # depending on attribute order. Scoping by name matters: pks restart at 1
+    # per table, so a bare value="1" search can match an unrelated element.
+    match = re.search(rf'<input[^>]*name="{name}"[^>]*value="{pk}"[^>]*>', content)
+    assert match, f"no checkbox {name}={pk}"
+    return match.group(0)
+
+
 def input_tag(content: str, pk: int) -> str:
     # The single <input> tag for a person's Include checkbox on the enroll
     # page, so a test can check its checked / disabled attributes without

--- a/tests/integration/web/chronology/test_shadowban_signup_notification.py
+++ b/tests/integration/web/chronology/test_shadowban_signup_notification.py
@@ -28,7 +28,14 @@ def _enroll_url(session_id: int, event_slug: str) -> str:
 @pytest.mark.usefixtures("enrollment_config")
 class TestShadowbanSignupNotification:
     def test_banner_emailed_when_shadowbanned_player_joins_event(
-        self, authenticated_client, agenda_item, active_user, event, space, mailoutbox
+        self,
+        authenticated_client,
+        agenda_item,
+        active_user,
+        event,
+        space,
+        mailoutbox,
+        django_capture_on_commit_callbacks,
     ):
         # A banner runs a session in the event and shadowbanned the player.
         banner = UserFactory(username="gm", email="gm@example.com", name="Game Master")
@@ -43,10 +50,11 @@ class TestShadowbanSignupNotification:
         )
         AgendaItemFactory(session=joined_session, space=SpaceFactory(event=space.event))
 
-        response = authenticated_client.post(
-            _enroll_url(joined_session.pk, joined_session.event.slug),
-            data={f"user_{active_user.id}": "enroll"},
-        )
+        with django_capture_on_commit_callbacks(execute=True):
+            response = authenticated_client.post(
+                _enroll_url(joined_session.pk, joined_session.event.slug),
+                data={f"user_{active_user.id}": "enroll"},
+            )
 
         assert response.status_code == HTTPStatus.FOUND
         assert Notification.objects.filter(
@@ -57,7 +65,14 @@ class TestShadowbanSignupNotification:
         assert "Test User" in mailoutbox[0].body
 
     def test_email_discerns_signup_into_session_where_banner_plays(
-        self, authenticated_client, agenda_item, active_user, event, space, mailoutbox
+        self,
+        authenticated_client,
+        agenda_item,
+        active_user,
+        event,
+        space,
+        mailoutbox,
+        django_capture_on_commit_callbacks,
     ):
         banner = UserFactory(username="gm6", email="gm6@example.com", name="GM")
         banner_session = agenda_item.session
@@ -79,10 +94,11 @@ class TestShadowbanSignupNotification:
             status=SessionParticipationStatus.CONFIRMED.value,
         )
 
-        response = authenticated_client.post(
-            _enroll_url(joined_session.pk, joined_session.event.slug),
-            data={f"user_{active_user.id}": "enroll"},
-        )
+        with django_capture_on_commit_callbacks(execute=True):
+            response = authenticated_client.post(
+                _enroll_url(joined_session.pk, joined_session.event.slug),
+                data={f"user_{active_user.id}": "enroll"},
+            )
 
         assert response.status_code == HTTPStatus.FOUND
         assert len(mailoutbox) == 1
@@ -94,7 +110,12 @@ class TestShadowbanSignupNotification:
         assert "where you are playing" in mailoutbox[0].body
 
     def test_banner_playing_in_session_notified_even_without_presenting(
-        self, authenticated_client, agenda_item, active_user, mailoutbox
+        self,
+        authenticated_client,
+        agenda_item,
+        active_user,
+        mailoutbox,
+        django_capture_on_commit_callbacks,
     ):
         banner = UserFactory(username="gm7", email="gm7@example.com", name="GM")
         banner.shadowbanned.add(active_user)
@@ -108,10 +129,11 @@ class TestShadowbanSignupNotification:
             status=SessionParticipationStatus.CONFIRMED.value,
         )
 
-        response = authenticated_client.post(
-            _enroll_url(joined_session.pk, joined_session.event.slug),
-            data={f"user_{active_user.id}": "enroll"},
-        )
+        with django_capture_on_commit_callbacks(execute=True):
+            response = authenticated_client.post(
+                _enroll_url(joined_session.pk, joined_session.event.slug),
+                data={f"user_{active_user.id}": "enroll"},
+            )
 
         assert response.status_code == HTTPStatus.FOUND
         assert Notification.objects.filter(
@@ -122,7 +144,14 @@ class TestShadowbanSignupNotification:
         assert "where you are playing" in mailoutbox[0].body
 
     def test_reconfirming_existing_signup_does_not_renotify(
-        self, authenticated_client, agenda_item, active_user, event, space, mailoutbox
+        self,
+        authenticated_client,
+        agenda_item,
+        active_user,
+        event,
+        space,
+        mailoutbox,
+        django_capture_on_commit_callbacks,
     ):
         # Re-submitting enroll for an already-existing participation is not a
         # fresh signup, so the banner must not be alerted again.
@@ -144,10 +173,11 @@ class TestShadowbanSignupNotification:
             status=SessionParticipationStatus.WAITING.value,
         )
 
-        response = authenticated_client.post(
-            _enroll_url(joined_session.pk, joined_session.event.slug),
-            data={f"user_{active_user.id}": "enroll"},
-        )
+        with django_capture_on_commit_callbacks(execute=True):
+            response = authenticated_client.post(
+                _enroll_url(joined_session.pk, joined_session.event.slug),
+                data={f"user_{active_user.id}": "enroll"},
+            )
 
         assert response.status_code == HTTPStatus.FOUND
         assert not Notification.objects.filter(
@@ -156,7 +186,14 @@ class TestShadowbanSignupNotification:
         assert not mailoutbox
 
     def test_no_email_when_player_not_shadowbanned(
-        self, authenticated_client, agenda_item, active_user, event, space, mailoutbox
+        self,
+        authenticated_client,
+        agenda_item,
+        active_user,
+        event,
+        space,
+        mailoutbox,
+        django_capture_on_commit_callbacks,
     ):
         banner = UserFactory(
             username="gm2", email="gm2@example.com", name="Other Master"
@@ -170,10 +207,11 @@ class TestShadowbanSignupNotification:
         )
         AgendaItemFactory(session=joined_session, space=SpaceFactory(event=space.event))
 
-        response = authenticated_client.post(
-            _enroll_url(joined_session.pk, joined_session.event.slug),
-            data={f"user_{active_user.id}": "enroll"},
-        )
+        with django_capture_on_commit_callbacks(execute=True):
+            response = authenticated_client.post(
+                _enroll_url(joined_session.pk, joined_session.event.slug),
+                data={f"user_{active_user.id}": "enroll"},
+            )
 
         assert response.status_code == HTTPStatus.FOUND
         assert not Notification.objects.filter(
@@ -182,7 +220,13 @@ class TestShadowbanSignupNotification:
         assert not mailoutbox
 
     def test_unscheduled_banner_not_notified(
-        self, authenticated_client, agenda_item, active_user, event, mailoutbox
+        self,
+        authenticated_client,
+        agenda_item,
+        active_user,
+        event,
+        mailoutbox,
+        django_capture_on_commit_callbacks,
     ):
         # A banner whose only session in the event is unscheduled (no agenda
         # item) is not "on the event" and is not notified.
@@ -200,10 +244,11 @@ class TestShadowbanSignupNotification:
         agenda_item.session.presenter = host
         agenda_item.session.save()
 
-        response = authenticated_client.post(
-            _enroll_url(agenda_item.session.pk, agenda_item.session.event.slug),
-            data={f"user_{active_user.id}": "enroll"},
-        )
+        with django_capture_on_commit_callbacks(execute=True):
+            response = authenticated_client.post(
+                _enroll_url(agenda_item.session.pk, agenda_item.session.event.slug),
+                data={f"user_{active_user.id}": "enroll"},
+            )
 
         assert response.status_code == HTTPStatus.FOUND
         assert not Notification.objects.filter(

--- a/tests/integration/web/chronology/test_waitlist_promotion.py
+++ b/tests/integration/web/chronology/test_waitlist_promotion.py
@@ -35,14 +35,17 @@ def _service():
 
 @pytest.mark.usefixtures("enrollment_config", "agenda_item")
 class TestFillFreedSeats:
-    def test_auto_promotes_waiter_and_notifies(self, session, waiter, mailoutbox):
+    def test_auto_promotes_waiter_and_notifies(
+        self, session, waiter, mailoutbox, django_capture_on_commit_callbacks
+    ):
         session.participants_limit = 1
         session.save()
         participation = SessionParticipation.objects.create(
             session=session, user=waiter, status=SessionParticipationStatus.WAITING
         )
 
-        result = _service().fill_freed_seats(session_id=session.pk)
+        with django_capture_on_commit_callbacks(execute=True):
+            result = _service().fill_freed_seats(session_id=session.pk)
 
         participation.refresh_from_db()
         assert participation.status == SessionParticipationStatus.CONFIRMED.value
@@ -54,7 +57,7 @@ class TestFillFreedSeats:
         assert mailoutbox[0].to == ["waiter@example.com"]
 
     def test_offer_mode_holds_seat_and_notifies(
-        self, session, event, waiter, mailoutbox
+        self, session, event, waiter, mailoutbox, django_capture_on_commit_callbacks
     ):
         session.participants_limit = 1
         session.category = ProposalCategoryFactory(
@@ -65,7 +68,8 @@ class TestFillFreedSeats:
             session=session, user=waiter, status=SessionParticipationStatus.WAITING
         )
 
-        result = _service().fill_freed_seats(session_id=session.pk)
+        with django_capture_on_commit_callbacks(execute=True):
+            result = _service().fill_freed_seats(session_id=session.pk)
 
         participation.refresh_from_db()
         assert participation.status == SessionParticipationStatus.OFFERED.value
@@ -380,7 +384,7 @@ class TestOfferClaimAndExpiry:
         assert "Decline offer" in content
 
     def test_expire_drops_lapsed_party_and_rolls_on(
-        self, session, event, waiter, mailoutbox
+        self, session, event, waiter, mailoutbox, django_capture_on_commit_callbacks
     ):
         participation = self._offer(session, event, waiter)
         # Force the offer past its deadline.
@@ -391,7 +395,8 @@ class TestOfferClaimAndExpiry:
             session=session, user=next_user, status=SessionParticipationStatus.WAITING
         )
 
-        _service().expire_offer(participation_id=participation.pk)
+        with django_capture_on_commit_callbacks(execute=True):
+            _service().expire_offer(participation_id=participation.pk)
 
         assert not SessionParticipation.objects.filter(pk=participation.pk).exists()
         next_participation.refresh_from_db()

--- a/tests/integration/web/crowd/test_auth0_logout_redirect_action.py
+++ b/tests/integration/web/crowd/test_auth0_logout_redirect_action.py
@@ -13,7 +13,7 @@ class TestAuth0LogoutRedirectActionView:
 
     def test_ok_with_domain(self, client):
         domain = "example.com"
-        site = Site.objects.get(domain=domain)
+        site = Site.objects.create(domain=domain, name="Example")
         Sphere.objects.create(site=site, name="Example")
         response = client.get(self.URL, {"last_domain": domain, "redirect_to": "/test"})
 

--- a/tests/integration/web/panel/test_proposal_edit_page.py
+++ b/tests/integration/web/panel/test_proposal_edit_page.py
@@ -38,7 +38,7 @@ from tests.integration.conftest import (
     SpaceFactory,
     UserFactory,
 )
-from tests.integration.utils import assert_response
+from tests.integration.utils import assert_response, checkbox_tag
 
 PERMISSION_ERROR = "You don't have permission to access the backoffice panel."
 PNG_BYTES = (
@@ -1349,19 +1349,7 @@ class TestProposalEditPageView:
         assert response.status_code == HTTPStatus.OK
         html = response.content.decode()
         assert 'id="facilitator-search"' in html
-        assert f'value="{assigned.pk}"' in html
-        assert f'value="{unassigned.pk}"' in html
         assert "Alice" in html
         assert "Bob" in html
-        assigned_row = html[
-            html.index(f'value="{assigned.pk}"') : html.index(f'value="{assigned.pk}"')
-            + 200
-        ]
-        assert "checked" in assigned_row
-        unassigned_row = html[
-            html.index(f'value="{unassigned.pk}"') : html.index(
-                f'value="{unassigned.pk}"'
-            )
-            + 200
-        ]
-        assert "checked" not in unassigned_row
+        assert "checked" in checkbox_tag(html, "facilitator_ids", assigned.pk)
+        assert "checked" not in checkbox_tag(html, "facilitator_ids", unassigned.pk)

--- a/tests/template_checks.py
+++ b/tests/template_checks.py
@@ -69,8 +69,13 @@ class MissingTemplateVariableFilter(logging.Filter):
         return False
 
     def _has_default_filter_on_simple_var(self) -> bool:
-        for frame_info in inspect.stack():
-            local_self = frame_info.frame.f_locals.get("self")
+        # Walk f_back rather than inspect.stack(): stack() resolves source
+        # context (linecache read + module lookup) for every frame, and we
+        # only need each frame's locals. It fires on every failed template
+        # variable lookup, so the waste dominates the test suite.
+        frame = inspect.currentframe()
+        while frame is not None:  # pylint: disable=while-used
+            local_self = frame.f_locals.get("self")
             if isinstance(local_self, FilterExpression):
                 var = local_self.var
                 if hasattr(var, "lookups") and var.lookups and len(var.lookups) == 1:
@@ -78,6 +83,7 @@ class MissingTemplateVariableFilter(logging.Filter):
                         if func.__name__ == "default":
                             return True
                 break
+            frame = frame.f_back
         return False
 
     def _get_lookup_info(self, record: logging.LogRecord) -> tuple[str, str] | None:


### PR DESCRIPTION
The integration suite was slow for reasons that had nothing to do with the tests themselves.

Profiling (--durations=0 for phases, cProfile for hot code) found:

- Every integration test ran under `transactional_db` via an autouse fixture, so each one committed for real and paid a full-table flush plus a re-emitted post_migrate on teardown. Only ~6 files ever needed it. Switching the autouse fixture to `db` (rollback) makes teardown essentially free.

- `template_checks.MissingTemplateVariableFilter` called `inspect.stack()` on every failed template variable lookup. stack() resolves source context (linecache + module lookup) for every frame; the filter only needs each frame's locals. Walking f_back instead cut the crowd directory from ~29s of test time to ~9.5s.

- The suite ran single-threaded on 8 cores. pytest-xdist `-n auto` does the rest.

Dropping transactional_db surfaced three classes of test that were coupled to its teardown rather than to the code under test:

- on_commit callbacks never fire under rollback, so the mail tests are now wrapped in django_capture_on_commit_callbacks(execute=True). The negative assertions (`assert mailoutbox == []`) had been passing unconditionally.

- test_auth0_logout_redirect_action fetched a Site the flush conjured: post_migrate recreates example.com only against an empty table, so the row existed solely because a previous test truncated the sites table. It now creates the Site it needs.

- test_proposal_edit_page searched the whole page for `value="{pk}"`. The flush left sequences climbing, so pks were globally unique by luck; under rollback every table starts at 1 and the search hit an unrelated <option>. Added a `checkbox_tag` helper alongside the existing `input_tag`.

TESTING_STRATEGY.md documents when transactional_db is actually warranted.

The pylint suppression in template_checks.py is a deliberate +1 on tingle: the frame walk needs a while loop, and the alternatives (recursion over stack frames, or an arbitrary frame cap) are worse in a logging filter.