### PR TITLE
Lay the timetable calendar out from one shared track list

### DIFF
--- a/PAPERCUTS.md
+++ b/PAPERCUTS.md
@@ -167,3 +167,11 @@ If you fix a papercut, remove it.
   Playwright still transpiles and executes the changed spec successfully.
 - 2026-07-24: playwriter 'session new' printed a fresh id but the relay 404'd it
   (Session 14 not found); had to reuse an old session id from session list
+- 2026-07-25: Web sandbox session started with an empty .venv (no pytest, no
+  django) and mise still wedged on pipx:shellcheck-py/hadolint-py, so no mise
+  task could bootstrap it; ran poetry install by hand and invoked pytest as
+  .venv/bin/python -m pytest with PYTHONPATH=src plus .env.test sourced
+  manually.
+- 2026-07-25: /opt/pw-browsers held chromium_headless_shell-1208 as an empty
+  directory, so every e2e test failed with "Executable doesn't exist" until
+  npx playwright install chromium refetched it.

--- a/PAPERCUTS.md
+++ b/PAPERCUTS.md
@@ -175,8 +175,11 @@ If you fix a papercut, remove it.
 - 2026-07-25: /opt/pw-browsers held chromium_headless_shell-1208 as an empty
   directory, so every e2e test failed with "Executable doesn't exist" until
   npx playwright install chromium refetched it.
-- 2026-07-25: After `aubr -C src/ludamus/client build`, a `runserver --noreload`
-  started earlier keeps serving the previous vite manifest, whose asset files
-  the rebuild has deleted - the page renders with no CSS at all and looks like
-  a layout bug rather than a stale server. Restart the server after every
-  client build.
+- 2026-07-25: Iterated on timetable CSS/TS against a `.env.e2e` server, where
+  `ENV="test"` turns django_vite `dev_mode` off, so each edit needed
+  `aubr build` plus a restart (`--noreload` caches the manifest, and the
+  rebuild deletes the hashed files it points at - the page then renders with
+  no CSS and reads as a layout bug). For an edit loop against the e2e seed,
+  export `ENV=development` and `VITE_PORT`, run the vite dev server, and keep
+  the rest of `.env.e2e`: assets come from vite with HMR, no build, no
+  restart. Build only before handing the page to Playwright.

--- a/PAPERCUTS.md
+++ b/PAPERCUTS.md
@@ -175,3 +175,8 @@ If you fix a papercut, remove it.
 - 2026-07-25: /opt/pw-browsers held chromium_headless_shell-1208 as an empty
   directory, so every e2e test failed with "Executable doesn't exist" until
   npx playwright install chromium refetched it.
+- 2026-07-25: After `aubr -C src/ludamus/client build`, a `runserver --noreload`
+  started earlier keeps serving the previous vite manifest, whose asset files
+  the rebuild has deleted - the page renders with no CSS at all and looks like
+  a layout bug rather than a stale server. Restart the server after every
+  client build.

--- a/src/ludamus/client/src/timetable.css
+++ b/src/ludamus/client/src/timetable.css
@@ -2,7 +2,11 @@
   .timetable-calendar {
     --minute-px: 1px;
     --timetable-time-column: 4rem;
-    --timetable-column-min: 9rem;
+    /* Every column is this wide, and the resize handles drag it (timetable.ts
+       writes --timetable-column-width on the document element, so the value
+       outlives each HTMX swap of the grid). The literal is only the default. */
+    --timetable-column-min: var(--timetable-column-width, 9rem);
+    --timetable-resizer-width: 0.875rem;
   }
 
   /* The sticky header and the scrolling body are separate elements, so they
@@ -70,6 +74,50 @@
 
   .timetable-room-cell {
     grid-row: 3;
+    position: relative;
+  }
+
+  /* One shared width means any handle drives the whole grid, so every room
+     cell carries one. It stays inside its cell rather than straddling the
+     border: an overhang would widen the calendar's scrollable area and put the
+     header back out of step with the body. */
+  .timetable-column-resizer {
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    right: 0;
+    width: var(--timetable-resizer-width);
+    z-index: 1;
+    padding: 0;
+    border: 0;
+    background: transparent;
+    cursor: col-resize;
+    touch-action: none;
+  }
+
+  /* Focus is left to the global :focus-visible ring; this bar is the pointer
+     affordance -- it marks the border the grip acts on. */
+  .timetable-column-resizer::before {
+    content: "";
+    position: absolute;
+    inset-block: 0.375rem;
+    right: 0;
+    width: 2px;
+    border-radius: 1px;
+    background: transparent;
+    transition: background-color 120ms;
+  }
+
+  .timetable-column-resizer:hover::before,
+  .timetable-column-resizer.is-resizing::before {
+    background: var(--color-primary);
+  }
+
+  /* Pointer capture keeps the drag alive over the whole page, so the resize
+     cursor has to follow it there too. */
+  .timetable-resizing,
+  .timetable-resizing * {
+    cursor: col-resize !important;
   }
 
   .timetable-time-axis,

--- a/src/ludamus/client/src/timetable.css
+++ b/src/ludamus/client/src/timetable.css
@@ -1,17 +1,75 @@
 @layer components {
   .timetable-calendar {
     --minute-px: 1px;
+    --timetable-time-column: 4rem;
+    --timetable-column-min: 9rem;
   }
 
-  .timetable-day-grid,
+  /* The sticky header and the scrolling body are separate elements, so they
+     line up only if both are laid out from the same track list. Tracks are
+     therefore fully explicit and nothing inside a cell can resize them:
+     `minmax(min, 1fr)` pins the lower bound, and the strip width is computed
+     from the column count instead of being derived from content. Sizing to
+     content is what drifts -- room names widen the header while the body,
+     whose sessions are absolutely positioned, contributes nothing. */
+  .timetable-day-strip {
+    display: grid;
+    grid-template-columns: var(--timetable-time-column) repeat(
+        var(--total-columns),
+        minmax(var(--timetable-column-min), 1fr)
+      );
+    width: max(
+      100%,
+      calc(var(--timetable-time-column) + var(--total-columns) * var(--timetable-column-min))
+    );
+  }
+
+  /* Day name, room group, room name. A tier with no cells collapses to zero --
+     that is how the single-day view drops the date row. */
+  .timetable-day-strip-header {
+    grid-template-rows: auto auto auto;
+  }
+
+  /* A day re-uses the parent tracks rather than splitting its own width, so
+     adding days or rooms cannot shift the columns out of step. Subgrids must
+     stay free of padding, border and margin: those inset the subgrid and would
+     shove every track inside the day sideways. Chrome goes on the cells. */
+  .timetable-day-header,
+  .timetable-day-grid {
+    display: grid;
+    grid-template-columns: subgrid;
+    grid-column: span var(--column-count);
+  }
+
   .timetable-day-header {
-    flex: 1 0 calc(9rem * var(--column-count));
-    min-width: calc(9rem * var(--column-count));
+    grid-row: 1 / -1;
+    grid-template-rows: subgrid;
+  }
+
+  /* Pinned explicitly: the day headers span rows, and auto-placement resolves
+     row-spanning items before auto-placed ones, so an unpinned corner would be
+     pushed past the first day. */
+  .timetable-corner {
+    grid-row: 1 / -1;
+    grid-column: 1;
+  }
+
+  .timetable-time-axis {
+    grid-column: 1;
+  }
+
+  .timetable-day-title {
+    grid-row: 1;
+    grid-column: 1 / -1;
   }
 
   .timetable-header-cell {
-    flex: var(--columns) 1 0;
-    min-width: calc(9rem * var(--columns));
+    grid-row: 2;
+    grid-column: span var(--columns);
+  }
+
+  .timetable-room-cell {
+    grid-row: 3;
   }
 
   .timetable-time-axis,

--- a/src/ludamus/client/src/timetable.css
+++ b/src/ludamus/client/src/timetable.css
@@ -6,7 +6,7 @@
        writes --timetable-column-width on the document element, so the value
        outlives each HTMX swap of the grid). The literal is only the default. */
     --timetable-column-min: var(--timetable-column-width, 9rem);
