### PR TITLE
Get rid of DDD vocabulary

### DIFF
--- a/.claude/skills/glimpse/SKILL.md
+++ b/.claude/skills/glimpse/SKILL.md
@@ -21,11 +21,11 @@ legacy — new code goes into GLIMPSE layers.
 Every layer is a package (directory), never a single `.py` file. Minimum shapes:
 
 ```text
-pacts/{subdomain}.py                    # or pacts/{subdomain}/{context}.py
-mills/{subdomain}.py                    # or mills/{subdomain}/{context}.py
-specs/{subdomain}.py
-inits/{subdomain}.py
-gates/{port}/{adapter}/{subdomain}.py   # or .../{subdomain}/{context}/...
+pacts/{noun}.py                         # or pacts/{noun}/{verb}.py
+mills/{noun}.py                         # or mills/{noun}/{verb}.py
+specs/{noun}.py
+inits/{noun}.py
+gates/{port}/{adapter}/{page}.py        # or .../{page_group}/...
 links/{port}/{adapter}/{kind}.py            # while small (models.py, repositories.py)
 links/{port}/{adapter}/{kind}/{module}.py   # when {kind} crosses threshold
 links/{port}/{adapter}/__init__.py          # facade — re-exports the public surface
@@ -48,29 +48,41 @@ line-length pressure, or a pre-existing legacy facade. It is not the default.
   `db`, `payment_api`, `email`
 - **Adapter** — specific technology implementing a port: `django`, `stripe`,
   `blik`, `sendgrid`. One port can have multiple adapters.
-- **Subdomain** — broad business area (`auth`, `billing`, `content`)
-- **Bounded context** — responsibility boundary with its own ubiquitous
-  language. Two contexts can share `User` and mean different things.
+- **Noun** — a fat data cow: the model cluster everything else hangs off
+  (`event`, `user`, `sphere`, `encounter`, `party`). The slicing axis for
+  pacts, mills, specs, inits.
+- **Verb** — an activity cut inside a noun (`enroll`, `propose`, `schedule`,
+  `present`). A verb module holds the records and logic of actions, not
+  first-class data. No catch-all verbs (`manage`, `organize`): a cut must name
+  a real activity — if you can't name one, the file isn't too big yet.
+- **Page** — gates' slicing axis: what the user touches. For `web`, a page (or
+  page group) plus its action views; for `cli`, a command; for `mcp`, a tool.
+  Gates mirror the sitemap; mills mirror the domain.
 - **Entity** — persistence-level concept: the unit a DTO + repository wraps.
-  Conceptual, not a file-layout axis: `links` slices by **kind** (per-adapter —
-  e.g. `models` / `repositories` for `db/django`), not by entity.
+  Narrower than a noun (the `event` noun spans many entities). Conceptual, not
+  a file-layout axis: `links` slices by **kind** (per-adapter — e.g. `models` /
+  `repositories` for `db/django`), not by entity.
 
-Subdomain contains bounded contexts. Bounded context depends on entities.
+A noun contains verb cuts. The old **subdomain** / **bounded context**
+vocabulary is banned; legacy names still on disk map as: chronology +
+submissions → event, crowd → user, multiverse → sphere, notice_board →
+encounter. The `old-subdomain-loc` tingle metric counts legacy-named modules
+down; new code slices by noun.
 
 ## Slicing rules
 
-**pacts, mills, specs, inits — by subdomain, then bounded context.**
+**pacts, mills, specs, inits — by noun, then verb.**
 
 ```text
-pacts/{subdomain}.py                    # flat while subdomain is small
-pacts/{subdomain}/{bounded_context}.py  # split when subdomain grows fat
-mills/{subdomain}.py
-mills/{subdomain}/{bounded_context}.py
-specs/{subdomain}.py
-inits/{subdomain}.py
+pacts/{noun}.py             # flat while the noun is small
+pacts/{noun}/{verb}.py      # cut by verb when the noun grows fat
+mills/{noun}.py
+mills/{noun}/{verb}.py
+specs/{noun}.py
+inits/{noun}.py
 ```
 
-Each pacts module holds all boundary contracts for that subdomain/context:
+Each pacts module holds all boundary contracts for that noun (or verb cut):
 DTOs, write TypedDicts, protocols, errors. Split by domain concern, not by
 technical kind — no `pacts/dtos.py`, `pacts/protocols.py`, or `pacts/repos/`
 directories.
@@ -83,7 +95,7 @@ they feel like domain objects: repo protocols in `pacts` return them, so moving
 them to `mills` would make `pacts → mills → pacts` circular. A DTO is a data
 contract for a port, not a domain object.
 
-**links — `{port}/{adapter}/{kind}`. gates — `{port}/{adapter}/{subdomain}`.**
+**links — `{port}/{adapter}/{kind}`. gates — `{port}/{adapter}/{page}`.**
 
 ```text
 # Small (default)
@@ -105,8 +117,8 @@ links/{port}/{adapter}/
         part2.py
 
 links/payment_api/stripe.py         # external client: port/adapter, single file
