### PR TITLE
Self-heal pipx wrapper version pins in sandbox sessions

### DIFF
--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -97,6 +97,28 @@ if [ -n "$purged" ]; then
     || echo "WARN: 'mise install' retry failed; broken tools:$purged"
 fi
 
+# A pipx-aliased tool can survive both installs broken when its PyPI wrapper
+# appends a packaging revision to the upstream version: shellcheck-py 0.11.0.1
+# wraps shellcheck 0.11.0, hadolint-py does the same. mise passes a full X.Y.Z
+# pin to uv verbatim as ==X.Y.Z, which matches nothing on PyPI. A shorter pin
+# makes mise resolve against the registry instead (shellcheck@0.11 picks
+# 0.11.0.1) and link a 0.11.0 alias dir that satisfies the mise.toml pin, so
+# retry each still-shimless aliased tool with its pin trimmed one segment.
+# Versions stay pinned in mise.toml alone; this survives future bumps.
+for tool in $purged; do
+  [ -e "$HOME/.local/share/mise/shims/$tool" ] && continue
+  pin="$(sed -n "s/^${tool}[[:space:]]*=[[:space:]]*\"\([^\"]*\)\".*/\1/p" \
+    mise.toml)"
+  prefix="${pin%.*}"
+  case "$prefix" in
+    *.*)
+      echo "Retrying $tool@$prefix (wrapper may add a revision to $pin)"
+      mise install "$tool@$prefix" \
+        || echo "WARN: 'mise install $tool@$prefix' failed; $tool unavailable"
+      ;;
+  esac
+done
+
 mise bootstrap packages apply --yes || echo "WARN: 'mise bootstrap packages apply' failed"
 mise run bootstrap || echo "WARN: 'mise run bootstrap' failed; JS deps/build may be unavailable"
 

--- a/docs/agents/sandbox.md
+++ b/docs/agents/sandbox.md
@@ -26,6 +26,15 @@ without a shim after `mise install` gets its install purged and reinstalled
 through the alias. Pre-baked layouts that happen to satisfy the alias (hk)
 are kept as is.
 
+PyPI wrapper packages add one more failure mode: they append a packaging
+revision to the upstream version (shellcheck-py 0.11.0.1 wraps shellcheck
+0.11.0), and mise passes a full `X.Y.Z` pin to uv verbatim as `==X.Y.Z`,
+which matches nothing. The hook's last resort covers it: any aliased tool
+still shimless after the reinstall is retried with its mise.toml pin trimmed
+one segment (`shellcheck@0.11`), which mise prefix-resolves to the wrapper's
+version and links back to the pinned one. Bumping a pin in `mise.toml` needs
+no sandbox-side edit.
+
 Playwright browsers: the image's `/opt/pw-browsers` build can lag the
 `@playwright/test` pin, so the hook runs `mise run test:e2e:install`; when its
 `--with-deps` apt step breaks (image PPA metadata drift), it falls back to a

--- a/mise.sandbox.toml
+++ b/mise.sandbox.toml
@@ -14,6 +14,9 @@ disable_tools = ["python", "pipx", "github:reteps/dockerfmt"]
 
 [tool_alias]
 hk = "cargo:hk"
+# The pipx wrappers version as <upstream>.<wrapper-rev> (0.11.0.1 wraps
+# 0.11.0), so mise.toml's exact pins never match PyPI; session-start.sh
+# retries shimless aliased tools with the pin trimmed one segment.
 shellcheck = "pipx:shellcheck-py"
 actionlint = "go:github.com/rhysd/actionlint/cmd/actionlint"
 hadolint = "pipx:hadolint-py"


### PR DESCRIPTION
Every `mise install` / `mise run` in a Claude Code web sandbox currently errors: `shellcheck-py` and `hadolint-py` version as `<upstream>.<wrapper-rev>` on PyPI (`0.11.0.1` wraps shellcheck `0.11.0`), and mise passes a full `X.Y.Z` pin to uv verbatim as `==X.Y.Z`, which matches nothing. The papercut task couldn't even run to record the bug it was hit by (logged in #679).

## Fix

The session-start hook's self-heal pass gets one more stage: any aliased tool that is still shimless after the existing purge-and-reinstall retry is reinstalled with its mise.toml pin trimmed one segment (`shellcheck@0.11`). mise prefix-resolves that against the registry (picks `0.11.0.1`) and links a `0.11.0` alias dir that satisfies the original pin.

Versions stay pinned in `mise.toml` alone. When a pin bumps to `0.12.0` and PyPI carries `0.12.0.1`, the hook heals it with no sandbox-side edit — that's why this is a hook fallback rather than duplicated fuzzy pins in `mise.sandbox.toml`, which would silently stick at the old version after a bump.

Also documents the failure mode in `docs/agents/sandbox.md` and next to the pipx aliases in `mise.sandbox.toml`.

## Verification

Ran in a live web sandbox: wiped both tools, executed the hook's purge/retry/fallback sequence verbatim — both tools healed, `mise install` reports all tools installed, `shellcheck --version` / `hadolint --version` run, `mise run` tasks execute past the install phase again, and the hk pre-commit suite (including shellcheck on the hook itself) ran green on this commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Fq7pLcCpE1fqNjz6QkURiv

---
_Generated by [Claude Code](https://claude.ai/code/session_01Fq7pLcCpE1fqNjz6QkURiv)_