### PR TITLE
fix(mobile): stop iOS device-takeover race cascading across regression files

### DIFF
--- a/scripts/ios-regressions/harness.ts
+++ b/scripts/ios-regressions/harness.ts
@@ -1,6 +1,7 @@
 import type {
   AgentDeviceClient,
   AgentDeviceSelectionOptions,
+  AgentDeviceSession,
   CaptureSnapshotResult,
   SnapshotNode,
 } from "agent-device";
@@ -57,7 +58,7 @@ export type IosHarness = {
 };
 
 export const createIosHarness = async (session: string): Promise<IosHarness> => {
-  const { createAgentDeviceClient } = await importAgentDevice();
+  const { createAgentDeviceClient, isAgentDeviceError } = await importAgentDevice();
   const client: AgentDeviceClient = createAgentDeviceClient({ session });
 
   const deviceOptions: IosDeviceOptions = providedUdid
@@ -96,6 +97,7 @@ export const createIosHarness = async (session: string): Promise<IosHarness> => 
     try {
       await client.apps.open({ ...deviceOptions, app: "Safari", url });
     } catch (error) {
+      if (isAgentDeviceError(error) && error.code === "DEVICE_IN_USE") throw error;
       console.warn(
         "Safari reported a URL open failure; continuing because iOS Simulator can time out after Safari has already loaded the page.",
         error,
@@ -131,19 +133,32 @@ export const createIosHarness = async (session: string): Promise<IosHarness> => 
     }
   };
 
+  const findConflictingSession = (sessions: AgentDeviceSession[]): AgentDeviceSession | null => {
+    const holder = sessions.find((candidate) => {
+      if (providedUdid) return candidate.device.ios?.udid === providedUdid;
+      return candidate.device.name === deviceName && candidate.device.platform === "ios";
+    });
+    return holder && holder.name !== session ? holder : null;
+  };
+
   const closeDeviceSessionIfPresent = async (): Promise<void> => {
     try {
-      const sessions = await client.sessions.list();
-      const activeSession = sessions.find((candidate) => {
-        if (providedUdid) return candidate.device.ios?.udid === providedUdid;
-        return candidate.device.name === deviceName && candidate.device.platform === "ios";
-      });
-      if (!activeSession || activeSession.name === session) return;
+      const activeSession = findConflictingSession(await client.sessions.list());
+      if (!activeSession) return;
 
       console.log(
         `Taking over iOS device from existing agent-device session: ${activeSession.name}`,
       );
       await client.sessions.close({ session: activeSession.name });
+
+      const deadline = Date.now() + 15000;
+      while (Date.now() < deadline) {
+        if (!findConflictingSession(await client.sessions.list())) return;
+        await new Promise((resolve) => setTimeout(resolve, 500));
+      }
+      console.warn(
+        `Session ${activeSession.name} still holds the device 15s after close; proceeding anyway.`,
+      );
     } catch (error) {
       console.warn("Could not check or close existing device session:", error);
     }


### PR DESCRIPTION
## What

The `ios-regressions` job flaked both regression files on every retry attempt, even for PRs that touch no mobile code — an unrelated template-free branch failed identically in the same runner window.

## Root cause

The two regression files (`modal`, `scrubber`) share one simulator via separate agent-device sessions. When one file's hook hangs, its session lingers holding the device. The next file *closes* that session but proceeds before the daemon releases the device → `DEVICE_IN_USE`. `openUrl` swallowed that as a benign Safari-load timeout, leaving no active session, so every later command died `SESSION_NOT_FOUND` and burned the full 240s hook budget.

Net effect: one flaky file failed **both** files across all three workflow attempts.

## Fix

`scripts/ios-regressions/harness.ts` only:

- After takeover, poll `sessions.list()` until the device is actually free (15s cap) before opening Safari — closes the race.
- Stop swallowing `DEVICE_IN_USE`; surface it so the workflow's retry restarts on a clean simulator instead of grinding a 240s timeout.

## Not changed (deliberately)

- Runner-startup flake (`Runner did not accept connection`) is upstream, already covered by the 3× retry.
- The 240s hook timeout and splitting files into separate `bun` invocations — the takeover race was the multiplier; the rest is upstream flake the retry handles.

## Verification

`bun build` clean. The regression job only runs on the mobile paths; this branch touches `scripts/ios-regressions/**`, so CI exercises the change directly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved iOS regression testing when devices are already in use.
  - Added clearer handling for device-busy errors when opening URLs in Safari.
  - Automatically closes conflicting device sessions and waits for the device to become available before continuing.
  - Added a timeout safeguard so testing can proceed if the device remains occupied.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->