### PR TITLE
fix(panel): let organizers toggle multi-select on an existing field

### DIFF
--- a/src/ludamus/gates/web/django/chronology/panel/views/personal_data_fields.py
+++ b/src/ludamus/gates/web/django/chronology/panel/views/personal_data_fields.py
@@ -153,6 +153,8 @@ class PersonalDataFieldEditPageView(PanelAccessMixin, EventContextMixin, View):
         }
         if field.field_type == "select":
             initial["options"] = "\n".join(o.label for o in field.options)
+            initial["is_multiple"] = field.is_multiple
+            initial["allow_custom"] = field.allow_custom
 
         context["active_nav"] = "cfp"
         context["field"] = field
@@ -217,6 +219,8 @@ class PersonalDataFieldEditPageView(PanelAccessMixin, EventContextMixin, View):
                 "help_text": form.cleaned_data.get("help_text") or "",
                 "is_public": form.cleaned_data.get("is_public", False),
                 "options": options,
+                "is_multiple": form.cleaned_data.get("is_multiple") or False,
+                "allow_custom": form.cleaned_data.get("allow_custom") or False,
             },
             category_requirements=cat_reqs,
         )

--- a/src/ludamus/gates/web/django/chronology/panel/views/session_fields.py
+++ b/src/ludamus/gates/web/django/chronology/panel/views/session_fields.py
@@ -180,6 +180,8 @@ class SessionFieldEditPageView(PanelAccessMixin, EventContextMixin, View):
         }
         if field.field_type == "select":
             initial["options"] = "\n".join(o.label for o in field.options)