-gates/web/django/{subdomain}.py     # or .../{subdomain}/{context}/...
-gates/cli/django/{subdomain}.py
+gates/web/django/{page}.py          # or .../{page_group}/... — page + actions
+gates/cli/django/{command}.py
 ```
 
 The `kind` axis and the split philosophy are per-adapter — `db/django` is
@@ -126,7 +138,7 @@ separate adapters. Same port can have multiple adapters: `payment_api/stripe`
 and `payment_api/blik` are interchangeable implementations.
 
 **Symmetry rule:** `pacts/` ↔ `mills/` must mirror each other — both sliced by
-subdomain/context. If one splits a subdomain into contexts, the other must too.
+noun/verb. If one cuts a noun into verbs, the other must too.
 
 ## Growing rules
 
@@ -142,12 +154,12 @@ Concrete thresholds — none is a hard line, all are "watch for this":
   holding one tightly coupled service is fine; a 600-line file holding three
   independent services is not.
 - **~12 public symbols per namespace level** — applies to repository
-  registries, the services tree, pacts subdomain modules, and the inits
-  namespaces. At 13+ leaves, introduce a sub-bucket grouped by subdomain or
-  bounded context. With ≤12, stay flat.
+  registries, the services tree, pacts noun modules, and the inits
+  namespaces. At 13+ leaves, introduce a sub-bucket grouped by noun or verb.
+  With ≤12, stay flat.
 - **Folder must contain at least 2 files before it exists.** Never create
   `inits/services/chronology/panel/` for a single leaf. Never create
-  `pacts/{subdomain}/{context}.py` while the subdomain has only one context.
+  `pacts/{noun}/{verb}.py` while the noun has only one cut.
   Reverse the speculative scaffold; flatten back when the leaf count drops.
 - **Split links by kind first.** Default: one file per kind. When a kind
   crosses ~1000 lines, **promote it to a package** and split into submodules
@@ -197,12 +209,12 @@ hatches, not invitations.
 
 ## Dependency direction
 
-**Cross-subdomain access is fine.** Repos cross subdomains freely — data access
-is not behavior. A view in one subdomain reading another subdomain's users is
-normal, not a boundary violation. The smell to watch is duplicated *behavior*
-across subdomains; the fix is an aggregate invariant (enforced at
-construction/transition) or a shared lower-level mill function, not a rule
-against cross-subdomain repo reads.
+**Cross-noun access is fine.** Repos cross nouns freely — data access is not
+behavior. A page on one noun's turf reading another noun's data is normal, not
+a boundary violation. The smell to watch is duplicated *behavior* across
+nouns; the fix is an aggregate invariant (enforced at construction/transition)
+or a shared lower-level mill function, not a rule against cross-noun repo
+reads.
 
 **Service-to-service calls are fine** when reusing real orchestration. The
 genuine smells are narrower: layering inversion (a low-level unit depending on a
@@ -237,10 +249,12 @@ unit-tested wherever it lives.
 - Port axis inside `mills/` or `specs/` (e.g. `mills/web/...`)
 - `specs` imported from `links`, `gates`, or `inits` — specs are only for mills
 - `pacts/dtos.py`, `pacts/protocols.py`, or `pacts/repos/` instead of
-  `pacts/{subdomain}.py`
+  `pacts/{noun}.py`
 - `common/` or `shared/` folder in any layer
-- `pacts/` sliced by entity while `mills/` sliced by context (or vice versa) —
-  axes must match
+- `pacts/` and `mills/` sliced on different axes (one by noun, the other by
+  entity or verb) — the mirror must match
+- A catch-all verb module (`manage.py`, `organize.py`, `misc.py`) — a cut must
+  name a real activity
 - Model and repository in the same `links` file (collapses the
   internal-vs-public boundary)
 - ORM model imported from outside `links/` (use the repo protocol from `pacts`

--- a/docs/TESTING_STRATEGY.md
+++ b/docs/TESTING_STRATEGY.md
@@ -92,7 +92,8 @@ passes unconditionally — the callback never ran, so the check cannot fail.
 Verify view→template **context contract**: views produce the right data for
 every branch.
 
-Structure: `{subdomain}/{bounded_context}/test_url_name.py`
+Structure: `{noun}/{page}/test_url_name.py` (existing directories keep
+their legacy subdomain names until renamed)
 
 Rules:
 

--- a/docs/agents/architecture.md
+++ b/docs/agents/architecture.md
@@ -5,7 +5,7 @@
 | Layer | Location | Purpose |
 | ----- | -------- | ------- |
 | pacts | `pacts.py` | Protocols, DTOs (Pydantic), errors, enums, TypedDicts |
-| specs | `specs/{subdomain}.py` | Business invariants — pure constants, no IO |
+| specs | `specs/{noun}.py` | Business invariants — pure constants, no IO |
 | mills | `mills.py` | Business logic, Django-free |
 | links | `links/` | Repositories, UoW, external clients |
 | gates | `gates/` | Views, forms, URLs, templatetags |
@@ -140,7 +140,7 @@ Services return DTOs; views render them.
 
 ### Mills layout
 
-`mills/{subdomain}.py` is promoted to a package when it crosses ~1000
+`mills/{noun}.py` is promoted to a package when it crosses ~1000
 lines. Modules slice **by service** — one view-facing service per module,
 named after its area (`mills/submissions/importing.py`, `import_log.py`,
 `field_layout.py`, `personal_data_fields.py`). A service holds the methods
@@ -158,7 +158,7 @@ Shared code splits by kind:
   never exposed on `request.services`, and it owns no transactions —
   services open `atomic()` and call engine methods inside it.
 
-`pacts/{subdomain}.py` stays a single module; each service gets its own
+`pacts/{noun}.py` stays a single module; each service gets its own
 protocol there (`ProposalImportServiceProtocol`, `ImportLogServiceProtocol`,
 `ImportFieldLayoutServiceProtocol`).
 
@@ -186,7 +186,7 @@ shape. `ServiceInjectionMiddleware` attaches `request.services` per request.
 
 Views are glue: parse forms, call services, render DTOs. They never reach
 into repos or build services themselves. Type-hint request as
-`RootRequestProtocol` (or a subdomain-specific request like `PanelRequest`):
+`RootRequestProtocol` (or a narrower request like `PanelRequest`):
 
 ```python
 def get(self, request: PanelRequest, slug: str) -> TemplateResponse:
@@ -214,7 +214,7 @@ surface — write a new mills service instead.
 ## Specs
 
 Business invariants consumed only by mills. No IO, no Django.
