### PR TITLE
Force checkout on deploy hosts

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -107,7 +107,8 @@ jobs:
             cd ludamus/
             chmod 600 .env.local
             git fetch
-            git checkout $GITHUB_COMMIT_SHA
+            # -f: discard local drift in tracked files; .env.local is untracked
+            git checkout -f $GITHUB_COMMIT_SHA
             export GIT_COMMIT_SHA=$(git rev-parse --short HEAD)
             # .env.local was validated by varlock on the CI runner. Here the
             # compose CLI reads it: --env-file feeds ${VAR} interpolation,

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -187,7 +187,8 @@ jobs:
             cd ludamus/
             chmod 600 .env.local
             git fetch
-            git checkout $GITHUB_COMMIT_SHA
+            # -f: discard local drift in tracked files; .env.local is untracked
+            git checkout -f $GITHUB_COMMIT_SHA
             export GIT_COMMIT_SHA=$(git rev-parse --short HEAD)
             # .env.local was validated by varlock on the CI runner. Here the
             # compose CLI reads it: --env-file feeds ${VAR} interpolation,


### PR DESCRIPTION
Prod deploy aborted on `git checkout $SHA` because the host's working copy had a locally-modified tracked `src/ludamus/static/favicon.ico`:

```
error: Your local changes to the following files would be overwritten by checkout
```

`git checkout -f` discards local drift in tracked files before switching. `.env.local` is untracked, so it's untouched. Applied to both prod and staging deploy workflows.

No app code changed, so no screenshots.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved staging and production deployments by ensuring services build and start from the exact target commit.
  * Prevented uncommitted tracked-file changes on deployment servers from interfering with releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->