+            initial["is_multiple"] = field.is_multiple
+            initial["allow_custom"] = field.allow_custom
         context["form"] = SessionFieldForm(initial=initial)
         context["categories"] = self.request.di.uow.proposal_categories.list_by_event(
             current_event.pk
@@ -264,6 +266,8 @@ class SessionFieldEditPageView(PanelAccessMixin, EventContextMixin, View):
                     "icon": form.cleaned_data.get("icon") or "",
                     "is_public": form.cleaned_data.get("is_public", False),
                     "options": options,
+                    "is_multiple": form.cleaned_data.get("is_multiple") or False,
+                    "allow_custom": form.cleaned_data.get("allow_custom") or False,
                 },
             )
             self.request.di.uow.proposal_categories.set_session_field_categories(

--- a/src/ludamus/links/db/django/repositories/submissions.py
+++ b/src/ludamus/links/db/django/repositories/submissions.py
@@ -693,6 +693,12 @@ class PersonalDataFieldRepository(PersonalDataFieldRepositoryProtocol):
         field.max_length = data["max_length"]
         field.help_text = data["help_text"]
         field.is_public = data["is_public"]
+        field.is_multiple = (
+            data["is_multiple"] if field.field_type == "select" else False
+        )
+        field.allow_custom = (
+            data["allow_custom"] if field.field_type == "select" else False
+        )
         field.save()
 
         options = data["options"]
@@ -843,6 +849,12 @@ class SessionFieldRepository(SessionFieldRepositoryProtocol):
         field.help_text = data["help_text"]
         field.icon = data["icon"]
         field.is_public = data["is_public"]
+        field.is_multiple = (
+            data["is_multiple"] if field.field_type == "select" else False
+        )
+        field.allow_custom = (
+            data["allow_custom"] if field.field_type == "select" else False
+        )
         field.save()
 
         options = data["options"]

--- a/src/ludamus/locale/pl/LC_MESSAGES/django.po
+++ b/src/ludamus/locale/pl/LC_MESSAGES/django.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-07-25 13:30+0200\n"
+"POT-Creation-Date: 2026-07-26 18:43+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -6825,13 +6825,17 @@ msgstr "Jedna opcja na linię"
 
 #: src/ludamus/templates/panel/parts/import-recipe-row.html
 #: src/ludamus/templates/panel/personal-data-field-create.html
+#: src/ludamus/templates/panel/personal-data-field-edit.html
 #: src/ludamus/templates/panel/session-field-create.html
+#: src/ludamus/templates/panel/session-field-edit.html
 msgid "Allow multiple selections"
 msgstr "Zezwól na wielokrotny wybór"
 
 #: src/ludamus/templates/panel/parts/import-recipe-row.html
 #: src/ludamus/templates/panel/personal-data-field-create.html
+#: src/ludamus/templates/panel/personal-data-field-edit.html
 #: src/ludamus/templates/panel/session-field-create.html
+#: src/ludamus/templates/panel/session-field-edit.html
 msgid "Allow custom values"
 msgstr "Zezwól na własne wartości"
 

--- a/src/ludamus/pacts/legacy.py
+++ b/src/ludamus/pacts/legacy.py
@@ -1102,6 +1102,8 @@ class PersonalDataFieldUpdateData(TypedDict):
     help_text: str
     is_public: bool
     options: list[str] | None
+    is_multiple: bool
+    allow_custom: bool
 
 
 class SessionFieldCreateData(TypedDict):
@@ -1126,6 +1128,8 @@ class SessionFieldUpdateData(TypedDict):
     icon: str
     is_public: bool
     options: list[str] | None
+    is_multiple: bool
+    allow_custom: bool
 
 
 class PersonalDataFieldRepositoryProtocol(Protocol):

--- a/src/ludamus/templates/panel/personal-data-field-edit.html
+++ b/src/ludamus/templates/panel/personal-data-field-edit.html
@@ -81,6 +81,12 @@
                                           class="w-full border border-border rounded-lg px-4 py-2 focus:outline-none focus:ring-2 focus:ring-primary"
                                           placeholder="{% translate "One option per line" %}">{{ form.options.value|default:'' }}</textarea>
                                 <p class="mt-1 text-sm text-foreground-muted">{% translate "Enter one option per line." %}</p>
+                                {% translate "Allow multiple selections" as t_is_multiple %}
+                                {% translate "Allow custom values" as t_allow_custom %}
+                                <div class="mt-4 flex flex-col gap-3">
+                                    {% include "components/checkbox-field.html" with name="is_multiple" id="id_is_multiple" label=t_is_multiple checked=form.is_multiple.value only %}
+                                    {% include "components/checkbox-field.html" with name="allow_custom" id="id_allow_custom" label=t_allow_custom checked=form.allow_custom.value only %}
+                                </div>
                             </div>
                         {% endif %}
                         {% if field.field_type != "checkbox" %}

--- a/src/ludamus/templates/panel/session-field-edit.html
+++ b/src/ludamus/templates/panel/session-field-edit.html
@@ -81,6 +81,12 @@
                                           class="w-full border border-border rounded-lg px-4 py-2 focus:outline-none focus:ring-2 focus:ring-primary"
                                           placeholder="{% translate "One option per line" %}">{{ form.options.value|default:'' }}</textarea>
                                 <p class="mt-1 text-sm text-foreground-muted">{% translate "Enter one option per line." %}</p>
+                                {% translate "Allow multiple selections" as t_is_multiple %}
+                                {% translate "Allow custom values" as t_allow_custom %}
+                                <div class="mt-4 flex flex-col gap-3">
+                                    {% include "components/checkbox-field.html" with name="is_multiple" id="id_is_multiple" label=t_is_multiple checked=form.is_multiple.value only %}
+                                    {% include "components/checkbox-field.html" with name="allow_custom" id="id_allow_custom" label=t_allow_custom checked=form.allow_custom.value only %}
+                                </div>
                             </div>
                         {% endif %}
                         {% if field.field_type != "checkbox" %}

--- a/tests/integration/web/panel/test_personal_data_field_edit_page.py
+++ b/tests/integration/web/panel/test_personal_data_field_edit_page.py
@@ -417,6 +417,108 @@ class TestPersonalDataFieldEditPageView:
         form = response.context["form"]
         assert form.initial["options"] == "Poland\nGermany"
 
+    def test_get_prepopulates_multi_and_custom_toggles_for_select_field(
+        self, authenticated_client, active_user, sphere, event
+    ):
+        sphere.managers.add(active_user)
+        field = PersonalDataField.objects.create(
+            event=event,
+            name="Country",
+            question="What country?",
+            slug="country",
+            field_type="select",
+            is_multiple=True,
+            allow_custom=True,
+        )
+
+        response = authenticated_client.get(self.get_url(event, field))
+
+        form = response.context["form"]
+        assert form.initial["is_multiple"] is True
+        assert form.initial["allow_custom"] is True
+
+    def test_post_enables_multiple_selection_on_select_field(
+        self, authenticated_client, active_user, sphere, event
+    ):
+        sphere.managers.add(active_user)
+        field = PersonalDataField.objects.create(
+            event=event,
+            name="Country",
+            question="What country?",
+            slug="country",
+            field_type="select",
+        )
+
+        response = authenticated_client.post(
+            self.get_url(event, field),
+            data={
+                "name": "Country",
+                "question": "What country?",
+                "options": "Poland\nGermany",
+                "is_multiple": "on",
+                "allow_custom": "on",
+            },
+        )
+
+        assert_response(
+            response,
+            HTTPStatus.FOUND,
+            messages=[(messages.SUCCESS, "Personal data field updated successfully.")],
+            url=f"/panel/event/{event.slug}/cfp/personal-data/",
+        )
+        field.refresh_from_db()
+        assert field.is_multiple is True
+        assert field.allow_custom is True
+
+    def test_post_disables_multiple_selection_when_unchecked(
+        self, authenticated_client, active_user, sphere, event
+    ):
+        sphere.managers.add(active_user)
+        field = PersonalDataField.objects.create(
+            event=event,
+            name="Country",
+            question="What country?",
+            slug="country",
+            field_type="select",
+            is_multiple=True,
+            allow_custom=True,
+        )
+
+        authenticated_client.post(
+            self.get_url(event, field),
+            data={
+                "name": "Country",
+                "question": "What country?",
+                "options": "Poland\nGermany",
+            },
+        )
+
+        field.refresh_from_db()
+        assert field.is_multiple is False
+        assert field.allow_custom is False
+
+    def test_post_ignores_multi_toggle_on_text_field(
+        self, authenticated_client, active_user, sphere, event
+    ):
+        sphere.managers.add(active_user)
+        field = PersonalDataField.objects.create(
+            event=event, name="Email", question="What is your email?", slug="email"
+        )
+
+        authenticated_client.post(
+            self.get_url(event, field),
+            data={
+                "name": "Email",
+                "question": "What is your email?",
+                "is_multiple": "on",
+                "allow_custom": "on",
+            },
+        )
+
+        field.refresh_from_db()
+        assert field.is_multiple is False
+        assert field.allow_custom is False
+
     def test_get_returns_field_with_is_multiple_attribute(
         self, authenticated_client, active_user, sphere, event
     ):

--- a/tests/integration/web/panel/test_personal_data_field_edit_page.py
+++ b/tests/integration/web/panel/test_personal_data_field_edit_page.py
@@ -484,7 +484,7 @@ class TestPersonalDataFieldEditPageView:
             allow_custom=True,
         )
 