-Sliced by subdomain, mirroring pacts and mills:
+Sliced by noun, mirroring pacts and mills:
 
 ```python
 # specs/event.py
@@ -234,342 +234,260 @@ SESSION_LIMITS: SessionLimits = {"max_per_user": 5}
 
 ---
 
-## Subdomains and Bounded Contexts
+## Nouns
 
-The application has five subdomains. Each subdomain
-contains one or more bounded contexts with distinct
-responsibilities, URL namespaces, templates, and DTOs.
+Slice by **noun**, cut by **verb**; gates slice by **page**. A noun is a
+fat data cow: the model cluster everything else hangs off. A verb is an
+activity (`enroll`, `propose`, `schedule`, `present`) — its modules hold
+the records and logic of actions, not first-class data. No catch-all
+verbs (`manage`, `organize`): a cut must name a real activity — if you
+can't name one, the file isn't too big yet. Gates mirror the sitemap
+(a page or page group plus its action views); mills mirror the domain.
+
+The old **subdomain** / **bounded context** vocabulary is banned.
+Directory, URL, template, and test paths still carry the legacy subdomain
+names; they are renamed opportunistically, tracked by the
+`old-subdomain-loc` tingle metric. New code slices by noun.
+
+| Legacy subdomain | Noun | Scope |
+| ---------------- | ---- | ----- |
+| Chronology | event | Scheduling, venues, enrollment, public event pages |
+| Submissions | event | Proposal intake: CFP config, curation, `Session` lifecycle |
+| Crowd | user | Authentication, profiles, delegate accounts |
+| Multiverse | sphere | Sphere and concepts depending only on Sphere |
+| Notice Board | encounter | Informal gatherings decoupled from events |
+| — (RFC 0001) | party | The drużyna: the group that enrolls together |
+
+---
+
+### event
+
+The fattest noun — legacy `chronology` and `submissions` both map here,
+which dissolves the old ownership split: proposal intake writes `Session`,
+scheduling and enrollment read it, all inside one noun. Verb cuts as it
+grows: `propose` (CFP config, proposals, facilitators), `enroll`,
+`schedule` (venues, time slots, tracks, timetable), `present` (public
+pages, printing).
+
+Enrollment behaviour currently bolted onto the `Session` model
+(`enrolled_count`, `is_full`, `effective_participants_limit`,
+`is_enrollment_available`, `SessionManager.has_conflicts`) belongs in
+`enroll` mills/specs, not on the model.
+
+#### Pages: Public event pages
+
+What visitors see: event details, session list, session cards.
+
+- **URLs:** `/chronology/event/<slug>/` (namespace `chronology`)
+- **Views:** `adapters/web/django/views.py` — `EventPageView`
+- **Templates:** `templates/chronology/event.html`,
+  `_session_card.html`, `session_tags.html`
+- **DTOs:** `EventDTO`, `SessionDTO`, `SessionListItemDTO`, `TrackDTO`
+
+#### Pages: Proposal wizard
+
+The multi-step wizard through which facilitators submit session proposals.
+
+- **URLs:** `/chronology/session/propose/` (namespace `session`)
+- **Views:** `gates/web/django/chronology/views.py` —
+  `ProposeSessionPageView` and component views for each wizard step
+  (category, personal data, time slots, session details, review, submit)
+- **Templates:** `templates/chronology/propose/`
+- **Service:** `ProposeSessionService` — resolves field requirements per
+  category, creates `Facilitator`, persists `Session` and field values,
+  rate-limits by IP
+- **DTOs:** `ProposalCategoryDTO`, `SessionFieldRequirementDTO`,
+  `PersonalFieldRequirementDTO`, `TimeSlotRequirementDTO`,
+  `FacilitatorDTO`, `SessionData`
+
+#### Pages: Enrollment
+
+Session sign-ups for authenticated users and anonymous attendees;
+proposal acceptance by organizers.
+
+- **URLs:** `/chronology/session/<id>/enrollment/`,
+  `/chronology/session/<id>/accept/`, `/chronology/anonymous/`
+- **Views:** `adapters/web/django/views.py` — `SessionEnrollPageView`,
+  `SessionEnrollmentAnonymousPageView`, `ProposalAcceptPageView`,
+  `EventAnonymousActivateActionView`, `AnonymousLoadActionView`,
+  `AnonymousResetActionView`
+- **Templates:** `templates/chronology/enroll_select.html`,
+  `anonymous_enroll.html`, `anonymous_manage.html`, `accept_proposal.html`
+- **Services:** `AcceptProposalService` (transitions session → ACCEPTED,
+  creates `AgendaItem`), `AnonymousEnrollmentService` (code-based
+  anonymous user lookup)
+- **DTOs:** `EnrollmentConfigDTO`, `UserEnrollmentConfigDTO`,
+  `VirtualEnrollmentConfig`, `AgendaItemDTO`
+
+#### Pages: Panel (event-scoped)
+
+The organiser backoffice: event configuration, scheduling, venues,
+enrollment administration, intake configuration, and curation — one page
+group, no ownership split.
+
+- **URLs:** `/panel/event/<slug>/…` (namespace `panel`)
+- **Views:** `gates/web/django/chronology/panel/views/` — one module per
+  page (`proposals.py`, `facilitators.py`, `timetable.py`, `cfp.py`,
+  `personal_data_fields.py`, `session_fields.py`, `venues.py`,
+  `time_slots.py`, `tracks.py`, `event_settings.py`, `discounts.py`,
+  `print.py`, `integrations.py`, `google_docs_import.py`, …)
+- **Templates:** `templates/panel/`
+- **Service:** `PanelService` — event stats aggregation, cascade-safe
+  entity deletion, time slot overlap validation
 
 <!-- markdownlint-disable MD013 -->
 
-| Subdomain | Scope | Bounded contexts |
-| --------- | ----- | ---------------- |
-| Multiverse | Sphere and concepts depending only on Sphere | Panel |
-| Submissions | Configure the call (categories, fields, requirements) and curate proposals; owns the `Session` lifecycle (create/update) | Proposal Wizard, Panel |
-| Chronology | Events, scheduling, venues, enrollment, public pages | Public Event Pages, Enrollment, Panel |
-| Notice Board | Informal social gatherings decoupled from the formal event/session lifecycle | Encounters |
-| Crowd | Authentication, profiles, delegate accounts | Auth, Profile |
+| Area | Views | Templates |
+| ---- | ----- | --------- |
+| Proposal categories | `panel/views/cfp.py` | `cfp-*.html` |
+| Proposals / sessions | `panel/views/proposals.py` | `proposal-*.html` |
+| Personal data fields | `panel/views/personal_data_fields.py` | `personal-data-field-*.html` |
+| Session fields | `panel/views/session_fields.py` | `session-field-*.html` |
+| Facilitators | `panel/views/facilitators.py` | `facilitator-*.html` |
+| Event settings | `panel/views/event_settings.py` | `settings.html` |
+| Time slots | `panel/views/time_slots.py` | `time-slot*.html` |
+| Tracks | `panel/views/tracks.py` | `track-*.html` |
+| Venues (Space tree) | `panel/views/venues.py` | `spaces.html`, `_space_tree_node.html`, `space-*.html` |
 
 <!-- markdownlint-enable MD013 -->
 
 ---
 
-### Multiverse
+### sphere
 
-Sphere-scoped configuration shared across the events
-that live under a sphere. Holds `Sphere` itself plus
-anything that depends only on Sphere (no Event coupling).
+Legacy name: `multiverse`. Sphere-scoped configuration shared across the
+events that live under a sphere. Holds `Sphere` itself plus anything that
+depends only on Sphere (no Event coupling).
 
-#### Bounded Context: Panel (Multiverse)
+#### Pages: Panel (sphere-scoped)
 
-Sphere-scoped backoffice for sphere managers. Parallel
-to `chronology/panel` (which is event-scoped) and uses
-its own access mixin keyed off `current_sphere_id`
-without an `EventContextMixin`.
+Sphere-scoped backoffice for sphere managers. Parallel to the event panel
+and uses its own access mixin keyed off `current_sphere_id` without an
+`EventContextMixin`.
 
-- **URLs:** `/multiverse/sphere/<slug>/…`
-  (namespace `multiverse:panel`)
+- **URLs:** `/multiverse/sphere/<slug>/…` (namespace `multiverse:panel`)
 - **Views:** `gates/web/django/multiverse/panel/views/…`
 - **Templates:** `templates/multiverse/panel/`
-- **Pacts/Mills/Specs:** `pacts/multiverse.py`,
-  `mills/multiverse.py`, `specs/multiverse.py`
-  (split into `multiverse/{context}.py` when big)
-- **Access:** `SphereAccessMixin` (sphere-manager check
-  via `request.di.uow.spheres.is_manager`)
+- **Pacts/Mills/Specs:** `pacts/multiverse.py`, `mills/multiverse.py`
+  (legacy module names; new cuts use `sphere`)
+- **Access:** `SphereAccessMixin` (sphere-manager check via
+  `request.di.uow.spheres.is_manager`)
 - **First feature:** sphere-scoped import-connections CRUD
   ("Połączenia importu" subpage)
 
 `Sphere` ORM models and repositories continue to live in
-`links/db/django/models.py` and
-`links/db/django/repositories.py` per the split-when-big
-rule; they are not moved into a multiverse-named file.
+`links/db/django/models.py` and `links/db/django/repositories.py` per the
+split-when-big rule; they are not moved into a sphere-named file.
 
 ---
 
-### Submissions
+### encounter
 
-The front door for programme content: configure *what*
-is asked for and curate *what comes in*. Owns the
-`Session` lifecycle — proposals are created and updated
-here — plus the configurable intake forms (proposal
-categories, personal-data fields, session fields, their
-requirements) and facilitators.
+Legacy name: `notice_board`. Informal social gathering system, decoupled
+from the formal event/session lifecycle.
 
-The handoff to Chronology is proposal **acceptance**:
-`AcceptProposalService` transitions a `Session` to
-ACCEPTED and creates the `AgendaItem` that places it in
-space and time. After acceptance Chronology reads
-`Session` for scheduling and enrollment; Submissions
-keeps ownership of writes to the proposal itself.
+#### Pages: Encounters
 
-Enrollment behaviour currently bolted onto the `Session`
-model (`enrolled_count`, `is_full`,
-`effective_participants_limit`, `is_enrollment_available`,
-`SessionManager.has_conflicts`) is a Chronology concern
-and belongs in Chronology `mills`/`specs`, not on the
-Submissions-owned model.
-
-#### Bounded Context: Proposal Wizard
-
-The multi-step wizard through which facilitators submit
-session proposals.
-
-- **URLs:** `/chronology/session/propose/`
-  (namespace `session`)
-- **Views:** `gates/web/django/chronology/views.py` —
-  `ProposeSessionPageView` and component views for each
-  wizard step (category, personal data, time slots,
-  session details, review, submit)
-- **Templates:** `templates/chronology/propose/`
-- **Service:** `ProposeSessionService` — resolves field
-  requirements per category, creates `Facilitator`,
-  persists `Session` and field values, rate-limits by IP
-- **DTOs:** `ProposalCategoryDTO`,
-  `SessionFieldRequirementDTO`,
-  `PersonalFieldRequirementDTO`,
-  `TimeSlotRequirementDTO`, `FacilitatorDTO`,
-  `SessionData`
-
-#### Bounded Context: Panel (Submissions)
-
-The intake-configuration and curation areas of the
-organiser backoffice. They share the `panel:` namespace
-and `gates/web/django/panel.py` view file with Panel
-(Chronology); the split is by subdomain ownership, not
-by URL or file.
-
-<!-- markdownlint-disable MD013 -->
-
-| Area | Views | Templates |
-| ---- | ----- | --------- |
-| Proposal categories | `CFPPageView` | `cfp-*.html` |
-| Proposals / sessions | `ProposalsPageView` | `proposal-*.html` |
-| Personal data fields | `PersonalDataFieldsPageView` | `personal-data-field-*.html` |
-| Session fields | `SessionFieldsPageView` | `session-field-*.html` |
-| Facilitators | `FacilitatorsPageView` | `facilitator-*.html` |
-
-<!-- markdownlint-enable MD013 -->
-
----
-
-### Chronology
-
-Manages events, scheduling, venues, enrollment, and the
-public event pages. Consumes `Session` (owned by
-Submissions) for scheduling and enrollment.
-
-#### Bounded Context: Public Event Pages
-
-What visitors see: event details, session list,
-session cards.
-
-- **URLs:** `/chronology/event/<slug>/`
-  (namespace `chronology`)
-- **Views:** `adapters/web/django/views.py` —
-  `EventPageView`
-- **Templates:** `templates/chronology/event.html`,
-  `_session_card.html`, `session_tags.html`
-- **DTOs:** `EventDTO`, `SessionDTO`,
-  `SessionListItemDTO`, `TrackDTO`
-
-#### Bounded Context: Enrollment
-
-Session sign-ups for authenticated users and
-anonymous attendees; proposal acceptance by
-organizers.
-
-- **URLs:**
-  `/chronology/session/<id>/enrollment/`,
-  `/chronology/session/<id>/accept/`,
-  `/chronology/anonymous/`
-- **Views:** `adapters/web/django/views.py` —
-  `SessionEnrollPageView`,
-  `SessionEnrollmentAnonymousPageView`,
-  `ProposalAcceptPageView`,
-  `EventAnonymousActivateActionView`,
-  `AnonymousLoadActionView`,
-  `AnonymousResetActionView`
-- **Templates:**
-  `templates/chronology/enroll_select.html`,
-  `anonymous_enroll.html`,
-  `anonymous_manage.html`,
-  `accept_proposal.html`
-- **Services:** `AcceptProposalService`
-  (transitions session → ACCEPTED, creates
-  `AgendaItem`), `AnonymousEnrollmentService`
-  (code-based anonymous user lookup)
-- **DTOs:** `EnrollmentConfigDTO`,
-  `UserEnrollmentConfigDTO`,
-  `VirtualEnrollmentConfig`, `AgendaItemDTO`
-
-#### Bounded Context: Panel (Chronology)
-
-The backoffice for event organisers. Covers event
-configuration, scheduling, venues, and enrollment
-administration. Proposal-configuration areas live in
-Panel (Submissions) above — same `panel:` namespace and
-view file, different subdomain.
-
-- **URLs:** `/panel/event/<slug>/…`
-  (namespace `panel`)
-- **Views:** `gates/web/django/panel.py`
-- **Templates:** `templates/panel/`
-- **Service:** `PanelService` — event stats
-  aggregation, cascade-safe entity deletion,
-  time slot overlap validation
-
-Internal areas (Chronology-owned):
-
-<!-- markdownlint-disable MD013 -->
-
-| Area | Views | Templates |
-| ---- | ----- | --------- |
-| Event settings | `EventSettingsPageView` | `settings.html` |
-| Time slots | `TimeSlotsPageView` | `time-slot*.html` |
-| Tracks | `TracksPageView` | `track-*.html` |
-| Venues (Space tree) | `SpacesPageView` + `Space*` CRUD | `spaces.html`, `_space_tree_node.html`, `space-*.html` |
-
-<!-- markdownlint-enable MD013 -->
-
----
-
-### Notice Board
-
-Informal social gathering system, decoupled from
-the formal event/session lifecycle.
-
-#### Bounded Context: Encounters
-
-Users create one-off encounters (game sessions,
-meetups) and others RSVP to join them. Includes
-the public share page, RSVP actions, and calendar
+Users create one-off encounters (game sessions, meetups) and others RSVP
+to join them. Includes the public share page, RSVP actions, and calendar
 exports.
 
-- **URLs:** `/encounters/` (authenticated),
-  `/e/<share_code>/` (public,
+- **URLs:** `/encounters/` (authenticated), `/e/<share_code>/` (public,
   namespace `notice-board`)
-- **Views:**
-  `gates/web/django/notice_board/views.py` —
-  `EncountersIndexPageView`,
-  `EncounterCreatePageView`,
-  `EncounterEditPageView`,
-  `EncounterDeleteActionView`,
-  `EncounterDetailPageView`,
-  `EncounterRSVPActionView`,
-  `EncounterCancelRSVPActionView`,
-  `EncounterQrView`, `EncounterIcsView`
+- **Views:** `gates/web/django/notice_board/views.py` —
+  `EncountersIndexPageView`, `EncounterCreatePageView`,
+  `EncounterEditPageView`, `EncounterDeleteActionView`,
+  `EncounterDetailPageView`, `EncounterRSVPActionView`,
+  `EncounterCancelRSVPActionView`, `EncounterQrView`, `EncounterIcsView`
 - **Templates:** `templates/notice_board/`
-- **Service:** `EncounterService` —
-  `build_detail()` (encounter + RSVPs +
-  computed availability), `build_index()`
-  (upcoming/past split, own vs RSVP'd)
-- **DTOs:** `EncounterDTO`,
-  `EncounterRSVPDTO`,
-  `EncounterDetailResult`,
-  `EncounterIndexItem`,
-  `EncounterIndexResult`, `EncounterData`
-- **Repositories:** `EncounterRepository`,
-  `EncounterRSVPRepository`
-- **External integrations:** Google Calendar
-  and Outlook deep links, iCalendar `.ics`
-  export, QR code generation
+- **Service:** `EncounterService` — `build_detail()` (encounter + RSVPs +
+  computed availability), `build_index()` (upcoming/past split, own vs
+  RSVP'd)
+- **DTOs:** `EncounterDTO`, `EncounterRSVPDTO`, `EncounterDetailResult`,
+  `EncounterIndexItem`, `EncounterIndexResult`, `EncounterData`
+- **Repositories:** `EncounterRepository`, `EncounterRSVPRepository`
+- **External integrations:** Google Calendar and Outlook deep links,
+  iCalendar `.ics` export, QR code generation
 
 ---
 
-### Crowd
+### user
 
-Authentication, user profiles, and delegate
+Legacy name: `crowd`. Authentication, user profiles, and delegate
 accounts.
 
-#### Bounded Context: Auth
+#### Pages: Auth
 
-Auth0 OAuth login/logout. State token management
-and JWT validation; user upsert on callback.
+Auth0 OAuth login/logout. State token management and JWT validation;
+user upsert on callback.
 
-- **URLs:** `/crowd/auth0/`
-  (namespace `auth0`)
-- **Views:** `gates/web/django/crowd/auth.py` —
-  `Auth0LoginActionView`,
-  `Auth0LoginCallbackActionView`,
-  `Auth0LogoutActionView`,
-  `Auth0LogoutRedirectActionView`,
-  `LoginRequiredPageView`
-- **Templates:**
-  `templates/crowd/login_required.html`
-- **Service:** `CrowdAuthService`
-  (`request.services.crowd_auth`) — user
-  provisioning on callback, identity sync,
-  sphere-domain checks
-- **External integration:** Auth0 PKCE/state
-  OAuth flow
+- **URLs:** `/crowd/auth0/` (namespace `auth0`)
+- **Views:** `gates/web/django/crowd/auth.py` — `Auth0LoginActionView`,
+  `Auth0LoginCallbackActionView`, `Auth0LogoutActionView`,
+  `Auth0LogoutRedirectActionView`, `LoginRequiredPageView`
+- **Templates:** `templates/crowd/login_required.html`
+- **Service:** `CrowdAuthService` (`request.services.crowd_auth`) — user
+  provisioning on callback, identity sync, sphere-domain checks
+- **External integration:** Auth0 PKCE/state OAuth flow
 
-#### Bounded Context: Profile
+#### Pages: Profile
 
-User profile management and delegate (connected)
-accounts.
+User profile management and delegate (connected) accounts.
 
-- **URLs:** `/crowd/profile/`,
-  `/crowd/profile/connected-users/` and
+- **URLs:** `/crowd/profile/`, `/crowd/profile/connected-users/` and
   `/crowd/claim/<token>/`
-- **Views:** `gates/web/django/crowd/profile.py` —
-  `ProfilePageView`,
-  `ProfileAvatarPageView`,
-  `ProfileShadowbanPageView`,
+- **Views:** `gates/web/django/crowd/profile.py` — `ProfilePageView`,
+  `ProfileAvatarPageView`, `ProfileShadowbanPageView`,
   `ProfileConnectedUsersPageView`,
   `ProfileConnectedUserUpdateActionView`,
   `ProfileConnectedUserDeleteActionView`,
-  `ProfileConnectedUserClaimLinkActionView`,
-  `ClaimPageView`
-- **Templates:**
-  `templates/crowd/user/edit.html`,
-  `avatar.html`, `parties.html`,
-  `shadowbans.html`, `crowd/claim.html`
-- **Services:** `ProfileService` (self-profile
-  reads/updates, avatar, confirmed-participation
-  count), `CompanionsService` (connected-user CRUD),
-  `ClaimService` (issue/redeem claim links),
-  `ShadowbanService`
-- **DTOs:** `UserDTO`, `ConnectedUserDTO`,
-  `AvatarPageDTO`, `UserData`, `UserType`
-  (`ACTIVE` / `CONNECTED` / `ANONYMOUS`)
-- **Repositories:** `UserRepository`,
-  `ConnectedUserRepository`,
+  `ProfileConnectedUserClaimLinkActionView`, `ClaimPageView`
+- **Templates:** `templates/crowd/user/edit.html`, `avatar.html`,
+  `parties.html`, `shadowbans.html`, `crowd/claim.html`
+- **Services:** `ProfileService` (self-profile reads/updates, avatar,
+  confirmed-participation count), `CompanionsService` (connected-user
+  CRUD), `ClaimService` (issue/redeem claim links), `ShadowbanService`
+- **DTOs:** `UserDTO`, `ConnectedUserDTO`, `AvatarPageDTO`, `UserData`,
+  `UserType` (`ACTIVE` / `CONNECTED` / `ANONYMOUS`)
+- **Repositories:** `UserRepository`, `ConnectedUserRepository`,
   `ProfileStatsRepository`
-- **External integration:**
-  `MembershipApiClient` (`links/ticket_api.py`)
-  — fetches enrollment quotas; Gravatar
-  (`links/gravatar.py`) — email-hash avatar
+- **External integration:** `MembershipApiClient` (`links/ticket_api.py`)
+  — fetches enrollment quotas; Gravatar (`links/gravatar.py`) —
+  email-hash avatar
 
 ---
 
-## Subdomain → Models
+### party
 
-ORM models — in `links/db/django/models.py` — mapped
-to the subdomain that owns them. Subdomain-level only, no
-bounded-context breakdown.
+The drużyna: the group that enrolls together. Party CRUD, membership
+invites, consent, and the companion (login-less member) lifecycle. See
+RFC 0001. Already noun-named: `pacts/party.py`, `mills/party.py`,
+`links/db/django/party.py`.
+
+---
+
+## Noun → Models
+
+ORM models — in `links/db/django/models.py` — mapped to the noun that
+owns them.
 
 <!-- markdownlint-disable MD013 -->
 
-| Subdomain | Models |
-| --------- | ------ |
-| Crowd | `User` |
-| Multiverse | `Sphere`, `Connection` |
-| Notice Board | `Encounter`, `EncounterRSVP` |
-| Submissions | `Session`, `ProposalCategory`, `EventProposalSettings`, `Facilitator`, `PersonalDataField`, `PersonalDataFieldOption`, `PersonalDataFieldRequirement`, `PersonalDataFieldValue`, `SessionField`, `SessionFieldOption`, `SessionFieldRequirement`, `SessionFieldValue`, `TimeSlotRequirement` |
-| Chronology | `Event`, `EventSettings`, `Venue`, `Area`, `Space`, `TimeSlot`, `Track`, `AgendaItem`, `ScheduleChangeLog`, `EnrollmentConfig`, `UserEnrollmentConfig`, `DomainEnrollmentConfig`, `SessionParticipation` |
+| Noun | Models |
+| ---- | ------ |
+| user | `User` |
+| sphere | `Sphere`, `Connection` |
+| encounter | `Encounter`, `EncounterRSVP` |
+| party | `Party`, `PartyMembership` |
+| event | `Event`, `EventSettings`, `EventProposalSettings`, `Session`, `ProposalCategory`, `Facilitator`, `PersonalDataField`, `PersonalDataFieldOption`, `PersonalDataFieldRequirement`, `PersonalDataFieldValue`, `SessionField`, `SessionFieldOption`, `SessionFieldRequirement`, `SessionFieldValue`, `TimeSlotRequirement`, `Venue`, `Area`, `Space`, `TimeSlot`, `Track`, `AgendaItem`, `ScheduleChangeLog`, `EnrollmentConfig`, `UserEnrollmentConfig`, `DomainEnrollmentConfig`, `SessionParticipation` |
 
 <!-- markdownlint-enable MD013 -->
 
-Boundary notes:
+Notes:
 
-- `Session` is owned by Submissions (it creates and
-  updates the row) and read across the boundary by
-  Chronology. `AgendaItem`, `SessionParticipation` and
-  `ScheduleChangeLog` (Chronology) FK into `Session`;
-  `Session`'s M2Ms reference `TimeSlot` and `Track`
-  (Chronology).
-- Enrollment is Chronology: the `SessionParticipation`
-  and `*EnrollmentConfig` models, plus the enrollment
-  behaviour still living on the `Session` model.
-- `Tag` / `TagCategory` are slated for deletion and are
-  intentionally absent from this mapping.
+- The old Submissions/Chronology ownership split over `Session` is gone —
+  proposal intake writes it, scheduling and enrollment read it, all
+  inside the event noun. The remaining debt is the enrollment behaviour
+  still living on the `Session` model (see the event section).
+- `Tag` / `TagCategory` are slated for deletion and are intentionally
+  absent from this mapping.

--- a/docs/agents/services-migration.md
+++ b/docs/agents/services-migration.md
@@ -5,12 +5,12 @@ the new `request.services.<service_name>` shape. Each file is its own PR.
 
 ## Recipe
 
-1. **Define the service protocol** in `pacts/<subdomain>.py`. Include any
+1. **Define the service protocol** in `pacts/<noun>.py`. Include any
    read DTOs the service returns (e.g. form-context aggregates that bundle
    what a template needs). Add a `@property` for the service to
    `ServicesProtocol` in `pacts/services.py`.
 
-2. **Implement the service** in `mills/<subdomain>.py`. The constructor
+2. **Implement the service** in `mills/<noun>.py`. The constructor
    takes a `TransactionProtocol` plus the specific repo protocols the
    service touches — never the full UoW. Methods return DTOs (not models,
    not raw dicts). Multi-repo writes happen inside

--- a/docs/features/README.md
+++ b/docs/features/README.md
@@ -9,8 +9,8 @@ describes a feature as one or more user stories.
 docs/features/
   README.md                                 # this file
   CHECKLIST.md                              # refinement triage list
-  drafts/<subdomain>/<context>/<name>.md    # status: draft
-  <subdomain>/<context>/<name>.md           # status: in-progress or done
+  drafts/<noun>/<verb>/<name>.md            # status: draft
+  <noun>/<verb>/<name>.md                   # status: in-progress or done
 ```
 
 Files live under `drafts/` while their status is `draft`. The moment a
