### PR TITLE
fix(flaky): panel-crud.spec.ts "creates a facilitator"

### DIFF
--- a/tests/e2e/tests/panel-crud.spec.ts
+++ b/tests/e2e/tests/panel-crud.spec.ts
@@ -19,7 +19,7 @@ const PROPOSAL_TITLE_EDITED = "Midnight Heist One-Shot (revised)";
 // first attempt died after the facilitator was already created — every later
 // name-based lookup would then match 2+ elements and fail strict mode. Keep
 // the name unique per attempt instead.
-let facilitator = "Wanda Frost";
+let facilitator: string = "Wanda Frost";
 
 test.describe("Panel facilitator + proposal CRUD", () => {
   test.beforeEach(async ({ page }) => {
@@ -43,16 +43,16 @@ test.describe("Panel facilitator + proposal CRUD", () => {
 
     // Redirects back to the list with the new facilitator present.
     await page.waitForURL(/\/facilitators\/$/);
-    await page.getByRole("link", { name: facilitator }).click();
+    await page.getByRole("link", { name: facilitator, exact: true }).click();
 
     // Detail page shows the cached name and the accreditation we picked.
-    await expect(page.getByRole("heading", { name: facilitator })).toBeVisible();
+    await expect(page.getByRole("heading", { name: facilitator, exact: true })).toBeVisible();
     await expect(page.getByText("Standard")).toBeVisible();
   });
 
   test("edits the facilitator accreditation", async ({ page }) => {
     await page.goto(FACILITATORS_URL);
-    await page.getByRole("link", { name: facilitator }).click();
+    await page.getByRole("link", { name: facilitator, exact: true }).click();
     // The detail page carries two "Edit" links (header button + the empty
     // personal-data hint); the header one comes first in the DOM.
     await page.getByRole("link", { name: "Edit" }).first().click();
@@ -74,7 +74,7 @@ test.describe("Panel facilitator + proposal CRUD", () => {
 
     // The picker is search-first: rows stay hidden until the search matches.
     await page.getByPlaceholder("Search by name…").fill(facilitator);
-    await page.getByRole("checkbox", { name: facilitator }).check();
+    await page.getByRole("checkbox", { name: facilitator, exact: true }).check();
     await page.getByLabel("Category").selectOption({ label: "RPG Proposals" });
     await page.getByLabel("Title").fill(PROPOSAL_TITLE);
     await page.getByLabel("Display Name").fill(facilitator);

--- a/tests/e2e/tests/panel-crud.spec.ts
+++ b/tests/e2e/tests/panel-crud.spec.ts
@@ -11,9 +11,15 @@ const EVENT = "frostfire-con";
 const FACILITATORS_URL = `/panel/event/${EVENT}/facilitators/`;
 const PROPOSALS_URL = `/panel/event/${EVENT}/proposals/`;
 
-const FACILITATOR = "Wanda Frost";
 const PROPOSAL_TITLE = "Midnight Heist One-Shot";
 const PROPOSAL_TITLE_EDITED = "Midnight Heist One-Shot (revised)";
+
+// Serial retries re-run the whole group from the top (Playwright semantics),
+// so a hardcoded name here would leave a duplicate row behind whenever the
+// first attempt died after the facilitator was already created — every later
+// name-based lookup would then match 2+ elements and fail strict mode. Keep
+// the name unique per attempt instead.
+let facilitator = "Wanda Frost";
 
 test.describe("Panel facilitator + proposal CRUD", () => {
   test.beforeEach(async ({ page }) => {
@@ -25,26 +31,28 @@ test.describe("Panel facilitator + proposal CRUD", () => {
     await page.getByRole("button", { name: /Log in/i }).click();
   });
 
-  test("creates a facilitator", async ({ page }) => {
+  test("creates a facilitator", async ({ page }, testInfo) => {
+    facilitator = testInfo.retry === 0 ? "Wanda Frost" : `Wanda Frost (retry ${testInfo.retry})`;
+
     await page.goto(FACILITATORS_URL);
     await page.getByRole("link", { name: "New Facilitator" }).click();
 
-    await page.getByLabel("Display Name").fill(FACILITATOR);
+    await page.getByLabel("Display Name").fill(facilitator);
     await page.getByLabel("Accreditation type").selectOption({ label: "Standard" });
     await page.getByRole("button", { name: "Create Facilitator" }).click();
 
     // Redirects back to the list with the new facilitator present.
     await page.waitForURL(/\/facilitators\/$/);
-    await page.getByRole("link", { name: FACILITATOR }).click();
+    await page.getByRole("link", { name: facilitator }).click();
 
     // Detail page shows the cached name and the accreditation we picked.
-    await expect(page.getByRole("heading", { name: FACILITATOR })).toBeVisible();
+    await expect(page.getByRole("heading", { name: facilitator })).toBeVisible();
     await expect(page.getByText("Standard")).toBeVisible();
   });
 
   test("edits the facilitator accreditation", async ({ page }) => {
     await page.goto(FACILITATORS_URL);
-    await page.getByRole("link", { name: FACILITATOR }).click();
+    await page.getByRole("link", { name: facilitator }).click();
     // The detail page carries two "Edit" links (header button + the empty
     // personal-data hint); the header one comes first in the DOM.
     await page.getByRole("link", { name: "Edit" }).first().click();
@@ -65,11 +73,11 @@ test.describe("Panel facilitator + proposal CRUD", () => {
     await page.getByRole("link", { name: "Create Session" }).first().click();
 
     // The picker is search-first: rows stay hidden until the search matches.
-    await page.getByPlaceholder("Search by name…").fill(FACILITATOR);
-    await page.getByRole("checkbox", { name: FACILITATOR }).check();
+    await page.getByPlaceholder("Search by name…").fill(facilitator);
+    await page.getByRole("checkbox", { name: facilitator }).check();
     await page.getByLabel("Category").selectOption({ label: "RPG Proposals" });
     await page.getByLabel("Title").fill(PROPOSAL_TITLE);
-    await page.getByLabel("Display Name").fill(FACILITATOR);
+    await page.getByLabel("Display Name").fill(facilitator);
     await page.getByRole("button", { name: "Create" }).click();
 
     // Lands on the new proposal's detail page: pending, with our title.


### PR DESCRIPTION
## Root cause

`tests/e2e/tests/panel-crud.spec.ts` runs in `describe.configure({ mode: "serial" })`. Playwright's serial mode re-runs the **whole file from the top** when a test in the group fails and retries are configured (`retries: isCI ? 2 : 0` in `playwright.config.ts`).

`creates a facilitator` used a hardcoded name (`"Wanda Frost"`). If attempt 0 failed *after* the facilitator was already created server-side (e.g. a transient timing hiccup on an assertion further down the test), the retry re-ran the whole group — including `creates a facilitator` — and created a **second** row with the identical display name. Every later `getByRole(..., { name: "Wanda Frost" })` lookup (`edits the facilitator accreditation`, `creates a proposal bound to the facilitator`) then matched 2+ elements and hit a Playwright strict-mode violation, turning one harmless transient flake into a hard failure of the whole serial group.

This matches the CI signature exactly:
```
strict mode violation: getByRole('link', { name: 'Wanda Frost' }) resolved to 2 elements
```
seen this week in 5 different CI runs/commits (flagged by Playwright itself as "flaky" — failed then passed on retry — with the sibling proposal-creation test hard-failing right after).

I reproduced this failure mode locally by running the spec twice against the same seeded DB without resetting between runs — got a 7-way strict-mode violation, confirming the app happily allows duplicate facilitator display names (it dedupes the *slug* only), which is exactly the mechanism above.

## Fix

Suffix the facilitator name with `testInfo.retry` so each attempt (original + each retry) creates and looks up a distinct, uniquely-named row instead of colliding with whatever a prior attempt left behind. All later tests in the file reference the shared `facilitator` variable instead of a hardcoded constant.

## Verification

- Ran the spec serially with `--retries=2` (mirroring CI) against a clean DB; confirmed via Playwright's error-context snapshots that each attempt correctly created and located its own uniquely-named facilitator (`Wanda Frost`, `Wanda Frost (retry 1)`, `Wanda Frost (retry 2)`) with no duplicate-name collisions.
- Ran the full 5-test serial suite end-to-end against a clean DB: all 5 passed.
- (This sandbox's Django dev server responds noticeably slower than real CI hardware — individual requests took ~13s here — so I temporarily bumped the local `expect` timeout to get a clean full-suite pass without that being a factor; not part of this commit.)

## Context

This was investigated as part of a scheduled flaky-test sweep of the last 7 days of CI on `main`. This was the #1 ranked flaky test by occurrence count (5 of 10 e2e-job failures this week traced to this cluster). Other flaky clusters found (`panel.spec.ts` "lists the space tree for the event" / "facilitators list shows a single merge entry", `panel.spec.ts` "creates a top-level space" / "duplicates a space", `event-details.spec.ts` "rejects an unknown code") share the same shared-seed-DB-mutation root cause but occurred less often; not addressed in this PR.


---
_Generated by [Claude Code](https://claude.ai/code/session_012jCNbzdfpBHhqhyFegkKKT)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved end-to-end CRUD test reliability by using unique facilitator names on retries.
  * Updated facilitator creation, editing, and proposal workflows to consistently reference the retry-specific name.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->