-        authenticated_client.post(
+        response = authenticated_client.post(
             self.get_url(event, field),
             data={
                 "name": "Country",
@@ -493,6 +493,12 @@ class TestPersonalDataFieldEditPageView:
             },
         )
 
+        assert_response(
+            response,
+            HTTPStatus.FOUND,
+            messages=[(messages.SUCCESS, "Personal data field updated successfully.")],
+            url=f"/panel/event/{event.slug}/cfp/personal-data/",
+        )
         field.refresh_from_db()
         assert field.is_multiple is False
         assert field.allow_custom is False
@@ -505,7 +511,7 @@ class TestPersonalDataFieldEditPageView:
             event=event, name="Email", question="What is your email?", slug="email"
         )
 
-        authenticated_client.post(
+        response = authenticated_client.post(
             self.get_url(event, field),
             data={
                 "name": "Email",
@@ -515,6 +521,12 @@ class TestPersonalDataFieldEditPageView:
             },
         )
 
+        assert_response(
+            response,
+            HTTPStatus.FOUND,
+            messages=[(messages.SUCCESS, "Personal data field updated successfully.")],
+            url=f"/panel/event/{event.slug}/cfp/personal-data/",
+        )
         field.refresh_from_db()
         assert field.is_multiple is False
         assert field.allow_custom is False

--- a/tests/integration/web/panel/test_session_field_edit_page.py
+++ b/tests/integration/web/panel/test_session_field_edit_page.py
@@ -416,6 +416,108 @@ class TestSessionFieldEditPageView:
         form = response.context["form"]
         assert form.initial["options"] == "Fantasy\nSci-Fi"
 
+    def test_get_prepopulates_multi_and_custom_toggles_for_select_field(
+        self, authenticated_client, active_user, sphere, event
+    ):
+        sphere.managers.add(active_user)
+        field = SessionField.objects.create(
+            event=event,
+            name="Tags",
+            question="What tags apply?",
+            slug="tags",
+            field_type="select",
+            is_multiple=True,
+            allow_custom=True,
+        )
+
+        response = authenticated_client.get(self.get_url(event, field))
+
+        form = response.context["form"]
+        assert form.initial["is_multiple"] is True
+        assert form.initial["allow_custom"] is True
+
+    def test_post_enables_multiple_selection_on_select_field(
+        self, authenticated_client, active_user, sphere, event
+    ):
+        sphere.managers.add(active_user)
+        field = SessionField.objects.create(
+            event=event,
+            name="Tags",
+            question="What tags apply?",
+            slug="tags",
+            field_type="select",
+        )
+
+        response = authenticated_client.post(
+            self.get_url(event, field),
+            data={
+                "name": "Tags",
+                "question": "What tags apply?",
+                "options": "Fantasy\nSci-Fi",
+                "is_multiple": "on",
+                "allow_custom": "on",
+            },
+        )
+
+        assert_response(
+            response,
+            HTTPStatus.FOUND,
+            messages=[(messages.SUCCESS, "Session field updated successfully.")],
+            url=f"/panel/event/{event.slug}/cfp/session-fields/",
+        )
+        field.refresh_from_db()
+        assert field.is_multiple is True
+        assert field.allow_custom is True
+
+    def test_post_disables_multiple_selection_when_unchecked(
+        self, authenticated_client, active_user, sphere, event
+    ):
+        sphere.managers.add(active_user)
+        field = SessionField.objects.create(
+            event=event,
+            name="Tags",
+            question="What tags apply?",
+            slug="tags",
+            field_type="select",
+            is_multiple=True,
+            allow_custom=True,
+        )
+
+        authenticated_client.post(
+            self.get_url(event, field),
+            data={
+                "name": "Tags",
+                "question": "What tags apply?",
+                "options": "Fantasy\nSci-Fi",
+            },
+        )
+
+        field.refresh_from_db()
+        assert field.is_multiple is False
+        assert field.allow_custom is False
+
+    def test_post_ignores_multi_toggle_on_text_field(
+        self, authenticated_client, active_user, sphere, event
+    ):
+        sphere.managers.add(active_user)
+        field = SessionField.objects.create(
+            event=event, name="Notes", question="Any notes?", slug="notes"
+        )
+
+        authenticated_client.post(
+            self.get_url(event, field),
+            data={
+                "name": "Notes",
+                "question": "Any notes?",
+                "is_multiple": "on",
+                "allow_custom": "on",
+            },
+        )
+
+        field.refresh_from_db()
+        assert field.is_multiple is False
+        assert field.allow_custom is False
+
     def test_get_returns_field_with_is_multiple_attribute(
         self, authenticated_client, active_user, sphere, event
     ):

--- a/tests/integration/web/panel/test_session_field_edit_page.py
+++ b/tests/integration/web/panel/test_session_field_edit_page.py
@@ -483,7 +483,7 @@ class TestSessionFieldEditPageView:
             allow_custom=True,
         )
 