@@ -18,7 +18,10 @@ feature is fired against, it moves out of `drafts/` into the matching
 path at the top level — `drafts/foo/bar/baz.md` becomes `foo/bar/baz.md`.
 This makes the status of every feature obvious from a directory listing.
 
-When a context folder grows enough that you can name the sub-clusters
+Existing folders keep their legacy subdomain names until renamed; new
+folders use noun/verb names (see `docs/agents/architecture.md`).
+
+When a folder grows enough that you can name the sub-clusters
 (e.g. "the read-side stuff", "the conflict-resolution stuff"), split it.
 Until the names are obvious, leave it flat.
 

--- a/docs/refactors/README.md
+++ b/docs/refactors/README.md
@@ -14,7 +14,7 @@ lands; keep the table below in sync._
 | - | -------- | ------ | ----------------- |
 | 1 | [GLIMPSE strangler: `adapters/` → layers](glimpse-strangler.md) | 🟡 in progress | Migrate Public Event Pages + Enrollment views out of `views.py` |
 | 2 | [UoW → Services (`request.di.uow` → `request.services`)](services-di.md) | 🟡 early | Finish `timetable` (promote `TimetableService` to `request.services`), then `time_slots.py` |
-| 3 | [Legacy module split (`*/legacy.py` → per-subdomain)](pacts-mills-split.md) | 🟡 in progress | Carve `notice_board` DTOs/services out of `legacy.py` |
+| 3 | [Legacy module split (`*/legacy.py` → per-noun)](pacts-mills-split.md) | 🟡 in progress | Carve `encounter` DTOs/services out of `legacy.py` |
 | 4 | [`links/db/django` layout (split fat repositories)](links-db-layout.md) | ✅ done | — (repositories split, `adapters/db/` relocated to `links/db/`) |
 | 5 | [Panel object-scope authorization (IDOR)](panel-object-scope-authz.md) | 🟢 active branch | Audit `venues.py` and `proposals.py`, then `facilitators.py` |
 | 6 | [HTMX adoption (frontend)](htmx-adoption.md) | 🟡 in progress | Convert one more multi-step/list page to HTMX partials |
