### PR TITLE
chore(lint): run oxlint in hk pre-commit

### DIFF
--- a/aube-lock.yaml
+++ b/aube-lock.yaml
@@ -24,6 +24,9 @@ importers:
       oxfmt:
         specifier: 0.56.0
         version: 0.56.0
+      oxlint:
+        specifier: 1.70.0
+        version: 1.70.0
       portless:
         specifier: 0.13.0
         version: 0.13.0

--- a/hk.pkl
+++ b/hk.pkl
@@ -58,6 +58,11 @@ local linters = new Mapping<String, Step> {
     )
   }
 
+  // Frontend — oxlint, run as an aube devDep like oxfmt
+  ["oxlint"] = (Builtins.ox_lint) {
+    prefix = "aube exec"
+  }
+
   // Config / infra
   ["yamllint"] = Builtins.yamllint
   ["actionlint"] = Builtins.actionlint

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "dclint": "3.1.0",
     "fallow": "2.73.0",
     "oxfmt": "0.56.0",
+    "oxlint": "1.70.0",
     "portless": "0.13.0"
   },
   "pnpm": {

--- a/tests/e2e/tests/helpers/ios-modal.ts
+++ b/tests/e2e/tests/helpers/ios-modal.ts
@@ -44,7 +44,7 @@ const installNavigationApi = (): void => {
       },
       navigationType: "push",
     };
-    for (const listener of [...listeners]) listener(navigateEvent);
+    for (const listener of listeners) listener(navigateEvent);
     if (!intercepted) return;
 
     event.preventDefault();


### PR DESCRIPTION
Plugs `oxlint` into the `hk` pre-commit/check hooks via the vendored `ox_lint` builtin, run as an aube devDep like `oxfmt`, with hk's default globs deciding coverage. Fixes the single warning the repo-wide sweep surfaced (`unicorn/no-useless-spread` in the e2e iOS modal helper — spreading a `Set` that's never mutated mid-dispatch).

Known scope note: the builtin runs oxlint's default rule set. The client package's stricter config (`oxlint.config.ts`, perfectionist etc.) is still enforced only by `lint-client` in CI — e.g. vite entry-map sort order is not covered by this hook.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated development tooling to support improved code-quality checks.
  - Improved navigation event handling during automated testing, including safer behavior when listeners change while notifications are being processed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->