### PR TITLE
test(panel): use assert_response in timetable problems page tests

### DIFF
--- a/tests/integration/web/panel/test_timetable_problems_page.py
+++ b/tests/integration/web/panel/test_timetable_problems_page.py
@@ -5,6 +5,13 @@ from django.contrib import messages
 from django.urls import reverse
 
 from ludamus.pacts import EventDTO
+from ludamus.pacts.chronology import (
+    ConflictDTO,
+    ConflictSeverity,
+    ConflictType,
+    PreferredSlotRangeDTO,
+    PreferredSlotViolationDTO,
+)
 from tests.integration.conftest import (
     AgendaItemFactory,
     SessionFactory,
@@ -14,6 +21,14 @@ from tests.integration.conftest import (
 from tests.integration.utils import assert_response
 
 PERMISSION_ERROR = "You don't have permission to access the backoffice panel."
+ONE_SCHEDULED_SESSION_STATS = {
+    "hosts_count": 1,
+    "pending_proposals": 1,
+    "rooms_count": 1,
+    "scheduled_sessions": 1,
+    "total_proposals": 1,
+    "total_sessions": 2,
+}
 
 
 class TestTimetableProblemsPageView:
@@ -22,6 +37,30 @@ class TestTimetableProblemsPageView:
     @staticmethod
     def get_url(event):
         return reverse("panel:timetable-problems", kwargs={"slug": event.slug})
+
+    @staticmethod
+    def expected_context(event, *, stats, conflicts_grouped, slot_violations):
+        return {
+            "current_event": EventDTO.model_validate(event),
+            "events": [EventDTO.model_validate(event)],
+            "is_proposal_active": False,
+            "stats": stats,
+            "active_nav": "timetable",
+            "conflicts_grouped": conflicts_grouped,
+            "slot_violations": slot_violations,
+            "slug": event.slug,
+            "tab_urls": {
+                "timetable": reverse("panel:timetable", kwargs={"slug": event.slug}),
+                "log": reverse("panel:timetable-log", kwargs={"slug": event.slug}),
+                "overview": reverse(
+                    "panel:timetable-overview", kwargs={"slug": event.slug}
+                ),
+                "problems": reverse(
+                    "panel:timetable-problems", kwargs={"slug": event.slug}
+                ),
+            },
+            "active_tab": "problems",
+        }
 
     def test_redirects_anonymous_user_to_login(self, client, event):
         url = self.get_url(event)
@@ -68,11 +107,9 @@ class TestTimetableProblemsPageView:
             response,
             HTTPStatus.OK,
             template_name="panel/timetable-problems.html",
-            context_data={
-                "current_event": EventDTO.model_validate(event),
-                "events": [EventDTO.model_validate(event)],
-                "is_proposal_active": False,
-                "stats": {
+            context_data=self.expected_context(
+                event,
+                stats={
                     "hosts_count": 0,
                     "pending_proposals": 0,
                     "rooms_count": 0,
@@ -80,24 +117,9 @@ class TestTimetableProblemsPageView:
                     "total_proposals": 0,
                     "total_sessions": 0,
                 },
-                "active_nav": "timetable",
-                "conflicts_grouped": {},
-                "slot_violations": [],
-                "slug": event.slug,
-                "tab_urls": {
-                    "timetable": reverse(
-                        "panel:timetable", kwargs={"slug": event.slug}
-                    ),
-                    "log": reverse("panel:timetable-log", kwargs={"slug": event.slug}),
-                    "overview": reverse(
-                        "panel:timetable-overview", kwargs={"slug": event.slug}
-                    ),
-                    "problems": reverse(
-                        "panel:timetable-problems", kwargs={"slug": event.slug}
-                    ),
-                },
-                "active_tab": "problems",
-            },
+                conflicts_grouped={},
+                slot_violations=[],
+            ),
         )
 
     def test_lists_space_overlap_conflict(
@@ -128,18 +150,35 @@ class TestTimetableProblemsPageView:
 
         response = authenticated_client.get(self.get_url(event))
 
-        assert response.status_code == HTTPStatus.OK
-        grouped = response.context["conflicts_grouped"]
-        assert "space_overlap" in grouped
-        overlaps = grouped["space_overlap"]
-        assert len(overlaps) == 1
-        conflict = overlaps[0]
-        assert conflict.subject_session_pk != conflict.session_pk
-        assert conflict.subject_session_title != conflict.session_title
-        assert {conflict.subject_session_pk, conflict.session_pk} == {
-            session_a.pk,
-            session_b.pk,
-        }
+        assert_response(
+            response,
+            HTTPStatus.OK,
+            template_name="panel/timetable-problems.html",
+            context_data=self.expected_context(
+                event,
+                stats={
+                    "hosts_count": 2,
+                    "pending_proposals": 2,
+                    "rooms_count": 1,
+                    "scheduled_sessions": 2,
+                    "total_proposals": 2,
+                    "total_sessions": 4,
+                },
+                conflicts_grouped={
+                    ConflictType.SPACE_OVERLAP: [
+                        ConflictDTO(
+                            type=ConflictType.SPACE_OVERLAP,
+                            severity=ConflictSeverity.ERROR,
+                            subject_session_title=session_a.title,
+                            subject_session_pk=session_a.pk,
+                            session_title=session_b.title,
+                            session_pk=session_b.pk,
+                        )
+                    ]
+                },
+                slot_violations=[],
+            ),
+        )
 
     def test_lists_session_outside_preferred_slot(
         self, authenticated_client, active_user, sphere, event, proposal_category
@@ -164,14 +203,32 @@ class TestTimetableProblemsPageView:
 
         response = authenticated_client.get(self.get_url(event))
 
-        assert response.status_code == HTTPStatus.OK
-        violations = response.context["slot_violations"]
-        assert len(violations) == 1
-        assert violations[0].session_pk == session.pk
-        assert violations[0].scheduled_start == start
-        assert violations[0].scheduled_end == end
-        assert len(violations[0].preferred_slots) == 1
-        assert violations[0].preferred_slots[0].start_time == preferred_slot.start_time
+        assert_response(
+            response,
+            HTTPStatus.OK,
+            template_name="panel/timetable-problems.html",
+            context_data=self.expected_context(
+                event,
+                stats=ONE_SCHEDULED_SESSION_STATS,
+                conflicts_grouped={},
+                slot_violations=[
+                    PreferredSlotViolationDTO(
+                        session_pk=session.pk,
+                        session_title=session.title,
+                        scheduled_start=start,
+                        scheduled_end=end,
+                        preferred_slots=[
+                            PreferredSlotRangeDTO(
+                                start_time=preferred_slot.start_time,
+                                end_time=preferred_slot.end_time,
+                            )
+                        ],
+                        track_name=None,
+                        manager_names=[],
+                    )
+                ],
+            ),
+        )
 
     def test_skips_session_inside_preferred_slot(
         self, authenticated_client, active_user, sphere, event, proposal_category
@@ -196,8 +253,17 @@ class TestTimetableProblemsPageView:
 
         response = authenticated_client.get(self.get_url(event))
 
-        assert response.status_code == HTTPStatus.OK
-        assert response.context["slot_violations"] == []
+        assert_response(
+            response,
+            HTTPStatus.OK,
+            template_name="panel/timetable-problems.html",
+            context_data=self.expected_context(
+                event,
+                stats=ONE_SCHEDULED_SESSION_STATS,
+                conflicts_grouped={},
+                slot_violations=[],
+            ),
+        )
 
     def test_skips_session_spanning_contiguous_preferred_slots(
         self, authenticated_client, active_user, sphere, event, proposal_category
@@ -228,8 +294,17 @@ class TestTimetableProblemsPageView:
 
         response = authenticated_client.get(self.get_url(event))
 
-        assert response.status_code == HTTPStatus.OK
-        assert response.context["slot_violations"] == []
+        assert_response(
+            response,
+            HTTPStatus.OK,
+            template_name="panel/timetable-problems.html",
+            context_data=self.expected_context(
+                event,
+                stats=ONE_SCHEDULED_SESSION_STATS,
+                conflicts_grouped={},
+                slot_violations=[],
+            ),
+        )
 
     def test_lists_session_spanning_gap_between_preferred_slots(
         self, authenticated_client, active_user, sphere, event, proposal_category
@@ -242,28 +317,53 @@ class TestTimetableProblemsPageView:
             participants_limit=5,
             min_age=0,
         )
-        session.time_slots.add(
-            TimeSlotFactory(
-                event=event,
-                start_time=event.start_time,
-                end_time=event.start_time + timedelta(hours=2),
-            ),
-            TimeSlotFactory(
-                event=event,
-                start_time=event.start_time + timedelta(hours=4),
-                end_time=event.start_time + timedelta(hours=8),
-            ),
+        early_slot = TimeSlotFactory(
+            event=event,
+            start_time=event.start_time,
+            end_time=event.start_time + timedelta(hours=2),
         )
+        late_slot = TimeSlotFactory(
+            event=event,
+            start_time=event.start_time + timedelta(hours=4),
+            end_time=event.start_time + timedelta(hours=8),
+        )
+        session.time_slots.add(early_slot, late_slot)
         start = event.start_time + timedelta(hours=1)
         end = event.start_time + timedelta(hours=5)
         AgendaItemFactory(session=session, space=space, start_time=start, end_time=end)
 
         response = authenticated_client.get(self.get_url(event))
 
-        assert response.status_code == HTTPStatus.OK
-        violations = response.context["slot_violations"]
-        assert len(violations) == 1
-        assert violations[0].session_pk == session.pk
+        assert_response(
+            response,
+            HTTPStatus.OK,
+            template_name="panel/timetable-problems.html",
+            context_data=self.expected_context(
+                event,
+                stats=ONE_SCHEDULED_SESSION_STATS,
+                conflicts_grouped={},
+                slot_violations=[
+                    PreferredSlotViolationDTO(
+                        session_pk=session.pk,
+                        session_title=session.title,
+                        scheduled_start=start,
+                        scheduled_end=end,
+                        preferred_slots=[
+                            PreferredSlotRangeDTO(
+                                start_time=early_slot.start_time,
+                                end_time=early_slot.end_time,
+                            ),
+                            PreferredSlotRangeDTO(
+                                start_time=late_slot.start_time,
+                                end_time=late_slot.end_time,
+                            ),
+                        ],
+                        track_name=None,
+                        manager_names=[],
+                    )
+                ],
+            ),
+        )
 
     def test_skips_session_with_no_preferred_slots(
         self, authenticated_client, active_user, sphere, event, proposal_category
@@ -282,5 +382,14 @@ class TestTimetableProblemsPageView:
 
         response = authenticated_client.get(self.get_url(event))
 
-        assert response.status_code == HTTPStatus.OK
-        assert response.context["slot_violations"] == []
+        assert_response(
+            response,
+            HTTPStatus.OK,
+            template_name="panel/timetable-problems.html",
+            context_data=self.expected_context(
+                event,
+                stats=ONE_SCHEDULED_SESSION_STATS,
+                conflicts_grouped={},
+                slot_violations=[],
+            ),
+        )


### PR DESCRIPTION
Replace manual `assert response.` checks with assert_response and full expected context_data, paying down 9 wrong-assert tingle occurrences.