@@ -31,7 +31,7 @@ angles, and they unblock each other:
 ```text
 1 strangler      moves code out of adapters/ into the layered tree
 2 services-di    replaces the UoW bag with per-service repo injection
-3 module-split   breaks the legacy.py facades into per-subdomain modules
+3 module-split   breaks the legacy.py facades into per-noun modules
 4 links-db       splits the fat repository/model files once they land in links
 ```
 
@@ -49,7 +49,7 @@ layering work.
 - [target-architecture.md](target-architecture.md) — the target shape and
   rationale for refactors 1–4 (the GLIMPSE → hexagonal direction).
 - [docs/agents/architecture.md](../agents/architecture.md) — current layer map,
-  import rules, subdomain/bounded-context catalogue.
+  import rules, noun catalogue.
 - [docs/agents/services-migration.md](../agents/services-migration.md) — the
   per-file recipe for refactor 2.
 - [TODO.md](../../TODO.md) — the kanban; GLIMPSE-tagged items map to 1–4.

--- a/docs/refactors/pacts-mills-split.md
+++ b/docs/refactors/pacts-mills-split.md
@@ -1,4 +1,4 @@
-# 3. Legacy module split (`*/legacy.py` → per-subdomain)
+# 3. Legacy module split (`*/legacy.py` → per-noun)
 
 **Status:** 🟡 in progress
 **Tracked in TODO:** "Split mills/pacts/inits into packages per GLIMPSE layer
