### PR TITLE
Add "Multiple tracks" filter to proposals panel track select

### DIFF
--- a/src/ludamus/gates/web/django/chronology/panel/views/proposals.py
+++ b/src/ludamus/gates/web/django/chronology/panel/views/proposals.py
@@ -91,6 +91,7 @@ class ProposalsPageView(PanelAccessMixin, EventContextMixin, View):
         sorted_tracks, managed_pks, filter_track_pk = self.get_track_filter_context(
             current_event.pk
         )
+        filter_track_multi = self.request.GET.get("track") == "multi"
 
         categories = self.request.di.uow.proposal_categories.list_by_event(
             current_event.pk
@@ -127,6 +128,7 @@ class ProposalsPageView(PanelAccessMixin, EventContextMixin, View):
                 "field_filters": field_filters or None,
                 "search": search,
                 "track_pk": filter_track_pk,
+                "multi_tracks": filter_track_multi or None,
                 "category_pk": filter_category_pk,
                 "status": status_filter,
                 "scheduled": scheduled_filter,
@@ -153,6 +155,7 @@ class ProposalsPageView(PanelAccessMixin, EventContextMixin, View):
         context["all_tracks"] = sorted_tracks
         context["managed_track_pks"] = managed_pks
         context["filter_track_pk"] = filter_track_pk
+        context["filter_track_multi"] = filter_track_multi
         context["categories"] = categories
         context["filter_category_pk"] = filter_category_pk
         status_labels = {

--- a/src/ludamus/links/db/django/repositories/sessions.py
+++ b/src/ludamus/links/db/django/repositories/sessions.py
@@ -2,7 +2,7 @@ import json
 import re
 from typing import TYPE_CHECKING
 
-from django.db.models import Exists, OuterRef, Q
+from django.db.models import Count, Exists, OuterRef, Q
 
 from ludamus.links.db.django.models import (
     AgendaItem,
@@ -371,6 +371,7 @@ class SessionRepository(SessionRepositoryProtocol):  # noqa: PLR0904
         field_filters = filters.get("field_filters")
         search = filters.get("search")
         track_pk = filters.get("track_pk")
+        multi_tracks = filters.get("multi_tracks")
         category_pk = filters.get("category_pk")
         status = filters.get("status")
         scheduled = filters.get("scheduled")
@@ -410,6 +411,11 @@ class SessionRepository(SessionRepositoryProtocol):  # noqa: PLR0904
 
         if track_pk is not None:
             qs = qs.filter(tracks__pk=track_pk)
+
+        if multi_tracks:
+            qs = qs.annotate(_track_count=Count("tracks", distinct=True)).filter(
+                _track_count__gt=1
+            )
 
         return [
             SessionListItemDTO(

--- a/src/ludamus/locale/pl/LC_MESSAGES/django.po
+++ b/src/ludamus/locale/pl/LC_MESSAGES/django.po
@@ -7182,6 +7182,10 @@ msgid "All tracks"
 msgstr "Wszystkie bloki"
 
 #: src/ludamus/templates/panel/proposals.html
+msgid "Multiple tracks"
+msgstr "Wiele bloków"
+
+#: src/ludamus/templates/panel/proposals.html
 msgid "Search by facilitator or field values"
 msgstr "Szukaj po prowadzącym lub wartościach pól"
 

--- a/src/ludamus/pacts/legacy.py
+++ b/src/ludamus/pacts/legacy.py
@@ -250,6 +250,7 @@ class SessionListFilters(TypedDict, total=False):
     field_filters: dict[int, str] | None
     search: str | None
     track_pk: int | None
+    multi_tracks: bool | None
     category_pk: int | None
     status: SessionStatus | None
     scheduled: bool | None

--- a/src/ludamus/templates/panel/proposals.html
+++ b/src/ludamus/templates/panel/proposals.html
@@ -41,6 +41,7 @@
                     onchange="this.form.submit()"
                     class="px-3 py-1.5 border border-border rounded-lg text-sm bg-bg-secondary text-foreground focus:outline-none focus:ring-2 focus:ring-primary">
                 <option value="">{% translate "All tracks" %}</option>
+                <option value="multi" {% if filter_track_multi %}selected{% endif %}>{% translate "Multiple tracks" %}</option>
                 {% for track in all_tracks %}
                     <option value="{{ track.pk }}"
                             {% if filter_track_pk == track.pk %}selected{% endif %}
@@ -58,7 +59,11 @@
         {% if current_event %}
             <div class="bg-bg-secondary rounded-2xl shadow-sm border border-border p-4 mb-6">
                 <form method="get" class="flex flex-wrap gap-4 items-end">
-                    {% if filter_track_pk %}<input type="hidden" name="track" value="{{ filter_track_pk }}">{% endif %}
+                    {% if filter_track_multi %}
+                        <input type="hidden" name="track" value="multi">
+                    {% elif filter_track_pk %}
+                        <input type="hidden" name="track" value="{{ filter_track_pk }}">
+                    {% endif %}
                     <div class="w-full sm:w-48 min-w-0">
                         <label for="filter-search"
                                title="{% translate "Search" %}"

--- a/tests/integration/web/panel/test_proposals_page.py
+++ b/tests/integration/web/panel/test_proposals_page.py
@@ -44,6 +44,7 @@ _TRACK_FILTER_CONTEXT = {
     "all_tracks": [],
     "managed_track_pks": set(),
     "filter_track_pk": None,
+    "filter_track_multi": False,
     "page_obj": PageMatcher(number=1, num_pages=1),
     "filter_category_pk": None,
     "filter_status": None,
@@ -877,6 +878,7 @@ class TestProposalsPageView:
                 "all_tracks": [TrackDTO.model_validate(track)],
                 "managed_track_pks": {track.pk},
                 "filter_track_pk": track.pk,
+                "filter_track_multi": False,
                 "page_obj": PageMatcher(number=1, num_pages=1),
                 "categories": [],
                 "filter_category_pk": None,
@@ -912,6 +914,7 @@ class TestProposalsPageView:
                 "all_tracks": [TrackDTO.model_validate(track)],
                 "managed_track_pks": set(),
                 "filter_track_pk": track.pk,
+                "filter_track_multi": False,
                 "page_obj": PageMatcher(number=1, num_pages=1),
                 "categories": [],
                 "filter_category_pk": None,
@@ -919,6 +922,55 @@ class TestProposalsPageView:
                 "statuses": _STATUSES,
             },
         )
+
+    def test_filters_by_multiple_tracks(
+        self, authenticated_client, active_user, sphere, event
+    ):
+        """track=multi shows only proposals assigned to more than one track."""
+        sphere.managers.add(active_user)
+        category = ProposalCategory.objects.create(event=event, name="RPG", slug="rpg")
+        track_a = Track.objects.create(
+            event=event, name="Alpha", slug="alpha", is_public=True
+        )
+        track_b = Track.objects.create(
+            event=event, name="Beta", slug="beta", is_public=True
+        )
+        multi = Session.objects.create(
+            event=event,
+            category=category,
+            display_name="Host M",
+            title="Multi",
+            slug="multi",
+            participants_limit=5,
+            status="pending",
+        )
+        multi.tracks.add(track_a, track_b)
+        single = Session.objects.create(
+            event=event,
+            category=category,
+            display_name="Host S",
+            title="Single",
+            slug="single",
+            participants_limit=5,
+            status="pending",
+        )
+        single.tracks.add(track_a)
+        Session.objects.create(
+            event=event,
+            category=category,
+            display_name="Host N",
+            title="None",
+            slug="none",
+            participants_limit=5,
+            status="pending",
+        )
+
+        response = authenticated_client.get(self.get_url(event), {"track": "multi"})
+
+        assert response.status_code == HTTPStatus.OK
+        assert [p.title for p in response.context["proposals"]] == ["Multi"]
+        assert response.context["filter_track_multi"] is True
+        assert response.context["filter_track_pk"] is None
 
     def test_excludes_text_fields_from_filters(
         self, authenticated_client, active_user, sphere, event


### PR DESCRIPTION
Adds a "Multiple tracks" option to the track switcher on the proposals panel that lists proposals assigned to more than one track. Implemented as a scalar sentinel (track=multi), so no multi-select UI.