-    --timetable-resizer-width: 0.875rem;
+    --timetable-grip-width: 0.875rem;
   }
 
   /* The sticky header and the scrolling body are separate elements, so they
@@ -34,7 +34,7 @@
     grid-template-rows: auto auto auto;
   }
 
-  /* A day re-uses the parent tracks rather than splitting its own width, so
+  /* A day reuses the parent tracks rather than splitting its own width, so
      adding days or rooms cannot shift the columns out of step. Subgrids must
      stay free of padding, border and margin: those inset the subgrid and would
      shove every track inside the day sideways. Chrome goes on the cells. */
@@ -42,7 +42,7 @@
   .timetable-day-grid {
     display: grid;
     grid-template-columns: subgrid;
-    grid-column: span var(--column-count);
+    grid-column: span var(--columns-per-day);
   }
 
   .timetable-day-header {
@@ -77,40 +77,41 @@
     position: relative;
   }
 
-  /* One shared width means any handle drives the whole grid, so every room
-     cell carries one. It stays inside its cell rather than straddling the
-     border: an overhang would widen the calendar's scrollable area and put the
-     header back out of step with the body. */
+  /* One shared width means every room border resizes the whole grid, so every
+     border is a grip. Pseudo-elements are hit-testable, so the pointer path
+     needs no nodes -- timetable.ts recognises a grab by how close the pointer
+     is to the cell's right edge. The grip stays inside its cell rather than
+     straddling the border: an overhang would widen the calendar's scrollable
+     area and put the header back out of step with the body. */
+  .timetable-room-cell::after {
+    content: "";
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    right: 0;
+    width: var(--timetable-grip-width);
+    border-right: 2px solid transparent;
+    cursor: col-resize;
+    transition: border-color 120ms;
+  }
+
+  .timetable-room-cell:hover::after,
+  .timetable-room-cell.is-resizing::after {
+    border-right-color: var(--color-primary);
+  }
+
+  /* The one focusable handle. It sits on the first border, over that cell's
+     grip, so the pointer path treats it like any other. Focus is left to the
+     global :focus-visible ring. */
   .timetable-column-resizer {
     position: absolute;
     top: 0;
     bottom: 0;
     right: 0;
-    width: var(--timetable-resizer-width);
+    width: var(--timetable-grip-width);
     z-index: 1;
-    padding: 0;
-    border: 0;
-    background: transparent;
     cursor: col-resize;
     touch-action: none;
-  }
-
-  /* Focus is left to the global :focus-visible ring; this bar is the pointer
-     affordance -- it marks the border the grip acts on. */
-  .timetable-column-resizer::before {
-    content: "";
-    position: absolute;
-    inset-block: 0.375rem;
-    right: 0;
-    width: 2px;
-    border-radius: 1px;
-    background: transparent;
-    transition: background-color 120ms;
-  }
-
-  .timetable-column-resizer:hover::before,
-  .timetable-column-resizer.is-resizing::before {
-    background: var(--color-primary);
   }
 
   /* Pointer capture keeps the drag alive over the whole page, so the resize
@@ -118,6 +119,13 @@
   .timetable-resizing,
   .timetable-resizing * {
     cursor: col-resize !important;
+  }
+
+  /* A day boundary reads the same as a room boundary once the header scrolls
+     out of view, so the day's first column carries a stronger rule. It cannot
+     go on the day itself: border on a subgrid insets its tracks. */
+  .timetable-day-grid + .timetable-day-grid > .timetable-column:first-child {
+    border-left-color: var(--color-foreground-muted);
   }
 
   .timetable-time-axis,

--- a/src/ludamus/client/src/timetable.ts
+++ b/src/ludamus/client/src/timetable.ts
@@ -411,3 +411,133 @@ document.addEventListener("keydown", (e) => {
     exitAssignMode();
   }
 });
+
+// --- Column width -----------------------------------------------------------
+// Every column is one CSS track of the same width, so a single stored number
+// drives the whole calendar. It lives on the document element rather than on
+// the calendar, which HTMX replaces wholesale on every pagination or refresh.
+
+const COLUMN_WIDTH_KEY = "timetable.columnWidth";
+const COLUMN_WIDTH_DEFAULT = 144;
+const COLUMN_WIDTH_MIN = 80;
+const COLUMN_WIDTH_MAX = 512;
+const COLUMN_WIDTH_STEP = 16;
+
+// Only the exposed handle carries values; the others are duplicate pointer
+// targets hidden from assistive tech.
+const resizers = (): NodeListOf<HTMLElement> =>
+  document.querySelectorAll<HTMLElement>('.timetable-column-resizer[role="separator"]');
+
+const roomCells = (): HTMLElement[] => [
+  ...document.querySelectorAll<HTMLElement>(".timetable-room-cell"),
+];
+
+const clampColumnWidth = (px: number): number =>
+  Math.round(Math.min(COLUMN_WIDTH_MAX, Math.max(COLUMN_WIDTH_MIN, px)));
+
+// The rendered width, which is what the handles have to report: below the
+// stored width the tracks stretch to fill the calendar (`minmax(w, 1fr)`).
+function renderedColumnWidth(): number {
+  const cell = roomCells()[0];
+  return cell ? cell.getBoundingClientRect().width : storedColumnWidth();
+}
+
+function storedColumnWidth(): number {
+  const parsed = Number.parseFloat(localStorage.getItem(COLUMN_WIDTH_KEY) ?? "");
+  return Number.isFinite(parsed) ? clampColumnWidth(parsed) : COLUMN_WIDTH_DEFAULT;
+}
+
+// One source of truth for the bounds: the template ships the handles without
+// values, and they are announced from here.
+function syncResizers(): void {
+  const now = Math.round(renderedColumnWidth());
+  for (const handle of resizers()) {
+    handle.setAttribute("aria-valuemin", String(COLUMN_WIDTH_MIN));
+    handle.setAttribute("aria-valuemax", String(COLUMN_WIDTH_MAX));
+    handle.setAttribute("aria-valuenow", String(now));
+    handle.setAttribute("aria-valuetext", `${now} px`);
+  }
+}
+
+function setColumnWidth(px: number): void {
+  const width = clampColumnWidth(px);
+  document.documentElement.style.setProperty("--timetable-column-width", `${width}px`);
+  localStorage.setItem(COLUMN_WIDTH_KEY, String(width));
+  syncResizers();
+}
+
+function resetColumnWidth(): void {
+  document.documentElement.style.removeProperty("--timetable-column-width");
+  localStorage.removeItem(COLUMN_WIDTH_KEY);
+  syncResizers();
+}
+
+// The handle sits on the right edge of column `index`, so the pointer marks the
+// end of `index + 1` equal columns measured from where the first one starts.
+// Dividing by the count keeps the drag stable: widening also pushes every
+// column left of the handle, and this accounts for that in the same step.
+function columnWidthFromPointer(handle: HTMLElement, clientX: number, grabOffset: number): number {
+  const cell = handle.closest<HTMLElement>(".timetable-room-cell");
+  const cells = roomCells();
+  const index = cell ? cells.indexOf(cell) : -1;
+  const first = cells[0];
+  if (index < 0 || !first) return storedColumnWidth();
+  return (clientX - grabOffset - first.getBoundingClientRect().left) / (index + 1);
+}
+
+document.addEventListener("pointerdown", (e) => {
+  const handle = (e.target as Element).closest?.<HTMLElement>(".timetable-column-resizer");
+  if (!handle || e.button !== 0) return;
+  e.preventDefault();
+
+  // Resize from wherever inside the grip the drag started, so the edge does not
+  // jump to the cursor on the first move.
+  const grabOffset = e.clientX - handle.getBoundingClientRect().right;
+  handle.setPointerCapture(e.pointerId);
+  handle.classList.add("is-resizing");
+  document.documentElement.classList.add("timetable-resizing");
+
+  const onMove = (move: PointerEvent): void => {
+    setColumnWidth(columnWidthFromPointer(handle, move.clientX, grabOffset));
+  };
+  const onEnd = (): void => {
+    handle.removeEventListener("pointermove", onMove);
+    handle.classList.remove("is-resizing");
+    document.documentElement.classList.remove("timetable-resizing");
+  };
+
+  handle.addEventListener("pointermove", onMove);
+  handle.addEventListener("pointerup", onEnd, { once: true });
+  handle.addEventListener("pointercancel", onEnd, { once: true });
+});
+
+document.addEventListener("dblclick", (e) => {
+  if ((e.target as Element).closest?.(".timetable-column-resizer")) resetColumnWidth();
+});
+
+document.addEventListener("keydown", (e) => {
+  const handle = (e.target as Element).closest?.<HTMLElement>(".timetable-column-resizer");
+  if (!handle) return;
+
+  const steps: Record<string, number> = {
+    ArrowLeft: -COLUMN_WIDTH_STEP,
+    ArrowRight: COLUMN_WIDTH_STEP,
+  };
+  if (e.key in steps) {
+    e.preventDefault();
+    setColumnWidth(renderedColumnWidth() + steps[e.key]);
+  } else if (e.key === "Home") {
+    e.preventDefault();
+    setColumnWidth(COLUMN_WIDTH_MIN);
+  } else if (e.key === "End") {
+    e.preventDefault();
+    setColumnWidth(COLUMN_WIDTH_MAX);
+  }
+});
+
+// The stored width has to be re-applied only once -- it lives above every
+// swapped node -- but freshly swapped handles still need their values.
+document.body.addEventListener("htmx:load", syncResizers);
+
+if (localStorage.getItem(COLUMN_WIDTH_KEY) !== null) setColumnWidth(storedColumnWidth());
+syncResizers();