@@ -7,32 +7,35 @@ rules" (GLIMPSE)
 ## Goal
 
 Break the catch-all `legacy.py` modules in `pacts/` and `mills/` into
-per-subdomain files (`submissions`, `chronology`, `multiverse`, `crowd`,
-`notice_board`),
+per-noun files (`event`, `user`, `sphere`, `encounter`, `party`),
 mirrored across the two layers, and fill in `specs/` with the business
 invariants those mills currently inline. Retire the wildcard facades.
+New carves use noun names; modules already carved under legacy subdomain
+names (`chronology`, `multiverse`, `submissions`, `crowd`) keep them until
+an opportunistic rename — the `old-subdomain-loc` tingle metric tracks
+that debt.
 
 ## Why
 
 `pacts/__init__.py` and `mills/__init__.py` are `from ...legacy import *`
 facades — the pre-existing legacy exception in CLAUDE.md. They keep the whole
-domain in one undifferentiated namespace, which works against the
-subdomain/bounded-context map and against the ~12-members-per-level rule. The
-target is `pacts/{subdomain}.py ↔ mills/{subdomain}.py`, split into
-`{subdomain}/{context}.py` only when a subdomain grows fat.
+domain in one undifferentiated namespace, which works against the noun map
+and against the ~12-members-per-level rule. The target is
+`pacts/{noun}.py ↔ mills/{noun}.py`, cut into `{noun}/{verb}.py` only when
+a noun grows fat.
 
 ## Current state
 
 **Still in the catch-all `legacy.py` modules:**
 
 - `pacts/legacy.py` — the bulk of the DTOs, write `TypedDict`s, enums and