-        authenticated_client.post(
+        response = authenticated_client.post(
             self.get_url(event, field),
             data={
                 "name": "Tags",
@@ -492,6 +492,12 @@ class TestSessionFieldEditPageView:
             },
         )
 
+        assert_response(
+            response,
+            HTTPStatus.FOUND,
+            messages=[(messages.SUCCESS, "Session field updated successfully.")],
+            url=f"/panel/event/{event.slug}/cfp/session-fields/",
+        )
         field.refresh_from_db()
         assert field.is_multiple is False
         assert field.allow_custom is False
@@ -504,7 +510,7 @@ class TestSessionFieldEditPageView:
             event=event, name="Notes", question="Any notes?", slug="notes"
         )
 
-        authenticated_client.post(
+        response = authenticated_client.post(
             self.get_url(event, field),
             data={
                 "name": "Notes",
@@ -514,6 +520,12 @@ class TestSessionFieldEditPageView:
             },
         )
 
+        assert_response(
+            response,
+            HTTPStatus.FOUND,
+            messages=[(messages.SUCCESS, "Session field updated successfully.")],
+            url=f"/panel/event/{event.slug}/cfp/session-fields/",
+        )
         field.refresh_from_db()
         assert field.is_multiple is False
         assert field.allow_custom is False


### PR DESCRIPTION
The "Allow multiple selections" and "Allow custom values" checkboxes only ever existed on the field *create* form. Editing a select field showed its options but no way to see or change either flag, so a field created without multi-select could only be fixed by deleting and recreating it — which drops every answer already given. SessionField isn't in Django admin either, so there was no workaround on production.

The gap ran through all four layers, for session fields and personal-data fields alike: the edit template rendered neither checkbox, the view neither seeded `initial` nor passed the values to the repo, the Update TypedDicts had no such keys, and `update()` never assigned the columns. Nothing was being wiped — `update()` simply left them at whatever create had set.

Both checkboxes now render through components/checkbox-field.html inside the existing server-side `field_type == "select"` guard, so no JS toggle is needed (field type is immutable on edit). The repos force both flags false for non-select fields, mirroring what `create()` already does.

tingle: +24 in legacy-loc / old-subdomain-loc — the views, repos and TypedDicts this fix touches all live in legacy-counted modules.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added “multiple selections” and “allow custom values” toggles for **select** fields.
  * Toggles are available on both personal data field and session field edit pages.
  * Existing select-field settings are preserved when reopening the form.
* **Bug Fixes**
  * Ensure select-field options persist correctly on save.
  * These toggles are ignored for non-select (e.g., text) fields to prevent unintended changes.
* **Tests**
  * Added integration coverage for toggle prepopulation and save/omit behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->