### PR TITLE
fix: accept sessions spanning contiguous preferred time slots

### DIFF
--- a/src/ludamus/mills/chronology.py
+++ b/src/ludamus/mills/chronology.py
@@ -102,6 +102,20 @@ def _duration_hours(start: datetime, end: datetime) -> float:
     return max((end - start).total_seconds() / 3600, 0.0)
 
 
+def _slot_start(slot: TimeSlotDTO) -> datetime:
+    return slot.start_time
+
+
+def _merged_slot_ranges(slots: list[TimeSlotDTO]) -> list[tuple[datetime, datetime]]:
+    merged: list[tuple[datetime, datetime]] = []
+    for slot in sorted(slots, key=_slot_start):
+        if merged and slot.start_time <= merged[-1][1]:
+            merged[-1] = (merged[-1][0], max(merged[-1][1], slot.end_time))
+        else:
+            merged.append((slot.start_time, slot.end_time))
+    return merged
+
+
 def _position_sessions(
     items: list[AgendaItemDTO], event_start: datetime
 ) -> list[SessionPositionDTO]:
@@ -818,8 +832,8 @@ class ConflictDetectionService:
             if not (preferred := preferred_by_session.get(item.session_id, [])):
                 continue
             if any(
-                slot.start_time <= item.start_time and slot.end_time >= item.end_time
-                for slot in preferred
+                start <= item.start_time and end >= item.end_time
+                for start, end in _merged_slot_ranges(preferred)
             ):
                 continue
             track_name, manager_names = self._slot_violation_track_attribution(

--- a/tests/integration/web/panel/test_timetable_problems_page.py
+++ b/tests/integration/web/panel/test_timetable_problems_page.py
@@ -199,6 +199,72 @@ class TestTimetableProblemsPageView:
         assert response.status_code == HTTPStatus.OK
         assert response.context["slot_violations"] == []
 
+    def test_skips_session_spanning_contiguous_preferred_slots(
+        self, authenticated_client, active_user, sphere, event, proposal_category
+    ):
+        sphere.managers.add(active_user)
+        space = SpaceFactory(event=event)
+        session = SessionFactory(
+            category=proposal_category,
+            status="pending",
+            participants_limit=5,
+            min_age=0,
+        )
+        session.time_slots.add(
+            TimeSlotFactory(
+                event=event,
+                start_time=event.start_time,
+                end_time=event.start_time + timedelta(hours=4),
+            ),
+            TimeSlotFactory(
+                event=event,
+                start_time=event.start_time + timedelta(hours=4),
+                end_time=event.start_time + timedelta(hours=8),
+            ),
+        )
+        start = event.start_time + timedelta(hours=2)
+        end = event.start_time + timedelta(hours=6)
+        AgendaItemFactory(session=session, space=space, start_time=start, end_time=end)
+
+        response = authenticated_client.get(self.get_url(event))
+
+        assert response.status_code == HTTPStatus.OK
+        assert response.context["slot_violations"] == []
+
+    def test_lists_session_spanning_gap_between_preferred_slots(
+        self, authenticated_client, active_user, sphere, event, proposal_category
+    ):
+        sphere.managers.add(active_user)
+        space = SpaceFactory(event=event)
+        session = SessionFactory(
+            category=proposal_category,
+            status="pending",
+            participants_limit=5,
+            min_age=0,
+        )
+        session.time_slots.add(
+            TimeSlotFactory(
+                event=event,
+                start_time=event.start_time,
+                end_time=event.start_time + timedelta(hours=2),
+            ),
+            TimeSlotFactory(
+                event=event,
+                start_time=event.start_time + timedelta(hours=4),
+                end_time=event.start_time + timedelta(hours=8),
+            ),
+        )
+        start = event.start_time + timedelta(hours=1)
+        end = event.start_time + timedelta(hours=5)
+        AgendaItemFactory(session=session, space=space, start_time=start, end_time=end)
+
+        response = authenticated_client.get(self.get_url(event))
+
+        assert response.status_code == HTTPStatus.OK
+        violations = response.context["slot_violations"]
+        assert len(violations) == 1
+        assert violations[0].session_pk == session.pk
+
     def test_skips_session_with_no_preferred_slots(
         self, authenticated_client, active_user, sphere, event, proposal_category
     ):


### PR DESCRIPTION
## Problem

A session with two adjacent preferred time slots (e.g. 10–14 and 14–18) scheduled across their boundary (e.g. 12–16) was reported on the timetable problems page as scheduled outside its preferred slots. The check required the agenda item to fit inside a **single** preferred slot.

## Fix

`list_preferred_slot_violations` now merges overlapping/contiguous preferred slots into continuous ranges before the containment check. Slots with a gap between them still produce a violation for a session spanning the gap.

## Tests

- `test_skips_session_spanning_contiguous_preferred_slots` — adjacent slots, session across the boundary → no violation
- `test_lists_session_spanning_gap_between_preferred_slots` — gapped slots, session across the gap → violation

No template/UI changes — the problems page just stops listing a false positive — so no screenshots.

🤖 Generated with [Claude Code](https://claude.com/claude-code)