### PR TITLE
fix(flaky): test_get_groups_errors_and_successes_and_folds_successes_by_default

### DIFF
--- a/tests/integration/web/panel/test_import_views.py
+++ b/tests/integration/web/panel/test_import_views.py
@@ -171,6 +171,14 @@ def _sheets_get(values, *, title="Form Responses 1"):
     return lambda url, **_: vals if "/values/" in url else meta
 
 
+def _successes_details_tag(body: str) -> str:
+    # Scoped to the successes <details ...> opening tag itself, not the whole
+    # page: unrelated content (e.g. a randomly generated event title) can
+    # otherwise contain the substring "open" and make the check flaky.
+    start = body.index('<details class="card p-4 sm:p-5"')
+    return body[start : body.index(">", start) + 1]
+
+
 @pytest.mark.django_db
 class TestEventImportProposalView:
     def test_get_redirects_anonymous(self, client, event):
@@ -2437,7 +2445,7 @@ class TestEventImportLogPageView:
         body = response.content.decode()
         # Successes are collapsed inside a <details> without `open`.
         assert "<details" in body
-        assert "open" not in body.split("</details>")[0]
+        assert "open" not in _successes_details_tag(body)
 
     def test_post_retry_creates_a_fresh_entry_and_redirects_to_log(
         self, authenticated_client, active_user, sphere, event, connection_with_secret
@@ -2616,7 +2624,7 @@ class TestEventImportLogFilters:
         # The success <details> renders with the open attribute.
         body = response.content.decode()
         assert "<details" in body
-        assert "open" in body.split("</details>")[0]
+        assert "open" in _successes_details_tag(body)
 
     def test_search_narrows_to_matching_title_or_display_name(
         self, authenticated_client, active_user, sphere, event, connection_with_secret


### PR DESCRIPTION
## Summary

Weekly flaky-test sweep of CI runs on `main` over the last 7 days (2026-07-19 → 2026-07-26, 30 CI runs, 462 total workflow runs on record) found exactly **one** test-job failure in that window:

- `tests/integration/web/panel/test_import_views.py::TestEventImportLogPageView::test_get_groups_errors_and_successes_and_folds_successes_by_default`
- Failing run: https://github.com/zagrajmy/ludamus/actions/runs/30021963543 (commit `deb660e`, 2026-07-23)
- No rerun of that exact commit exists in the window, so it doesn't meet the strict "same SHA passed and failed" bar, but the root cause is a textbook non-deterministic-data flake, so I fixed it rather than filing it as unconfirmed.

## Root cause

The test renders the import log page and asserts the successes `<details>` element isn't expanded by default:

```python
assert "open" not in body.split("</details>")[0]
```

`body.split("</details>")[0]` is **everything in the page before the first `</details>` tag** — the whole `<head>`, nav, sidebar, and header — not just the `<details>` opening tag. `EventFactory.name` is `Faker("sentence", nb_words=4)`, and on the failing run it generated the event title "Wind open commercial." — the word "open" in the *title* tripped the substring check even though the `<details>` tag itself correctly had no `open` attribute.

The sibling test `test_status_pill_success_hides_errors_and_opens_details` had the same fragile pattern (checking `"open" in body.split("</details>")[0]`); it happened to keep passing, but for the wrong reason — a random title containing "open" would make it pass regardless of what the `<details>` tag actually rendered.

## Fix

Added a small helper that extracts just the successes `<details class="card p-4 sm:p-5" ...>` opening tag from the response body, and scoped both assertions to it instead of the whole page:

```python
def _successes_details_tag(body: str) -> str:
    start = body.index('<details class="card p-4 sm:p-5"')
    return body[start : body.index(">", start) + 1]
```

Verified against the exact failing scenario (event name forced to `"Wind open commercial."`): the old assertion fails, the new one passes. Ran both affected tests 5x and the full `test_import_views.py` file (128 tests) locally — all green.

## Test plan

- [x] `pytest tests/integration/web/panel/test_import_views.py -k "test_get_groups_errors_and_successes_and_folds_successes_by_default or test_status_pill_success_hides_errors_and_opens_details"` — 5 consecutive runs, all pass
- [x] `pytest tests/integration/web/panel/test_import_views.py` (full file, `-n auto`) — 127 passed, 1 skipped
- [x] Reproduced the original failure mode with a forced `event.name = "Wind open commercial."`, confirmed the new assertion is unaffected while the old one would have failed
- [x] `ruff check` on the changed file — clean

Co-authored-by: hasparus <hasparus@gmail.com>


---
_Generated by [Claude Code](https://claude.ai/code/session_0178vvyPREFqcbpUcvCF97qr)_