-  errors for every subdomain (`EncounterDTO`, `SessionDTO`, `EventDTO`,
+  errors for every noun (`EncounterDTO`, `SessionDTO`, `EventDTO`,
   `UserDTO`, `SpaceDTO`, `TrackDTO`, `NotFoundError`, …).
 - `mills/legacy.py` — `EncounterService`, `ProposeSessionService`,
   `PanelService`, `AcceptProposalService`, `AnonymousEnrollmentService`,
   `check_proposal_rate_limit`, and the calendar/ICS/share-code helpers.
 
-**Already carved into per-subdomain modules:**
+**Already carved (still under legacy subdomain names):**
 
 - `pacts/chronology.py` — timetable + CFP DTOs and the
   `CFPPersonalDataFieldServiceProtocol` (`TimetableGridDTO`, `ConflictDTO`,
@@ -58,13 +61,13 @@ symbol still physically lives in `legacy.py`.
 
 ## Next step
 
-Carve the **Notice Board / Encounters** slice out of `legacy.py`, since
-Encounters is already fully migrated in `gates`/`links` and is self-contained:
+Carve the **encounter** noun out of `legacy.py`, since it is already fully
+migrated in `gates`/`links` and is self-contained:
 
-1. Create `pacts/notice_board.py`; move `EncounterDTO`, `EncounterRSVPDTO`,
+1. Create `pacts/encounter.py`; move `EncounterDTO`, `EncounterRSVPDTO`,
    `EncounterData`, `EncounterDetailResult`, `EncounterIndexItem`,
    `EncounterIndexResult` and related types out of `pacts/legacy.py`.
-2. Create `mills/notice_board.py`; move `EncounterService` and the calendar /
+2. Create `mills/encounter.py`; move `EncounterService` and the calendar /
    ICS / share-code helpers (`generate_ics_content`, `google_calendar_url`,
    `outlook_calendar_url`, `generate_share_code`, `render_markdown`).
 3. Update imports at the use sites (`gates/web/django/notice_board/`,
@@ -72,20 +75,19 @@ Encounters is already fully migrated in `gates`/`links` and is self-contained:
    leaning on the `__init__` facade for the moved symbols.
 4. Run `mise run check` (importlinter) + `mise run test:py`.
 
-Encounters is the cleanest first cut because nothing else depends on its DTOs.
-Submissions and Chronology are the fat ones. Submissions is now its own
-subdomain (it owns the `Session` lifecycle): carve `pacts/submissions.py ↔
-mills/submissions.py` for proposals, sessions, categories, fields, requirements
-and facilitators — its contracts currently live in `pacts/chronology.py` /
-`mills/chronology.py` and move out when carved. Split what remains of Chronology
-per bounded context (Enrollment / Panel / Public). Both only after the smaller
-subdomains are out.
+Encounter is the cleanest first cut because nothing else depends on its DTOs.
+The **event** noun (legacy `chronology` + `submissions`) is the fat one:
+carve it out of `legacy.py` by verb — `propose` (proposals, categories,
+fields, requirements, facilitators), `enroll`, `schedule`, `present` — rather
+than into one giant `pacts/event.py`. Contracts currently parked in
+`pacts/chronology.py` / `mills/chronology.py` move into the verb cuts as they
+are carved. Event goes last, after the smaller nouns are out.
 
 ## Definition of done
 
 - `pacts/legacy.py` and `mills/legacy.py` are gone; `__init__.py` files are
   empty (no wildcard re-exports), per the CLAUDE.md default.
-- Each subdomain has matching `pacts/` and `mills/` modules, split by context
+- Each noun has matching `pacts/` and `mills/` modules, cut by verb
   where the ~12-members rule demands it.
 - `specs/` holds the invariants currently hard-coded inside mills (e.g. rate
   limits, session caps) and is imported only by `mills`.

--- a/docs/refactors/target-architecture.md
+++ b/docs/refactors/target-architecture.md
@@ -3,7 +3,7 @@
 ## Direction
 
 GLIMPSE already has all the structural pieces for hexagonal. The evolution is
-two independent changes that can be applied per bounded context incrementally,
+two independent changes that can be applied per noun incrementally,
 with the first landing as a strangler fig so no view sees both shapes at once.
 
 ---
@@ -63,21 +63,21 @@ inside a `chronology` bucket, then `panel` inside `chronology`, both
 flattened).
 
 **Rule of thumb**: a single namespace level holds up to ~12 members; beyond
-that, split into sub-buckets grouped by subdomain or bounded context.
-Applies to the repo registry, the services tree, and `pacts` subdomain
+that, split into sub-buckets grouped by noun or verb.
+Applies to the repo registry, the services tree, and `pacts` noun
 modules alike. Until the count crosses the threshold, names like
 `personal_data_fields` or `proposals` are findable enough on their own.
 
 A folder must contain at least 2 files before it exists. Reverse and
 flatten the moment a bucket drops back to a single leaf.
 
-### Cross-subdomain access is fine
+### Cross-noun access is fine
 
-Repos cross subdomains freely — data access is not behavior. Enrollment
-reading `crowd.users` is normal and not a boundary violation. The smell to
-watch is duplicated *behavior* across subdomains; the fix for that is an
+Repos cross nouns freely — data access is not behavior. Enrollment
+reading user repos is normal and not a boundary violation. The smell to
+watch is duplicated *behavior* across nouns; the fix for that is an
 aggregate invariant (preferred — enforced at construction/transition) or a
-shared lower-level mill function, not a rule against cross-subdomain repo
+shared lower-level mill function, not a rule against cross-noun repo
 access.
 
 Service-to-service calls are also fine when reusing real orchestration. The
@@ -87,9 +87,9 @@ another for one trivial read it could do via a repo).
 
 ### How (per file)
 
-1. Add the service protocol + needed DTOs to `pacts/{subdomain}.py`. Add
+1. Add the service protocol + needed DTOs to `pacts/{noun}.py`. Add
    the property to `ServicesProtocol` in `pacts/services.py`.
-2. Implement the service in `mills/{subdomain}.py` — constructor takes
+2. Implement the service in `mills/{noun}.py` — constructor takes
    specific repo protocols and `TransactionProtocol`.
 3. Add the leaf as `@cached_property` on `Services` in `inits/services.py`.
    Add any new repo leaves to `inits/repositories.py`.
@@ -121,7 +121,7 @@ moved. Don't pull them in preemptively.
 
 ---
 
-## Change 2: Pacts restructured by subdomain/context
+## Change 2: Pacts restructured by noun/verb
 
 ### Pacts current state
 
@@ -135,14 +135,14 @@ layer sitting below business logic, which is an inversion.
 
 ```text
 pacts/
-  {subdomain}.py                      # flat when subdomain is small
-  {subdomain}/{bounded_context}.py    # split when subdomain grows fat
+  {noun}.py             # flat while the noun is small
+  {noun}/{verb}.py      # cut by verb when the noun grows fat
 mills/
-  {subdomain}.py                      # same axis — mirror pacts
-  {subdomain}/{bounded_context}.py
+  {noun}.py             # same axis — mirror pacts
+  {noun}/{verb}.py
 ```
 
-Each pacts module holds whatever belongs to that subdomain/context at the
+Each pacts module holds whatever belongs to that noun (or verb cut) at the
 boundary: DTOs, write TypedDicts, repo protocols, service protocols, errors.
 Split by domain concern, not by technical kind (no `repos/`, `services/`,
 `clients/` directories). Same ~12-members-per-level rule of thumb applies.
@@ -176,12 +176,12 @@ once the distinction is clear in the code.
 ## Symmetry after both changes
 
 ```text
-pacts/{subdomain}[/{context}]   ↔  mills/{subdomain}[/{context}]
-specs/{subdomain}.py               pure invariants, used only by mills
-inits/repositories.py              flat ≤12/level, internal only
-inits/services.py                  flat ≤12/level, as request.services
-links/{port}/{adapter}/{entity}    implements repo protocols from pacts
-links/{port}/{adapter}             implements client protocols from pacts
+pacts/{noun}[/{verb}]   ↔  mills/{noun}[/{verb}]
+specs/{noun}.py            pure invariants, used only by mills
+inits/repositories.py      flat ≤12/level, internal only
+inits/services.py          flat ≤12/level, as request.services
+links/{port}/{adapter}/{kind}   implements repo protocols from pacts
+links/{port}/{adapter}          implements client protocols from pacts
 ```
 
 `gates` touches only `pacts` protocols and `request.services`. `mills` owns

--- a/tingle.toml
+++ b/tingle.toml
@@ -14,6 +14,20 @@ include = ["src/ludamus/adapters/**/*.py", "src/**/legacy.py"]
 [ranges.gates]
 include = ["src/ludamus/gates/**/*.py"]
 
+[ranges.old-subdomain-modules]
+include = [
+  "src/ludamus/**/chronology.py",
+  "src/ludamus/**/chronology/**/*.py",
+  "src/ludamus/**/submissions.py",
+  "src/ludamus/**/submissions/**/*.py",
+  "src/ludamus/**/multiverse.py",
+  "src/ludamus/**/multiverse/**/*.py",
+  "src/ludamus/**/crowd.py",
+  "src/ludamus/**/crowd/**/*.py",
+  "src/ludamus/**/notice_board.py",
+  "src/ludamus/**/notice_board/**/*.py",
+]
+
 [ranges.python-tests]
 include = ["tests/**/*.py"]
 
@@ -186,6 +200,14 @@ name = "legacy-loc"
 type = "line_count"
 group = "refactoring"
 ranges = ["legacy-code"]
+
+# Old subdomain names (noun/verb migration): chronology+submissions -> event,
+# crowd -> user, multiverse -> sphere, notice_board -> encounter
+[[metrics]]
+name = "old-subdomain-loc"
+type = "line_count"
+group = "refactoring"
+ranges = ["old-subdomain-modules"]
 
 [[metrics]]
 name = "script-tags"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated architecture and migration guidance to organize modules by nouns and verbs instead of subdomains and bounded contexts.
  - Revised directory examples for services, specifications, views, features, and refactors.
  - Added noun-based slicing rules, mapping guidance, symmetry expectations, and legacy naming notes.
  - Updated testing documentation with noun/page-based view test paths.

- **Refactor Tracking**
  - Added metrics and tracking for remaining legacy subdomain-based modules.
  - Documented the planned migration of legacy modules into noun-specific service areas.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->