--- a/src/ludamus/client/src/timetable.ts
+++ b/src/ludamus/client/src/timetable.ts
@@ -416,17 +416,20 @@ document.addEventListener("keydown", (e) => {
 // Every column is one CSS track of the same width, so a single stored number
 // drives the whole calendar. It lives on the document element rather than on
 // the calendar, which HTMX replaces wholesale on every pagination or refresh.
+// The default is the CSS fallback in timetable.css, never restated here.
 
 const COLUMN_WIDTH_KEY = "timetable.columnWidth";
-const COLUMN_WIDTH_DEFAULT = 144;
 const COLUMN_WIDTH_MIN = 80;
 const COLUMN_WIDTH_MAX = 512;
 const COLUMN_WIDTH_STEP = 16;
+const GRIP_FALLBACK_PX = 14;
+const COLUMN_WIDTH_KEY_STEPS: Record<string, number> = {
+  ArrowLeft: -COLUMN_WIDTH_STEP,
+  ArrowRight: COLUMN_WIDTH_STEP,
+};
 
-// Only the exposed handle carries values; the others are duplicate pointer
-// targets hidden from assistive tech.
-const resizers = (): NodeListOf<HTMLElement> =>
-  document.querySelectorAll<HTMLElement>('.timetable-column-resizer[role="separator"]');
+const resizer = (): HTMLElement | null =>
+  document.querySelector<HTMLElement>(".timetable-column-resizer");
 
 const roomCells = (): HTMLElement[] => [
   ...document.querySelectorAll<HTMLElement>(".timetable-room-cell"),
@@ -435,109 +438,133 @@ const roomCells = (): HTMLElement[] => [
 const clampColumnWidth = (px: number): number =>
   Math.round(Math.min(COLUMN_WIDTH_MAX, Math.max(COLUMN_WIDTH_MIN, px)));
 
-// The rendered width, which is what the handles have to report: below the
-// stored width the tracks stretch to fill the calendar (`minmax(w, 1fr)`).
-function renderedColumnWidth(): number {
-  const cell = roomCells()[0];
-  return cell ? cell.getBoundingClientRect().width : storedColumnWidth();
-}
+// The rendered width, not the stored one: under the stored width the tracks
+// stretch to fill the calendar (`minmax(w, 1fr)`), and that is what the handle
+// has to report and step from. Reads layout, so never call it mid-drag.
+const renderedColumnWidth = (): number =>
+  roomCells()[0]?.getBoundingClientRect().width ?? COLUMN_WIDTH_MIN;
 
-function storedColumnWidth(): number {
+function storedColumnWidth(): number | null {
   const parsed = Number.parseFloat(localStorage.getItem(COLUMN_WIDTH_KEY) ?? "");
-  return Number.isFinite(parsed) ? clampColumnWidth(parsed) : COLUMN_WIDTH_DEFAULT;
+  return Number.isFinite(parsed) ? clampColumnWidth(parsed) : null;
 }
 
-// One source of truth for the bounds: the template ships the handles without
-// values, and they are announced from here.
-function syncResizers(): void {
-  const now = Math.round(renderedColumnWidth());
-  for (const handle of resizers()) {
-    handle.setAttribute("aria-valuemin", String(COLUMN_WIDTH_MIN));
-    handle.setAttribute("aria-valuemax", String(COLUMN_WIDTH_MAX));
-    handle.setAttribute("aria-valuenow", String(now));
-    handle.setAttribute("aria-valuetext", `${now} px`);
-  }
-}
-
-function setColumnWidth(px: number): void {
-  const width = clampColumnWidth(px);
+// Paint only. Runs per pointermove, so it touches nothing but the property.
+const applyColumnWidth = (width: number): void =>
   document.documentElement.style.setProperty("--timetable-column-width", `${width}px`);
+
+// The bounds live here alone; the template ships a static separator and this is
+// what promotes it to a focusable one, so a missing bundle leaves no dead tab
+// stop behind.
+function announceColumnWidth(): void {
+  const handle = resizer();
+  if (!handle) return;
+  const now = Math.round(renderedColumnWidth());
+  handle.tabIndex = 0;
+  handle.setAttribute("aria-valuemin", String(COLUMN_WIDTH_MIN));
+  handle.setAttribute("aria-valuemax", String(COLUMN_WIDTH_MAX));
+  handle.setAttribute("aria-valuenow", String(now));
+  handle.setAttribute("aria-valuetext", `${now} px`);
+}
+
+// Paint, persist and announce together -- for the discrete changes (keyboard,
+// end of a drag), never for a drag frame.
+function commitColumnWidth(width: number): void {
+  applyColumnWidth(width);
   localStorage.setItem(COLUMN_WIDTH_KEY, String(width));
-  syncResizers();
+  announceColumnWidth();
 }
 
 function resetColumnWidth(): void {
   document.documentElement.style.removeProperty("--timetable-column-width");
   localStorage.removeItem(COLUMN_WIDTH_KEY);
-  syncResizers();
+  announceColumnWidth();
 }
 
-// The handle sits on the right edge of column `index`, so the pointer marks the
-// end of `index + 1` equal columns measured from where the first one starts.
-// Dividing by the count keeps the drag stable: widening also pushes every
-// column left of the handle, and this accounts for that in the same step.
-function columnWidthFromPointer(handle: HTMLElement, clientX: number, grabOffset: number): number {
-  const cell = handle.closest<HTMLElement>(".timetable-room-cell");
-  const cells = roomCells();
-  const index = cell ? cells.indexOf(cell) : -1;
-  const first = cells[0];
-  if (index < 0 || !first) return storedColumnWidth();
-  return (clientX - grabOffset - first.getBoundingClientRect().left) / (index + 1);
+// Every room border is a grip (a ::after, so there are no nodes to hit): a
+// pointerdown counts as a grab when it lands within one grip of the right edge.
+function grabbedCell(e: PointerEvent): HTMLElement | null {
+  const cell = (e.target as Element).closest?.<HTMLElement>(".timetable-room-cell");
+  if (!cell) return null;
+  // Measured off the one real handle, which the same custom property sizes, so
+  // the grip width stays in CSS instead of being restated here in pixels.
+  const grip = resizer()?.getBoundingClientRect().width || GRIP_FALLBACK_PX;
+  return e.clientX >= cell.getBoundingClientRect().right - grip ? cell : null;
+}
+
+// The grabbed border closes `index + 1` equal columns counted from where the
+// first one starts, so the travel divides by that many. Widening pushes every
+// column left of the border along too, and folding that into the same step is
+// what keeps the border under the cursor instead of running away from it.
+function columnWidthFromPointer(index: number, left: number, clientX: number): number {
+  return clampColumnWidth((clientX - left) / (index + 1));
 }
 
 document.addEventListener("pointerdown", (e) => {
-  const handle = (e.target as Element).closest?.<HTMLElement>(".timetable-column-resizer");
-  if (!handle || e.button !== 0) return;
+  const cell = e.button === 0 ? grabbedCell(e) : null;
+  if (!cell) return;
   e.preventDefault();
 
-  // Resize from wherever inside the grip the drag started, so the edge does not
-  // jump to the cursor on the first move.
-  const grabOffset = e.clientX - handle.getBoundingClientRect().right;
-  handle.setPointerCapture(e.pointerId);
-  handle.classList.add("is-resizing");
+  const cells = roomCells();
+  const index = cells.indexOf(cell);
+  const [first] = cells;
+  if (index === -1 || !first) return;
+
+  // Measured once: the drag reads no layout after this, and the first column's
+  // left edge cannot move -- the time column ahead of it is a fixed track.
+  const { left } = first.getBoundingClientRect();
+  // Resize from wherever inside the grip the drag started, so the border does
+  // not jump to the cursor on the first move.
+  const grabOffset = e.clientX - cell.getBoundingClientRect().right;
+
+  const target = e.target as HTMLElement;
+  target.setPointerCapture(e.pointerId);
+  cell.classList.add("is-resizing");
   document.documentElement.classList.add("timetable-resizing");
 
+  let width = renderedColumnWidth();
   const onMove = (move: PointerEvent): void => {
-    setColumnWidth(columnWidthFromPointer(handle, move.clientX, grabOffset));
+    width = columnWidthFromPointer(index, left, move.clientX - grabOffset);
+    applyColumnWidth(width);
   };
   const onEnd = (): void => {
-    handle.removeEventListener("pointermove", onMove);
-    handle.classList.remove("is-resizing");
+    target.removeEventListener("pointermove", onMove);
+    target.removeEventListener("pointerup", onEnd);
+    target.removeEventListener("pointercancel", onEnd);
+    cell.classList.remove("is-resizing");
     document.documentElement.classList.remove("timetable-resizing");
+    commitColumnWidth(width);
   };
 
-  handle.addEventListener("pointermove", onMove);
-  handle.addEventListener("pointerup", onEnd, { once: true });
-  handle.addEventListener("pointercancel", onEnd, { once: true });
+  target.addEventListener("pointermove", onMove);
+  target.addEventListener("pointerup", onEnd);
+  target.addEventListener("pointercancel", onEnd);
 });
 
 document.addEventListener("dblclick", (e) => {
-  if ((e.target as Element).closest?.(".timetable-column-resizer")) resetColumnWidth();
+  if (grabbedCell(e as unknown as PointerEvent)) resetColumnWidth();
 });
 
 document.addEventListener("keydown", (e) => {
-  const handle = (e.target as Element).closest?.<HTMLElement>(".timetable-column-resizer");
-  if (!handle) return;
+  if (!(e.target as Element).closest?.(".timetable-column-resizer")) return;
 
-  const steps: Record<string, number> = {
-    ArrowLeft: -COLUMN_WIDTH_STEP,
-    ArrowRight: COLUMN_WIDTH_STEP,
-  };
-  if (e.key in steps) {
+  if (e.key in COLUMN_WIDTH_KEY_STEPS) {
     e.preventDefault();
-    setColumnWidth(renderedColumnWidth() + steps[e.key]);
+    commitColumnWidth(clampColumnWidth(renderedColumnWidth() + COLUMN_WIDTH_KEY_STEPS[e.key]));
   } else if (e.key === "Home") {
     e.preventDefault();
-    setColumnWidth(COLUMN_WIDTH_MIN);
+    commitColumnWidth(COLUMN_WIDTH_MIN);
   } else if (e.key === "End") {
     e.preventDefault();
-    setColumnWidth(COLUMN_WIDTH_MAX);
+    commitColumnWidth(COLUMN_WIDTH_MAX);
   }
 });
 
-// The stored width has to be re-applied only once -- it lives above every
-// swapped node -- but freshly swapped handles still need their values.
-document.body.addEventListener("htmx:load", syncResizers);
+// The width itself survives an HTMX swap on its own -- it is set above every
+// node HTMX replaces -- but the handle inside the new markup is static until
+// this promotes it again.
+document.body.addEventListener("htmx:load", announceColumnWidth);
 
-if (localStorage.getItem(COLUMN_WIDTH_KEY) !== null) setColumnWidth(storedColumnWidth());
-syncResizers();
+const storedWidth = storedColumnWidth();
+if (storedWidth !== null) applyColumnWidth(storedWidth);
+announceColumnWidth();

--- a/src/ludamus/locale/pl/LC_MESSAGES/django.po
+++ b/src/ludamus/locale/pl/LC_MESSAGES/django.po
@@ -7081,6 +7081,17 @@ msgstr "Dodaj przedziały czasowe, aby zobaczyć siatkę harmonogramu."
 msgid "total"
 msgstr "łącznie"
 
+#: src/ludamus/templates/panel/parts/timetable-grid.html
+msgid "Column width"
+msgstr "Szerokość kolumny"
+
+#: src/ludamus/templates/panel/parts/timetable-grid.html
+msgid ""
+"Drag, or use the arrow keys, to resize every column. Double-click to reset."
+msgstr ""
+"Przeciągnij lub użyj strzałek, aby zmienić szerokość wszystkich kolumn. "
+"Kliknij dwukrotnie, aby przywrócić domyślną."
+
 #: src/ludamus/templates/panel/parts/timetable-session-detail.html
 msgid "Session details"
 msgstr "Szczegóły punktu programu"

--- a/src/ludamus/mills/chronology.py
+++ b/src/ludamus/mills/chronology.py
@@ -24,7 +24,6 @@ from ludamus.pacts import (
     SessionStatus,
 )
 from ludamus.pacts.chronology import (
-    TIMETABLE_SLOT_MINUTES,
     CapacityHoursDTO,
     CheckOutcome,
     CheckResult,
@@ -60,6 +59,7 @@ from ludamus.pacts.chronology import (
 from ludamus.pacts.legacy import resolve_cover_image
 from ludamus.pacts.submissions import ImportRow, ImportSettings, QuestionTarget
 from ludamus.specs.chronology import resolve_facilitator_session_edit
+from ludamus.specs.timetable import TIMETABLE_SLOT_MINUTES
 
 _SOURCE_QUESTIONS_ADAPTER = TypeAdapter(list[SourceQuestion])
 

--- a/src/ludamus/mills/timetable.py
+++ b/src/ludamus/mills/timetable.py
@@ -11,9 +11,6 @@ from ludamus.pacts import (
     SessionStatus,
 )
 from ludamus.pacts.chronology import (
-    TIMETABLE_ROOM_PAGE_SIZE,
-    TIMETABLE_SLOT_MINUTES,
-    TIMETABLE_SNAP_MINUTES,
     DateSelection,
     SessionPlacement,
     SessionPositionDTO,
@@ -22,6 +19,11 @@ from ludamus.pacts.chronology import (
     TimeLabelDTO,
     TimetableDayGridDTO,
     TimetableGridDTO,
+)
+from ludamus.specs.timetable import (
+    TIMETABLE_ROOM_PAGE_SIZE,
+    TIMETABLE_SLOT_MINUTES,
+    TIMETABLE_SNAP_MINUTES,
 )
 
 if TYPE_CHECKING:
@@ -153,6 +155,10 @@ class TimetableService:
             page=space_page,
             total_pages=total_pages,
             total_spaces=total_spaces,
+            # Every day renders the same page of spaces -- `groups` already
+            # relies on that -- so the calendar's flat track list is just the
+            # page repeated once per day.
+            total_columns=len(spaces) * len(days),
             available_dates=available_dates,
             date_selection=date_selection,
         )

--- a/src/ludamus/pacts/chronology.py
+++ b/src/ludamus/pacts/chronology.py
@@ -427,6 +427,13 @@ class TimetableGridDTO(BaseModel):
     available_dates: list[date] = []
     date_selection: DateSelection = "all"
 
+    @property
+    def total_columns(self) -> int:
+        # The calendar is one flat track list that the sticky header and the
+        # scrolling body are both laid out from, so it needs every day's
+        # columns end to end.
+        return sum(len(day.columns) for day in self.days)
+
 
 class ConflictType(StrEnum):
     SPACE_OVERLAP = auto()

--- a/src/ludamus/pacts/chronology.py
+++ b/src/ludamus/pacts/chronology.py
@@ -373,11 +373,6 @@ class SessionModalServiceProtocol(Protocol):
     ) -> SessionModalDTO | None: ...
 
 
-TIMETABLE_ROOM_PAGE_SIZE = 5
-TIMETABLE_SLOT_MINUTES = 60
-TIMETABLE_SNAP_MINUTES = 5
-
-
 class SessionPositionDTO(BaseModel):
     agenda_item: AgendaItemDTO
     start_minutes: int
@@ -424,15 +419,9 @@ class TimetableGridDTO(BaseModel):
     page: int
     total_pages: int
     total_spaces: int
+    total_columns: int
     available_dates: list[date] = []
     date_selection: DateSelection = "all"
-
-    @property
-    def total_columns(self) -> int:
-        # The calendar is one flat track list that the sticky header and the
-        # scrolling body are both laid out from, so it needs every day's
-        # columns end to end.
-        return sum(len(day.columns) for day in self.days)
 
 
 class ConflictType(StrEnum):

--- a/src/ludamus/specs/timetable.py
+++ b/src/ludamus/specs/timetable.py
@@ -1,0 +1,5 @@
+"""Business invariants for the timetable grid."""
+
+TIMETABLE_ROOM_PAGE_SIZE = 5
+TIMETABLE_SLOT_MINUTES = 60
+TIMETABLE_SNAP_MINUTES = 5

--- a/src/ludamus/templates/panel/parts/timetable-day-grid.html
+++ b/src/ludamus/templates/panel/parts/timetable-day-grid.html
@@ -1,52 +1,50 @@
 {% load i18n %}
 {% with date_value=date_selection|date:"Y-m-d"|default:date_selection %}
     {% load tessera %}
-    <div class="flex bg-bg-secondary">
-        {% for col in day.columns %}
-            <div class="flex-1 min-w-36 relative border-l border-border timetable-column first:border-l-0"
-                 data-space-pk="{{ col.space.pk }}">
-                {% for label in grid.time_labels %}
-                    <div class="timetable-slot-line absolute left-0 right-0 border-t border-border"
-                         style="--offset: {{ label.offset_minutes }}"></div>
-                {% endfor %}
-                {% for pos in col.sessions %}
-                    <div class="timetable-session absolute rounded-md overflow-hidden cursor-pointer border text-xs opacity-85 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary {% if pos.agenda_item.session_id in conflict_session_pks %} bg-danger-bg border-danger hover:opacity-100 {% elif pos.agenda_item.session_id in slot_violation_session_pks %} bg-warning-bg border-warning hover:opacity-100 {% else %} bg-info-bg border-info hover:opacity-100 {% endif %}"
-                         tabindex="0"
-                         draggable="true"
-                         data-session-pk="{{ pos.agenda_item.session_id }}"
-                         data-duration="{{ pos.duration_minutes }}"
-                         data-confirmed="{{ pos.agenda_item.session_confirmed|yesno:'true,false' }}"
-                         title="{{ pos.agenda_item.session_title }}"
-                         style="--offset: {{ pos.start_minutes }};
-                                --duration: {{ pos.duration_minutes }};
-                                --lane-start: {{ pos.lane_start_pct }}%;
-                                --lane-width: {{ pos.lane_width_pct }}%"
-                         hx-get="{% url 'panel:timetable-session-detail-part' slug=slug pk=pos.agenda_item.session_id %}?track={{ filter_track_pk|default:'' }}&date={{ date_value }}"
-                         hx-target="#left-pane"
-                         hx-swap="outerHTML">
-                        <div class="timetable-session-body px-1 py-0.5 h-full overflow-hidden">
-                            <div class="timetable-session-title font-medium wrap-anywhere {% if pos.agenda_item.session_id in conflict_session_pks %}text-danger-text{% elif pos.agenda_item.session_id in slot_violation_session_pks %}text-warning-text{% else %}text-info-text{% endif %}">
-                                {% if pos.agenda_item.session_id in conflict_session_pks %}
-                                    ⚠
-                                {% elif pos.agenda_item.session_id in slot_violation_session_pks %}
-                                    ⏰
-                                {% endif %}
-                                {% if pos.agenda_item.session_confirmed %}
-                                    {% translate "Confirmed" as t_confirmed %}
-                                    <span aria-label="{{ t_confirmed }}" title="{{ t_confirmed }}">{% icon "lock-closed" variant="mini" class="w-3 h-3 inline" %}</span>
-                                {% endif %}
-                                {{ pos.agenda_item.session_title|truncatechars:256 }}
-                            </div>
-                            <div class="timetable-session-meta timetable-session-presenter wrap-anywhere {% if pos.agenda_item.session_id in conflict_session_pks %}text-danger{% elif pos.agenda_item.session_id in slot_violation_session_pks %}text-warning{% else %}text-info{% endif %} {% if pos.duration_minutes <= 32 %}hidden{% endif %}">
-                                {{ pos.agenda_item.presenter_name }}
-                            </div>
-                            <div class="timetable-session-meta timetable-session-duration {% if pos.agenda_item.session_id in conflict_session_pks %}text-danger{% elif pos.agenda_item.session_id in slot_violation_session_pks %}text-warning{% else %}text-info{% endif %} {% if pos.duration_minutes <= 52 %}hidden{% endif %}">
-                                {{ pos.agenda_item.session_duration_minutes }} min
-                            </div>
+    {% for col in day.columns %}
+        <div class="timetable-column relative border-l border-border"
+             data-space-pk="{{ col.space.pk }}">
+            {% for label in grid.time_labels %}
+                <div class="timetable-slot-line absolute left-0 right-0 border-t border-border"
+                     style="--offset: {{ label.offset_minutes }}"></div>
+            {% endfor %}
+            {% for pos in col.sessions %}
+                <div class="timetable-session absolute rounded-md overflow-hidden cursor-pointer border text-xs opacity-85 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary {% if pos.agenda_item.session_id in conflict_session_pks %} bg-danger-bg border-danger hover:opacity-100 {% elif pos.agenda_item.session_id in slot_violation_session_pks %} bg-warning-bg border-warning hover:opacity-100 {% else %} bg-info-bg border-info hover:opacity-100 {% endif %}"
+                     tabindex="0"
+                     draggable="true"
+                     data-session-pk="{{ pos.agenda_item.session_id }}"
+                     data-duration="{{ pos.duration_minutes }}"
+                     data-confirmed="{{ pos.agenda_item.session_confirmed|yesno:'true,false' }}"
+                     title="{{ pos.agenda_item.session_title }}"
+                     style="--offset: {{ pos.start_minutes }};
+                            --duration: {{ pos.duration_minutes }};
+                            --lane-start: {{ pos.lane_start_pct }}%;
+                            --lane-width: {{ pos.lane_width_pct }}%"
+                     hx-get="{% url 'panel:timetable-session-detail-part' slug=slug pk=pos.agenda_item.session_id %}?track={{ filter_track_pk|default:'' }}&date={{ date_value }}"
+                     hx-target="#left-pane"
+                     hx-swap="outerHTML">
+                    <div class="timetable-session-body px-1 py-0.5 h-full overflow-hidden">
+                        <div class="timetable-session-title font-medium wrap-anywhere {% if pos.agenda_item.session_id in conflict_session_pks %}text-danger-text{% elif pos.agenda_item.session_id in slot_violation_session_pks %}text-warning-text{% else %}text-info-text{% endif %}">
+                            {% if pos.agenda_item.session_id in conflict_session_pks %}
+                                ⚠
+                            {% elif pos.agenda_item.session_id in slot_violation_session_pks %}
+                                ⏰
+                            {% endif %}
+                            {% if pos.agenda_item.session_confirmed %}
+                                {% translate "Confirmed" as t_confirmed %}
+                                <span aria-label="{{ t_confirmed }}" title="{{ t_confirmed }}">{% icon "lock-closed" variant="mini" class="w-3 h-3 inline" %}</span>
+                            {% endif %}
+                            {{ pos.agenda_item.session_title|truncatechars:256 }}
+                        </div>
+                        <div class="timetable-session-meta timetable-session-presenter wrap-anywhere {% if pos.agenda_item.session_id in conflict_session_pks %}text-danger{% elif pos.agenda_item.session_id in slot_violation_session_pks %}text-warning{% else %}text-info{% endif %} {% if pos.duration_minutes <= 32 %}hidden{% endif %}">
+                            {{ pos.agenda_item.presenter_name }}
+                        </div>
+                        <div class="timetable-session-meta timetable-session-duration {% if pos.agenda_item.session_id in conflict_session_pks %}text-danger{% elif pos.agenda_item.session_id in slot_violation_session_pks %}text-warning{% else %}text-info{% endif %} {% if pos.duration_minutes <= 52 %}hidden{% endif %}">
+                            {{ pos.agenda_item.session_duration_minutes }} min
                         </div>
                     </div>
-                {% endfor %}
-            </div>
-        {% endfor %}
-    </div>
+                </div>
+            {% endfor %}
+        </div>
+    {% endfor %}
 {% endwith %}

--- a/src/ludamus/templates/panel/parts/timetable-grid.html
+++ b/src/ludamus/templates/panel/parts/timetable-grid.html
@@ -39,12 +39,12 @@
     <div class="timetable-calendar overflow-auto overscroll-contain border border-border rounded-lg select-none"
          data-timetable-days
          style="--grid-extent: {{ grid.total_minutes }};
-                --total-columns: {{ grid.total_columns }}">
+                --total-columns: {{ grid.total_columns }};
+                --columns-per-day: {{ grid.spaces|length }}">
         <div class="timetable-day-strip timetable-day-strip-header sticky top-0 z-20 border-b border-neutral-700">
             <div class="timetable-corner sticky left-0 z-40 flex items-end justify-end bg-neutral-800 px-2 py-2 text-xs text-neutral-300">{% translate "Time" %}</div>
             {% for day in grid.days %}
-                <div class="timetable-day-header"
-                     style="--column-count: {{ day.columns|length }}">
+                <div class="timetable-day-header">
                     {% if grid.days|length > 1 %}
                         <h2 id="timetable-day-{{ day.date|date:'Ymd' }}"
                             class="timetable-day-title flex h-9 items-center border-b border-l border-neutral-700 bg-neutral-900 px-3 text-sm font-semibold text-white">{{ day.date|date:"l, M j" }}</h2>
@@ -62,21 +62,22 @@
                                 <div class="text-xs text-neutral-400">{{ col.space.capacity }} cap.</div>
                             {% endif %}
                             {% comment %}
-                            All columns share one width, so every handle resizes the whole grid. The
-                            rest are the same control under a different pointer target, so only the
-                            first one is exposed — one tab stop per column would be noise.
+                            Every room border is a drag grip (a hit-testable ::after, so the pointer
+                            path costs no nodes). All columns share one width, so one control is the
+                            whole story -- this is it, carrying focus and the ARIA contract.
                             {% endcomment %}
                             {% if forloop.first and forloop.parentloop.first %}
+                                {% comment %}
+                                Focusable only once timetable.ts has added tabindex and the
+                                aria-value* range: resizing is script-only, so without it this is a
+                                static separator rather than a dead tab stop. The bounds stay in one
+                                place, the script.
+                                {% endcomment %}
                                 <div class="timetable-column-resizer"
                                      role="separator"
                                      aria-orientation="vertical"
                                      aria-label="{{ t_column_width }}"
-                                     title="{{ t_column_width_hint }}"
-                                     tabindex="0"></div>
-                            {% else %}
-                                <div class="timetable-column-resizer"
-                                     title="{{ t_column_width_hint }}"
-                                     aria-hidden="true"></div>
+                                     title="{{ t_column_width_hint }}"></div>
                             {% endif %}
                         </div>
                     {% endfor %}

--- a/src/ludamus/templates/panel/parts/timetable-grid.html
+++ b/src/ludamus/templates/panel/parts/timetable-grid.html
@@ -36,39 +36,36 @@
     {% endif %}
     <div class="timetable-calendar overflow-auto overscroll-contain border border-border rounded-lg select-none"
          data-timetable-days
-         style="--grid-extent: {{ grid.total_minutes }}">
-        <div class="timetable-day-strip sticky top-0 z-20 flex min-w-full w-max items-stretch border-b border-neutral-700 pr-px">
-            <div class="sticky left-0 z-40 flex w-16 flex-none items-end justify-end bg-neutral-800 px-2 py-2 text-xs text-neutral-300">{% translate "Time" %}</div>
+         style="--grid-extent: {{ grid.total_minutes }};
+                --total-columns: {{ grid.total_columns }}">
+        <div class="timetable-day-strip timetable-day-strip-header sticky top-0 z-20 border-b border-neutral-700">
+            <div class="timetable-corner sticky left-0 z-40 flex items-end justify-end bg-neutral-800 px-2 py-2 text-xs text-neutral-300">{% translate "Time" %}</div>
             {% for day in grid.days %}
-                <div class="timetable-day-header flex flex-col border-l border-neutral-700"
+                <div class="timetable-day-header"
                      style="--column-count: {{ day.columns|length }}">
                     {% if grid.days|length > 1 %}
                         <h2 id="timetable-day-{{ day.date|date:'Ymd' }}"
-                            class="flex h-9 items-center border-b border-neutral-700 bg-neutral-900 px-3 text-sm font-semibold text-white">{{ day.date|date:"l, M j" }}</h2>
+                            class="timetable-day-title flex h-9 items-center border-b border-l border-neutral-700 bg-neutral-900 px-3 text-sm font-semibold text-white">{{ day.date|date:"l, M j" }}</h2>
                     {% endif %}
-                    <div class="flex border-b border-neutral-700 bg-neutral-900">
-                        {% for group in grid.groups %}
-                            <div class="timetable-header-cell border-l border-neutral-700 bg-neutral-900 px-3 py-1 text-center first:border-l-0"
-                                 style="--columns: {{ group.span }}">
-                                <div class="text-xs font-semibold text-white uppercase tracking-wide">{{ group.parent_name|default:"—" }}</div>
-                            </div>
-                        {% endfor %}
-                    </div>
-                    <div class="flex flex-1 bg-neutral-800">
-                        {% for col in day.columns %}
-                            <div class="flex min-w-36 flex-1 flex-col justify-center border-l border-neutral-700 px-3 py-2 text-center first:border-l-0">
-                                <div class="text-sm font-medium text-white wrap-anywhere">{{ col.space.name }}</div>
-                                {% if col.space.capacity %}
-                                    <div class="text-xs text-neutral-400">{{ col.space.capacity }} cap.</div>
-                                {% endif %}
-                            </div>
-                        {% endfor %}
-                    </div>
+                    {% for group in grid.groups %}
+                        <div class="timetable-header-cell border-b border-l border-neutral-700 bg-neutral-900 px-3 py-1 text-center"
+                             style="--columns: {{ group.span }}">
+                            <div class="text-xs font-semibold text-white uppercase tracking-wide">{{ group.parent_name|default:"—" }}</div>
+                        </div>
+                    {% endfor %}
+                    {% for col in day.columns %}
+                        <div class="timetable-room-cell flex flex-col justify-center border-l border-neutral-700 bg-neutral-800 px-3 py-2 text-center">
+                            <div class="text-sm font-medium text-white wrap-anywhere">{{ col.space.name }}</div>
+                            {% if col.space.capacity %}
+                                <div class="text-xs text-neutral-400">{{ col.space.capacity }} cap.</div>
+                            {% endif %}
+                        </div>
+                    {% endfor %}
                 </div>
             {% endfor %}
         </div>
-        <div class="timetable-day-strip flex min-w-full w-max items-start">
-            <div class="timetable-time-axis sticky left-0 z-10 w-16 flex-none border-r border-border bg-bg-secondary shadow-sm">
+        <div class="timetable-day-strip">
+            <div class="timetable-time-axis sticky left-0 z-10 bg-bg-secondary shadow-sm">
                 {% for label in grid.time_labels %}
                     <div class="timetable-time-label absolute left-0 right-0 flex items-center justify-end -translate-y-1/2"
                          style="--offset: {{ label.offset_minutes }}">
@@ -77,7 +74,7 @@
                 {% endfor %}
             </div>
             {% for day in grid.days %}
-                <section class="timetable-day-grid {% if not forloop.first %}border-l border-border{% endif %}"
+                <section class="timetable-day-grid bg-bg-secondary"
                          style="--column-count: {{ day.columns|length }}"
                          data-timetable-day="{{ day.date|date:'Y-m-d' }}"
                          data-date="{{ day.date|date:'Y-m-d' }}"

--- a/src/ludamus/templates/panel/parts/timetable-grid.html
+++ b/src/ludamus/templates/panel/parts/timetable-grid.html
@@ -34,6 +34,8 @@
             {% endif %}
         </div>
     {% endif %}
+    {% translate "Column width" as t_column_width %}
+    {% translate "Drag, or use the arrow keys, to resize every column. Double-click to reset." as t_column_width_hint %}
     <div class="timetable-calendar overflow-auto overscroll-contain border border-border rounded-lg select-none"
          data-timetable-days
          style="--grid-extent: {{ grid.total_minutes }};
@@ -58,6 +60,23 @@
                             <div class="text-sm font-medium text-white wrap-anywhere">{{ col.space.name }}</div>
                             {% if col.space.capacity %}
                                 <div class="text-xs text-neutral-400">{{ col.space.capacity }} cap.</div>
+                            {% endif %}
+                            {% comment %}
+                            All columns share one width, so every handle resizes the whole grid. The
+                            rest are the same control under a different pointer target, so only the
+                            first one is exposed — one tab stop per column would be noise.
+                            {% endcomment %}
+                            {% if forloop.first and forloop.parentloop.first %}
+                                <div class="timetable-column-resizer"
+                                     role="separator"
+                                     aria-orientation="vertical"
+                                     aria-label="{{ t_column_width }}"
+                                     title="{{ t_column_width_hint }}"
+                                     tabindex="0"></div>
+                            {% else %}
+                                <div class="timetable-column-resizer"
+                                     title="{{ t_column_width_hint }}"
+                                     aria-hidden="true"></div>
                             {% endif %}
                         </div>
                     {% endfor %}

--- a/tests/e2e/tests/timetable.spec.ts
+++ b/tests/e2e/tests/timetable.spec.ts
@@ -187,6 +187,57 @@ test.describe("Timetable", () => {
     await expectAligned();
   });
 
+  test("dragging one column edge resizes every column, and the width sticks", async ({ page }) => {
+    await page.setViewportSize({ width: 1280, height: 800 });
+    await page.goto("/panel/event/sunhaven-festival/timetable/?date=all");
+
+    // One entry means every column agrees; drift is header vs the body it labels.
+    const geometry = () =>
+      page.locator(".timetable-calendar").evaluate((calendar) => {
+        const boxes = (selector: string) =>
+          Array.from(calendar.querySelectorAll(selector), (cell) => cell.getBoundingClientRect());
+        const header = boxes(".timetable-room-cell");
+        const body = boxes(".timetable-column");
+        return {
+          drift: Math.max(...body.map((box, index) => Math.abs(box.left - header[index].left))),
+          widths: [...new Set(header.map((box) => Math.round(box.width)))],
+        };
+      });
+    const expectWidth = async (expected: number) => {
+      const { drift, widths } = await geometry();
+      expect(widths).toHaveLength(1);
+      expect(Math.abs(widths[0] - expected)).toBeLessThanOrEqual(1);
+      expect(drift).toBeLessThanOrEqual(1);
+    };
+
+    const start = (await geometry()).widths[0];
+
+    // The second handle has two columns to its left, so they split the travel.
+    const handle = page.locator(".timetable-column-resizer").nth(1);
+    const grip = (await handle.boundingBox())!;
+    const [gripX, gripY] = [grip.x + grip.width / 2, grip.y + grip.height / 2];
+    await page.mouse.move(gripX, gripY);
+    await page.mouse.down();
+    await page.mouse.move(gripX + 80, gripY, { steps: 8 });
+    await page.mouse.up();
+    await expectWidth(start + 40);
+
+    await page.reload();
+    await expect(page.locator(".timetable-calendar")).toBeVisible();
+    await expectWidth(start + 40);
+
+    // A single exposed handle stands in for all of them.
+    const exposed = page.locator('.timetable-column-resizer[role="separator"]');
+    await expect(exposed).toHaveCount(1);
+    await expect(exposed).toHaveAttribute("aria-valuenow", String(start + 40));
+    await exposed.focus();
+    await exposed.press("ArrowRight");
+    await expectWidth(start + 56);
+
+    await handle.dblclick();
+    await expectWidth(start);
+  });
+
   test("session list loads via HTMX and shows unscheduled sessions", async ({ page }) => {
     const sessionListLoaded = page.waitForResponse(
       (r) => r.url().includes("/parts/sessions/") && r.status() === 200,

--- a/tests/e2e/tests/timetable.spec.ts
+++ b/tests/e2e/tests/timetable.spec.ts
@@ -149,6 +149,44 @@ test.describe("Timetable", () => {
     });
   });
 
+  test("room headers stay aligned with their columns, whatever they contain", async ({ page }) => {
+    await page.setViewportSize({ width: 480, height: 800 });
+    await page.goto("/panel/event/sunhaven-festival/timetable/?date=all");
+
+    const columnEdges = () =>
+      page.locator(".timetable-calendar").evaluate((calendar) => {
+        const edges = (selector: string) =>
+          Array.from(calendar.querySelectorAll(selector), (cell) => {
+            const box = cell.getBoundingClientRect();
+            return { left: box.left, right: box.right };
+          });
+        return { body: edges(".timetable-column"), header: edges(".timetable-room-cell") };
+      });
+
+    const expectAligned = async () => {
+      const { body, header } = await columnEdges();
+      expect(header.length).toBeGreaterThan(1);
+      expect(body).toHaveLength(header.length);
+      for (const [index, cell] of header.entries()) {
+        expect(Math.abs(cell.left - body[index].left)).toBeLessThanOrEqual(1);
+        expect(Math.abs(cell.right - body[index].right)).toBeLessThanOrEqual(1);
+      }
+    };
+
+    await expectAligned();
+
+    // Column widths must come from the track list, not from what a cell holds:
+    // sessions are absolutely positioned and contribute no width, so any
+    // content-driven header would drift away from the body it labels.
+    await page
+      .locator(".timetable-room-cell")
+      .first()
+      .evaluate((cell) => {
+        cell.textContent = "Room name long enough to stretch a content-sized column";
+      });
+    await expectAligned();
+  });
+
   test("session list loads via HTMX and shows unscheduled sessions", async ({ page }) => {
     const sessionListLoaded = page.waitForResponse(
       (r) => r.url().includes("/parts/sessions/") && r.status() === 200,

--- a/tests/e2e/tests/timetable.spec.ts
+++ b/tests/e2e/tests/timetable.spec.ts
@@ -177,12 +177,13 @@ test.describe("Timetable", () => {
 
     // Column widths must come from the track list, not from what a cell holds:
     // sessions are absolutely positioned and contribute no width, so any
-    // content-driven header would drift away from the body it labels.
+    // content-driven header would drift away from the body it labels. Written
+    // into the room name, leaving the resize handle that shares the cell alone.
     await page
-      .locator(".timetable-room-cell")
-      .first()
-      .evaluate((cell) => {
-        cell.textContent = "Room name long enough to stretch a content-sized column";
+      .locator(".timetable-room-cell div")
+      .last()
+      .evaluate((name) => {
+        name.textContent = "Room name long enough to stretch a content-sized column";
       });
     await expectAligned();
   });
@@ -212,29 +213,55 @@ test.describe("Timetable", () => {
 
     const start = (await geometry()).widths[0];
 
-    // The second handle has two columns to its left, so they split the travel.
-    const handle = page.locator(".timetable-column-resizer").nth(1);
-    const grip = (await handle.boundingBox())!;
-    const [gripX, gripY] = [grip.x + grip.width / 2, grip.y + grip.height / 2];
-    await page.mouse.move(gripX, gripY);
+    // Grabbing the border after the second column, so the two columns before it
+    // split the travel -- the border itself tracks the cursor either way.
+    const grabbed = 2;
+    const border = (await page
+      .locator(".timetable-room-cell")
+      .nth(grabbed - 1)
+      .boundingBox())!;
+    const [edgeX, edgeY] = [border.x + border.width - 2, border.y + border.height / 2];
+    const travel = 80;
+    await page.mouse.move(edgeX, edgeY);
     await page.mouse.down();
-    await page.mouse.move(gripX + 80, gripY, { steps: 8 });
+    await page.mouse.move(edgeX + travel, edgeY, { steps: 8 });
     await page.mouse.up();
-    await expectWidth(start + 40);
+    const resized = start + travel / grabbed;
+    await expectWidth(resized);
 
     await page.reload();
     await expect(page.locator(".timetable-calendar")).toBeVisible();
-    await expectWidth(start + 40);
+    await expectWidth(resized);
 
-    // A single exposed handle stands in for all of them.
-    const exposed = page.locator('.timetable-column-resizer[role="separator"]');
-    await expect(exposed).toHaveCount(1);
-    await expect(exposed).toHaveAttribute("aria-valuenow", String(start + 40));
-    await exposed.focus();
-    await exposed.press("ArrowRight");
-    await expectWidth(start + 56);
+    // Every border resizes, but one handle carries focus and the ARIA contract,
+    // and the script is what promotes it from a static separator.
+    const handle = page.locator('.timetable-column-resizer[role="separator"]');
+    await expect(handle).toHaveCount(1);
+    await expect(handle).toHaveAttribute("aria-valuenow", String(Math.round(resized)));
+    await expect(handle).toHaveAttribute("tabindex", "0");
+    await handle.focus();
+    await handle.press("ArrowRight");
+    await expectWidth(resized + 16);
 
-    await handle.dblclick();
+    // The width outlives an HTMX swap of the grid because it is stored above
+    // every node HTMX replaces; the handle in the new markup is re-promoted.
+    await Promise.all([
+      page.waitForResponse((r) => r.url().includes("/parts/grid/") && r.status() === 200),
+      page.evaluate(() => document.body.dispatchEvent(new Event("timetableChanged"))),
+    ]);
+    await expectWidth(resized + 16);
+    await expect(handle).toHaveAttribute("tabindex", "0");
+
+    // Re-measured: the cell is wider than when it was grabbed, so the grip has
+    // moved with its right edge.
+    const widened = (await page
+      .locator(".timetable-room-cell")
+      .nth(grabbed - 1)
+      .boundingBox())!;
+    await page
+      .locator(".timetable-room-cell")
+      .nth(grabbed - 1)
+      .dblclick({ position: { x: widened.width - 2, y: widened.height / 2 } });
     await expectWidth(start);
   });
 

--- a/tests/e2e/tests/timetable.spec.ts
+++ b/tests/e2e/tests/timetable.spec.ts
@@ -235,7 +235,7 @@ test.describe("Timetable", () => {
 
     // Every border resizes, but one handle carries focus and the ARIA contract,
     // and the script is what promotes it from a static separator.
-    const handle = page.locator('.timetable-column-resizer[role="separator"]');
+    const handle = page.getByRole("separator", { name: "Column width" });
     await expect(handle).toHaveCount(1);
     await expect(handle).toHaveAttribute("aria-valuenow", String(Math.round(resized)));
     await expect(handle).toHaveAttribute("tabindex", "0");

--- a/tests/integration/web/panel/test_timetable.py
+++ b/tests/integration/web/panel/test_timetable.py
@@ -9,11 +9,11 @@ from django.urls import reverse
 
 from ludamus.links.db.django.models import Track
 from ludamus.pacts import EventDTO
-from ludamus.pacts.chronology import (
+from ludamus.pacts.chronology import TimetableGridDTO
+from ludamus.specs.timetable import (
     TIMETABLE_ROOM_PAGE_SIZE,
     TIMETABLE_SLOT_MINUTES,
     TIMETABLE_SNAP_MINUTES,
-    TimetableGridDTO,
 )
 from tests.integration.conftest import (
     AgendaItemFactory,
@@ -39,6 +39,7 @@ def _empty_grid():
         page=1,
         total_pages=1,
         total_spaces=0,
+        total_columns=0,
         available_dates=[],
     )
 
@@ -220,10 +221,40 @@ class TestTimetablePageView:
         assert content.count('class="timetable-time-axis ') == 1
         assert content.count("Time</div>") == 1
         assert [column.space.pk for column in grid.days[0].columns] == [space.pk]
-        # Header and body share one track list, so the calendar has to declare
-        # every day's columns end to end.
-        assert grid.total_columns == expected_day_count
-        assert "--total-columns: 2" in content
+
+    def test_grid_declares_one_track_per_room_per_day(
+        self, authenticated_client, active_user, sphere, event, space, time_slot
+    ):
+        # Rooms and days differ, and differ from their product, so nothing but
+        # the track count itself can satisfy the assertions.
+        sphere.managers.add(active_user)
+        room_count = 3
+        day_count = 2
+        for _ in range(room_count - 1):
+            SpaceFactory(event=event)
+        TimeSlotFactory(
+            event=event,
+            start_time=time_slot.start_time + timedelta(days=1),
+            end_time=time_slot.end_time + timedelta(days=1),
+        )
+
+        response = authenticated_client.get(self.get_url(event), {"date": "all"})
+
+        assert_response(
+            response,
+            HTTPStatus.OK,
+            template_name="panel/timetable.html",
+            context_data=response.context_data,
+            # Header and body are laid out from these two numbers alone.
+            contains=["--total-columns: 6", "--columns-per-day: 3"],
+        )
+        grid = response.context["grid"]
+        assert len(grid.spaces) == room_count
+        assert len(grid.days) == day_count
+        assert grid.total_columns == room_count * day_count
+        content = response.content.decode()
+        assert content.count('class="timetable-room-cell ') == room_count * day_count
+        assert space.pk in {column.space.pk for column in grid.days[0].columns}
 
     def test_single_schedule_day_hides_day_selector(
         self, authenticated_client, active_user, sphere, event, time_slot

--- a/tests/integration/web/panel/test_timetable.py
+++ b/tests/integration/web/panel/test_timetable.py
@@ -220,6 +220,10 @@ class TestTimetablePageView:
         assert content.count('class="timetable-time-axis ') == 1
         assert content.count("Time</div>") == 1
         assert [column.space.pk for column in grid.days[0].columns] == [space.pk]
+        # Header and body share one track list, so the calendar has to declare
+        # every day's columns end to end.
+        assert grid.total_columns == expected_day_count
+        assert "--total-columns: 2" in content
 
     def test_single_schedule_day_hides_day_selector(
         self, authenticated_client, active_user, sphere, event, time_slot

--- a/tests/integration/web/panel/test_timetable_assign.py
+++ b/tests/integration/web/panel/test_timetable_assign.py
@@ -11,12 +11,9 @@ from ludamus.links.db.django.models import (
     SessionParticipation,
     SessionParticipationStatus,
 )
-from ludamus.pacts.chronology import (
-    TIMETABLE_SLOT_MINUTES,
-    TIMETABLE_SNAP_MINUTES,
-    TimetableGridDTO,
-)
+from ludamus.pacts.chronology import TimetableGridDTO
 from ludamus.pacts.legacy import NotificationKind
+from ludamus.specs.timetable import TIMETABLE_SLOT_MINUTES, TIMETABLE_SNAP_MINUTES
 from tests.integration.conftest import (
     AgendaItemFactory,
     EventFactory,
@@ -43,6 +40,7 @@ def _empty_grid():
         page=1,
         total_pages=1,
         total_spaces=0,
+        total_columns=0,
         available_dates=[],
     )
 


### PR DESCRIPTION
The sticky header and the scrolling body were two independent `w-max`
flex rows. Each sized itself to its own content, and the two contents are
not comparable: room names give the header real intrinsic width, while
the body's sessions are absolutely positioned and contribute none. The
header therefore ran wider than the columns it labels, by a gap that grew
with every day and room -- 392px at three days by five rooms, enough to
put a session under the wrong room name.

Both strips are now CSS grids over the same explicit tracks, one per
column across all days, declared once on the calendar as
`--total-columns`. `minmax(9rem, 1fr)` pins the lower bound so no cell's
content can widen a track, and each strip's width is computed from the
column count rather than derived from `max-content`. Days become subgrids
so a day's own cells inherit those tracks instead of re-splitting their
share -- which is also why day wrappers must stay free of padding and
border, noted in the CSS.

Adding a day, a room, or a longer room name now moves both strips
identically or not at all.

Co-authored-by: hasparus <hasparus@gmail.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added resizable timetable columns using mouse or keyboard controls.
  * Column widths now persist between visits and can be reset with a double-click.
  * Added accessible labels and instructions for column resizing.
* **Improvements**
  * Improved timetable header and room-column alignment, including when content changes.
  * Enhanced layout stability across dynamic timetable updates.
* **Documentation**
  * Recorded troubleshooting notes for sandbox tooling, browser setup, and frontend asset updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->