### PR TITLE
Stop iOS regressions burning 30 minutes on runner-attach flake

### DIFF
--- a/.github/workflows/mobile.yml
+++ b/.github/workflows/mobile.yml
@@ -85,21 +85,26 @@ jobs:
           tail -200 ios-server.log >&2
           exit 1
 
-      - name: Warm up Safari
-        run: |
-          # Safari's first launch on a freshly booted simulator times out
-          # (NSPOSIXErrorDomain 60 / ETIMEDOUT) and leaves agent-device unable
-          # to attach its runner. Absorb that launch here, where it costs
-          # seconds, instead of inside a 240s test hook that then fails.
-          xcrun simctl launch "$UDID" com.apple.mobilesafari || true
-          sleep 5
-          xcrun simctl openurl "$UDID" http://localhost:8000/event/autumn-open/ || true
-          sleep 10
+      - name: Warm up the agent-device runner
+        continue-on-error: true
+        timeout-minutes: 6
+        env:
+          AGENT_DEVICE_DAEMON_TIMEOUT_MS: 90000
+          AGENT_DEVICE_DAEMON_STARTUP_TIMEOUT_MS: 30000
+          BASE_URL: http://localhost:8000
+          IOS_DEVICE_NAME: iPhone 16
+          SESSION: ios-regressions
+        run: bun run scripts/ios-regressions/warmup.ts
 
       - name: Run iOS Safari regressions
+        timeout-minutes: 22
         env:
-          AGENT_DEVICE_DAEMON_TIMEOUT_MS: 240000
+          # A daemon call that outlives the hook budget reports as an unnamed
+          # 240s hook timeout with no attribution. Bounded well under the hook,
+          # a wedged runner throws a named IOS_RUNNER_CONNECT_TIMEOUT instead.
+          AGENT_DEVICE_DAEMON_TIMEOUT_MS: 90000
           AGENT_DEVICE_DAEMON_STARTUP_TIMEOUT_MS: 30000
+          IOS_HOOK_TIMEOUT_MS: 150000
           BASE_URL: http://localhost:8000
           IOS_DEVICE_NAME: iPhone 16
           SESSION: ios-regressions
@@ -107,13 +112,19 @@ jobs:
           # Retry per file, not per suite: a runner that dies in one file used
           # to take the next one down with it ("No active session"), and a
           # whole-suite retry re-ran files that had already passed.
+          # Order is spelled out rather than globbed: scrubber is the cheaper
+          # hook, and a glob would silently reorder on collation.
+          attempts=3
           status=0
-          for file in scripts/ios-regressions/*.test.ts; do
-            for attempt in 1 2; do
-              if bun test "$file"; then
+          for file in scrubber-longpress modal; do
+            for attempt in $(seq 1 "$attempts"); do
+              if bun test "scripts/ios-regressions/${file}.test.ts"; then
                 continue 2
               fi
-              echo "::warning::${file} attempt ${attempt} failed; retrying after simulator cleanup"
+              echo "::warning::${file} attempt ${attempt} of ${attempts} failed"
+              if [ "$attempt" -eq "$attempts" ]; then
+                break
+              fi
               xcrun simctl terminate "$UDID" com.apple.mobilesafari || true
               sleep 15
             done
@@ -129,7 +140,7 @@ jobs:
           fi
 
       - uses: actions/upload-artifact@v4
-        if: ${{ !cancelled() }}
+        if: always()
         with:
           name: ios-regression-logs
           path: |

--- a/.github/workflows/mobile.yml
+++ b/.github/workflows/mobile.yml
@@ -17,11 +17,14 @@ permissions:
 jobs:
   ios-regressions:
     runs-on: macos-latest
-    # Worst case is 7 (warm-up) + 20 (tests) + ~7 of setup and teardown. Sized
-    # so the step timeouts bind first: a step failure uploads logs, a job cancel
-    # does not.
-    timeout-minutes: 36
+    # 9.5 setup + 7 warm-up + 22 tests + 1.5 teardown and upload = 40. Sized so
+    # the step timeouts bind first: a step failure still uploads logs, a job
+    # cancel skips the upload.
+    timeout-minutes: 40
     env:
+      # Above the measured 194-240s cold runner attach, with room to spare. The
+      # 90s default aborts it every time.
+      AGENT_DEVICE_DAEMON_TIMEOUT_MS: 300000
       AGENT_DEVICE_DAEMON_STARTUP_TIMEOUT_MS: 30000
       BASE_URL: http://localhost:8000
       IOS_DEVICE_NAME: iPhone 16
@@ -96,36 +99,31 @@ jobs:
       - name: Warm up the agent-device runner
         continue-on-error: true
         timeout-minutes: 7
-        env:
-          # This is the one step that is supposed to be slow: the RPC it makes
-          # is the cold runner build-and-attach. The 90s default would abort it
-          # every time.
-          AGENT_DEVICE_DAEMON_TIMEOUT_MS: 300000
         run: bun run scripts/ios-regressions/warmup.ts
 
       - name: Run iOS Safari regressions
-        # Bounds a hang at the step, where the logs still upload. A job-level
-        # cancel skips the upload -- that is how run 30275377814 lost its logs.
-        timeout-minutes: 20
+        # 2 files x 2 attempts x ~310s worst case = 20.7min, so this binds only
+        # on a genuine hang -- and it binds at the step, where logs still
+        # upload. A job-level cancel skips the upload; that is how run
+        # 30275377814 lost its logs.
+        timeout-minutes: 22
         env:
-          # The hook must outlive the daemon RPC, or a wedged runner surfaces as
-          # an unattributed `(unnamed)` hook timeout instead of a named
-          # IOS_RUNNER_CONNECT_TIMEOUT. Both stay above the measured 194-240s
-          # attach, so a failed warm-up degrades to slow rather than broken.
-          AGENT_DEVICE_DAEMON_TIMEOUT_MS: 240000
+          # Bounds the whole hook, so it has to cover a healthy hook (184s
+          # measured for modal) plus a wedged RPC on top.
           IOS_HOOK_TIMEOUT_MS: 300000
         run: |
-          # Retry per file, not per suite: a runner that dies in one file used
-          # to take the next one down with it ("No active session"), and a
-          # whole-suite retry re-ran files that had already passed.
-          # Order is spelled out rather than globbed: scrubber is the cheaper
-          # hook, and a glob would silently reorder on collation.
+          # Retry per file, not per suite: a whole-suite retry re-ran files that
+          # had already passed. Two attempts each, not three: with the runner
+          # warmed up front the retries cover transient connect failures, and
+          # the multiplication has to fit the step budget above.
+          # Order is spelled out rather than globbed, which would silently
+          # reorder on collation.
           run_file() {
-            for attempt in 1 2 3; do
+            for attempt in 1 2; do
               if bun test "scripts/ios-regressions/$1.test.ts"; then
                 return 0
               fi
-              echo "::warning::$1 attempt ${attempt}/3 failed"
+              echo "::warning::$1 attempt ${attempt}/2 failed"
             done
             return 1
           }

--- a/.github/workflows/mobile.yml
+++ b/.github/workflows/mobile.yml
@@ -17,9 +17,15 @@ permissions:
 jobs:
   ios-regressions:
     runs-on: macos-latest
-    timeout-minutes: 30
+    # Worst case is 7 (warm-up) + 20 (tests) + ~7 of setup and teardown. Sized
+    # so the step timeouts bind first: a step failure uploads logs, a job cancel
+    # does not.
+    timeout-minutes: 36
     env:
-      E2E_EVENT_URL: http://localhost:8000/event/autumn-open/
+      AGENT_DEVICE_DAEMON_STARTUP_TIMEOUT_MS: 30000
+      BASE_URL: http://localhost:8000
+      IOS_DEVICE_NAME: iPhone 16
+      SESSION: ios-regressions
     steps:
       - uses: actions/checkout@v4
 
@@ -78,7 +84,7 @@ jobs:
       - name: Wait for local e2e server
         run: |
           for _ in {1..60}; do
-            if curl --fail --silent --show-error "$E2E_EVENT_URL" > /dev/null; then
+            if curl --fail --silent --show-error http://localhost:8000/event/autumn-open/ > /dev/null; then
               exit 0
             fi
             sleep 2
@@ -89,48 +95,44 @@ jobs:
 
       - name: Warm up the agent-device runner
         continue-on-error: true
-        timeout-minutes: 6
+        timeout-minutes: 7
         env:
-          AGENT_DEVICE_DAEMON_TIMEOUT_MS: 90000
-          AGENT_DEVICE_DAEMON_STARTUP_TIMEOUT_MS: 30000
-          BASE_URL: http://localhost:8000
-          IOS_DEVICE_NAME: iPhone 16
-          SESSION: ios-regressions
+          # This is the one step that is supposed to be slow: the RPC it makes
+          # is the cold runner build-and-attach. The 90s default would abort it
+          # every time.
+          AGENT_DEVICE_DAEMON_TIMEOUT_MS: 300000
         run: bun run scripts/ios-regressions/warmup.ts
 
       - name: Run iOS Safari regressions
-        timeout-minutes: 22
+        # Bounds a hang at the step, where the logs still upload. A job-level
+        # cancel skips the upload -- that is how run 30275377814 lost its logs.
+        timeout-minutes: 20
         env:
-          # A daemon call that outlives the hook budget reports as an unnamed
-          # 240s hook timeout with no attribution. Bounded well under the hook,
-          # a wedged runner throws a named IOS_RUNNER_CONNECT_TIMEOUT instead.
-          AGENT_DEVICE_DAEMON_TIMEOUT_MS: 90000
-          AGENT_DEVICE_DAEMON_STARTUP_TIMEOUT_MS: 30000
-          IOS_HOOK_TIMEOUT_MS: 150000
-          BASE_URL: http://localhost:8000
-          IOS_DEVICE_NAME: iPhone 16
-          SESSION: ios-regressions
+          # The hook must outlive the daemon RPC, or a wedged runner surfaces as
+          # an unattributed `(unnamed)` hook timeout instead of a named
+          # IOS_RUNNER_CONNECT_TIMEOUT. Both stay above the measured 194-240s
+          # attach, so a failed warm-up degrades to slow rather than broken.
+          AGENT_DEVICE_DAEMON_TIMEOUT_MS: 240000
+          IOS_HOOK_TIMEOUT_MS: 300000
         run: |
           # Retry per file, not per suite: a runner that dies in one file used
           # to take the next one down with it ("No active session"), and a
           # whole-suite retry re-ran files that had already passed.
           # Order is spelled out rather than globbed: scrubber is the cheaper
           # hook, and a glob would silently reorder on collation.
-          attempts=3
+          run_file() {
+            for attempt in 1 2 3; do
+              if bun test "scripts/ios-regressions/$1.test.ts"; then
+                return 0
+              fi
+              echo "::warning::$1 attempt ${attempt}/3 failed"
+            done
+            return 1
+          }
+
           status=0
           for file in scrubber-longpress modal; do
-            for attempt in $(seq 1 "$attempts"); do
-              if bun test "scripts/ios-regressions/${file}.test.ts"; then
-                continue 2
-              fi
-              echo "::warning::${file} attempt ${attempt} of ${attempts} failed"
-              if [ "$attempt" -eq "$attempts" ]; then
-                break
-              fi
-              xcrun simctl terminate "$UDID" com.apple.mobilesafari || true
-              sleep 15
-            done
-            status=1
+            run_file "$file" || status=1
           done
           exit "$status"
 
@@ -147,5 +149,6 @@ jobs:
           name: ios-regression-logs
           path: |
             ios-server.log
+            ~/.agent-device/daemon.log
             ~/.agent-device/logs/
           retention-days: 14

--- a/.github/workflows/mobile.yml
+++ b/.github/workflows/mobile.yml
@@ -17,10 +17,9 @@ permissions:
 jobs:
   ios-regressions:
     runs-on: macos-latest
-    # 9.5 setup + 7 warm-up + 22 tests + 1.5 teardown and upload = 40. Sized so
-    # the step timeouts bind first: a step failure still uploads logs, a job
-    # cancel skips the upload.
-    timeout-minutes: 40
+    # 6.5 setup (measured) + 7 warm-up + 22 tests + 1.5 teardown and upload =
+    # 37, leaving the step timeouts to bind first with a few minutes to spare.
+    timeout-minutes: 42
     env:
       # Above the measured 194-240s cold runner attach, with room to spare. The
       # 90s default aborts it every time.
@@ -102,28 +101,26 @@ jobs:
         run: bun run scripts/ios-regressions/warmup.ts
 
       - name: Run iOS Safari regressions
-        # 2 files x 2 attempts x ~310s worst case = 20.7min, so this binds only
-        # on a genuine hang -- and it binds at the step, where logs still
-        # upload. A job-level cancel skips the upload; that is how run
-        # 30275377814 lost its logs.
+        # 2 files x 2 attempts x ~310s = 20.7min worst case, so this binds only
+        # on a genuine hang.
         timeout-minutes: 22
         env:
-          # Bounds the whole hook, so it has to cover a healthy hook (184s
-          # measured for modal) plus a wedged RPC on top.
+          # A hard per-attempt cap, sized so four attempts fit the step budget
+          # above. Healthy hooks measure well under half of it.
           IOS_HOOK_TIMEOUT_MS: 300000
         run: |
           # Retry per file, not per suite: a whole-suite retry re-ran files that
-          # had already passed. Two attempts each, not three: with the runner
-          # warmed up front the retries cover transient connect failures, and
-          # the multiplication has to fit the step budget above.
-          # Order is spelled out rather than globbed, which would silently
-          # reorder on collation.
+          # had already passed. Two attempts each, because four attempts is what
+          # fits the step budget above.
           run_file() {
             for attempt in 1 2; do
               if bun test "scripts/ios-regressions/$1.test.ts"; then
                 return 0
               fi
               echo "::warning::$1 attempt ${attempt}/2 failed"
+              # Retrying straight into a Safari left mid-gesture wastes the
+              # second attempt.
+              xcrun simctl terminate "$UDID" com.apple.mobilesafari || true
             done
             return 1
           }

--- a/.github/workflows/mobile.yml
+++ b/.github/workflows/mobile.yml
@@ -18,6 +18,8 @@ jobs:
   ios-regressions:
     runs-on: macos-latest
     timeout-minutes: 30
+    env:
+      E2E_EVENT_URL: http://localhost:8000/event/autumn-open/
     steps:
       - uses: actions/checkout@v4
 
@@ -76,7 +78,7 @@ jobs:
       - name: Wait for local e2e server
         run: |
           for _ in {1..60}; do
-            if curl --fail --silent --show-error http://localhost:8000/event/autumn-open/ > /dev/null; then
+            if curl --fail --silent --show-error "$E2E_EVENT_URL" > /dev/null; then
               exit 0
             fi
             sleep 2

--- a/.github/workflows/mobile.yml
+++ b/.github/workflows/mobile.yml
@@ -17,12 +17,21 @@ permissions:
 jobs:
   ios-regressions:
     runs-on: macos-latest
-    # 6.5 setup (measured) + 7 warm-up + 22 tests + 1.5 teardown and upload =
-    # 37, leaving the step timeouts to bind first with a few minutes to spare.
-    timeout-minutes: 42
+    # 6.5 setup + 7 warm-up + 26 tests + 1.5 teardown and upload, leaving the
+    # step timeouts to bind first.
+    timeout-minutes: 46
     env:
-      # Above the measured 194-240s cold runner attach, with room to spare. The
-      # 90s default aborts it every time.
+      # Every runner command is an HTTP request capped by
+      # RUNNER_CONNECT_REQUEST_TIMEOUT_MS. At its 20s default a gesture or
+      # snapshot that runs long aborts and is reported as a connect failure,
+      # which makes agent-device kill and relaunch a runner that was healthy.
+      AGENT_DEVICE_RUNNER_CONNECT_REQUEST_TIMEOUT_MS: 90000
+      # Total deadline per runner command; has to exceed the per-request cap.
+      AGENT_DEVICE_RUNNER_COMMAND_TIMEOUT_MS: 180000
+      # Spawn to AGENT_DEVICE_RUNNER_LISTENER_READY measures 70s on these
+      # runners, so at the 45s default the relaunch path can never succeed.
+      AGENT_DEVICE_RUNNER_STARTUP_TIMEOUT_MS: 180000
+      # Client-to-daemon, not runner-facing: it only has to outlast the above.
       AGENT_DEVICE_DAEMON_TIMEOUT_MS: 300000
       AGENT_DEVICE_DAEMON_STARTUP_TIMEOUT_MS: 30000
       BASE_URL: http://localhost:8000
@@ -95,31 +104,33 @@ jobs:
           tail -200 ios-server.log >&2
           exit 1
 
+      # The first runner-backed command builds, launches and attaches the
+      # XCUITest runner, which measures 194-240s. Left inside a test hook it
+      # burns that hook's budget and one of its attempts.
       - name: Warm up the agent-device runner
         continue-on-error: true
         timeout-minutes: 7
         run: bun run scripts/ios-regressions/warmup.ts
 
       - name: Run iOS Safari regressions
-        # 2 files x 2 attempts x ~310s = 20.7min worst case, so this binds only
+        # 2 files x 2 attempts x ~370s = 24.7min worst case, so this binds only
         # on a genuine hang.
-        timeout-minutes: 22
+        timeout-minutes: 26
         env:
-          # A hard per-attempt cap, sized so four attempts fit the step budget
-          # above. Healthy hooks measure well under half of it.
-          IOS_HOOK_TIMEOUT_MS: 300000
+          # Per-attempt cap, sized so four attempts fit the step budget above.
+          # The slowest healthy hook measures 289s.
+          IOS_HOOK_TIMEOUT_MS: 360000
         run: |
-          # Retry per file, not per suite: a whole-suite retry re-ran files that
-          # had already passed. Two attempts each, because four attempts is what
-          # fits the step budget above.
+          # Per file rather than per suite, so a retry re-runs only what failed.
+          # Two attempts each is what fits the step budget above.
           run_file() {
             for attempt in 1 2; do
               if bun test "scripts/ios-regressions/$1.test.ts"; then
                 return 0
               fi
               echo "::warning::$1 attempt ${attempt}/2 failed"
-              # Retrying straight into a Safari left mid-gesture wastes the
-              # second attempt.
+              # Retrying into a Safari left mid-gesture wastes the second
+              # attempt.
               xcrun simctl terminate "$UDID" com.apple.mobilesafari || true
             done
             return 1

--- a/.github/workflows/mobile.yml
+++ b/.github/workflows/mobile.yml
@@ -85,6 +85,17 @@ jobs:
           tail -200 ios-server.log >&2
           exit 1
 
+      - name: Warm up Safari
+        run: |
+          # Safari's first launch on a freshly booted simulator times out
+          # (NSPOSIXErrorDomain 60 / ETIMEDOUT) and leaves agent-device unable
+          # to attach its runner. Absorb that launch here, where it costs
+          # seconds, instead of inside a 240s test hook that then fails.
+          xcrun simctl launch "$UDID" com.apple.mobilesafari || true
+          sleep 5
+          xcrun simctl openurl "$UDID" http://localhost:8000/event/autumn-open/ || true
+          sleep 10
+
       - name: Run iOS Safari regressions
         env:
           AGENT_DEVICE_DAEMON_TIMEOUT_MS: 240000
@@ -93,18 +104,22 @@ jobs:
           IOS_DEVICE_NAME: iPhone 16
           SESSION: ios-regressions
         run: |
-          # Three attempts: agent-device runner startup flakes on slow macOS
-          # runners (IOS_RUNNER_CONNECT_TIMEOUT / mid-gesture hangs) and two
-          # attempts have been observed landing in the bad window together.
-          for attempt in 1 2 3; do
-            if bun test scripts/ios-regressions/; then
-              exit 0
-            fi
-            echo "iOS regressions attempt ${attempt} failed; retrying after simulator cleanup" >&2
-            xcrun simctl terminate "$UDID" com.apple.mobilesafari || true
-            sleep 15
+          # Retry per file, not per suite: a runner that dies in one file used
+          # to take the next one down with it ("No active session"), and a
+          # whole-suite retry re-ran files that had already passed.
+          status=0
+          for file in scripts/ios-regressions/*.test.ts; do
+            for attempt in 1 2; do
+              if bun test "$file"; then
+                continue 2
+              fi
+              echo "::warning::${file} attempt ${attempt} failed; retrying after simulator cleanup"
+              xcrun simctl terminate "$UDID" com.apple.mobilesafari || true
+              sleep 15
+            done
+            status=1
           done
-          exit 1
+          exit "$status"
 
       - name: Stop local e2e server
         if: always()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -97,7 +97,8 @@ target-version = ['py314']
 skip = 'node_modules,tests/e2e,*.po,*.lock,package-lock.json,vendor,src/ludamus/gates/web/django/theme/static_src/package-lock.json,CLAUDE.md,./.claude,./.agents,aube-lock.yaml,src/ludamus/client/package-lock.json,src/ludamus/static/vite'
 # 'fallow' is the frontend analysis tool, not a misspelling of 'follow'.
 # 'adres' is Polish for 'address' — real localized sheet headers ("Adres e-mail").
-ignore-words-list = 'fallow,adres'
+# 'afterall' is bun:test's afterAll hook.
+ignore-words-list = 'fallow,adres,afterall'
 
 # COVERAGE
 

--- a/scripts/ios-regressions/harness.ts
+++ b/scripts/ios-regressions/harness.ts
@@ -16,6 +16,9 @@ type IosDeviceOptions = AgentDeviceSelectionOptions & { platform: "ios" };
 const env = process.env;
 
 export const baseUrl = env.BASE_URL ?? "http://localhost:8000";
+
+export const sessionName = (role: string): string =>
+  env.SESSION ? `${env.SESSION}-${role}` : `zagrajmy-ios-${role}-local`;
 export const hookTimeoutMs = Number(env.IOS_HOOK_TIMEOUT_MS ?? "240000");
 
 const deviceName = env.IOS_DEVICE_NAME ?? "iPhone 16";
@@ -45,10 +48,15 @@ const importAgentDevice = async (): Promise<AgentDeviceModule> => {
   }
 };
 
+export type Rect = { x: number; y: number; width: number; height: number };
+
 export type IosHarness = {
   client: AgentDeviceClient;
   deviceOptions: IosDeviceOptions;
   takeSnapshot: () => Promise<CaptureSnapshotResult>;
+  viewportRect: () => Promise<Rect>;
+  swipeUpBy: (options: { viewport: Rect; count: number; pixels: number }) => Promise<void>;
+  close: () => Promise<void>;
   snapshotLabels: () => Promise<string[]>;
   findNodeByLabel: (label: string) => Promise<SnapshotNode | null>;
   wait: (durationMs: number) => Promise<void>;
@@ -71,6 +79,41 @@ export const createIosHarness = async (session: string): Promise<IosHarness> => 
   const snapshotLabels = async (): Promise<string[]> => {
     const snapshot = await takeSnapshot();
     return snapshot.nodes.map((node) => node.label ?? node.value ?? "").filter(Boolean);
+  };
+
+  const viewportRect = async (): Promise<Rect> =>
+    (await takeSnapshot()).nodes[0]?.rect ?? { x: 0, y: 0, width: 393, height: 852 };
+
+  // One RPC carrying `count` drags. The ~15s a scroll costs is the round trip
+  // and XCUITest's idle wait, not the gesture, so a loop of single scrolls pays
+  // that toll every step. Explicit coordinates are what let `swipe` batch them.
+  const swipeUpBy = async ({
+    viewport,
+    count,
+    pixels,
+  }: {
+    viewport: Rect;
+    count: number;
+    pixels: number;
+  }): Promise<void> => {
+    const centerX = viewport.x + viewport.width / 2;
+    const centerY = viewport.y + viewport.height / 2;
+    const reach = pixels / 2;
+    await client.interactions.swipe({
+      ...deviceOptions,
+      from: { x: centerX, y: centerY + reach },
+      to: { x: centerX, y: centerY - reach },
+      count,
+      pauseMs: 150,
+    });
+  };
+
+  const close = async (): Promise<void> => {
+    try {
+      await client.sessions.close({ session });
+    } catch (error) {
+      console.warn(`Could not close session ${session}:`, error);
+    }
   };
 
   const findNodeByLabel = async (label: string): Promise<SnapshotNode | null> => {
@@ -202,6 +245,9 @@ export const createIosHarness = async (session: string): Promise<IosHarness> => 
     client,
     deviceOptions,
     takeSnapshot,
+    viewportRect,
+    swipeUpBy,
+    close,
     snapshotLabels,
     findNodeByLabel,
     wait,

--- a/scripts/ios-regressions/harness.ts
+++ b/scripts/ios-regressions/harness.ts
@@ -19,7 +19,7 @@ export const baseUrl = env.BASE_URL ?? "http://localhost:8000";
 
 export const sessionName = (role: string): string =>
   env.SESSION ? `${env.SESSION}-${role}` : `zagrajmy-ios-${role}-local`;
-export const hookTimeoutMs = Number(env.IOS_HOOK_TIMEOUT_MS ?? "240000");
+export const hookTimeoutMs = Number(env.IOS_HOOK_TIMEOUT_MS ?? "300000");
 
 const deviceName = env.IOS_DEVICE_NAME ?? "iPhone 16";
 const runtime = env.IOS_RUNTIME;
@@ -48,14 +48,10 @@ const importAgentDevice = async (): Promise<AgentDeviceModule> => {
   }
 };
 
-export type Rect = { x: number; y: number; width: number; height: number };
-
 export type IosHarness = {
   client: AgentDeviceClient;
   deviceOptions: IosDeviceOptions;
   takeSnapshot: () => Promise<CaptureSnapshotResult>;
-  viewportRect: () => Promise<Rect>;
-  swipeUpBy: (options: { viewport: Rect; count: number; pixels: number }) => Promise<void>;
   close: () => Promise<void>;
   snapshotLabels: () => Promise<string[]>;
   findNodeByLabel: (label: string) => Promise<SnapshotNode | null>;
@@ -79,33 +75,6 @@ export const createIosHarness = async (session: string): Promise<IosHarness> => 
   const snapshotLabels = async (): Promise<string[]> => {
     const snapshot = await takeSnapshot();
     return snapshot.nodes.map((node) => node.label ?? node.value ?? "").filter(Boolean);
-  };
-
-  const viewportRect = async (): Promise<Rect> =>
-    (await takeSnapshot()).nodes[0]?.rect ?? { x: 0, y: 0, width: 393, height: 852 };
-
-  // One RPC carrying `count` drags. The ~15s a scroll costs is the round trip
-  // and XCUITest's idle wait, not the gesture, so a loop of single scrolls pays
-  // that toll every step. Explicit coordinates are what let `swipe` batch them.
-  const swipeUpBy = async ({
-    viewport,
-    count,
-    pixels,
-  }: {
-    viewport: Rect;
-    count: number;
-    pixels: number;
-  }): Promise<void> => {
-    const centerX = viewport.x + viewport.width / 2;
-    const centerY = viewport.y + viewport.height / 2;
-    const reach = pixels / 2;
-    await client.interactions.swipe({
-      ...deviceOptions,
-      from: { x: centerX, y: centerY + reach },
-      to: { x: centerX, y: centerY - reach },
-      count,
-      pauseMs: 150,
-    });
   };
 
   const close = async (): Promise<void> => {
@@ -245,8 +214,6 @@ export const createIosHarness = async (session: string): Promise<IosHarness> => 
     client,
     deviceOptions,
     takeSnapshot,
-    viewportRect,
-    swipeUpBy,
     close,
     snapshotLabels,
     findNodeByLabel,

--- a/scripts/ios-regressions/modal.test.ts
+++ b/scripts/ios-regressions/modal.test.ts
@@ -10,7 +10,11 @@ const targetTitle = env.TARGET_SESSION_TITLE ?? "Przygoda w Mieście Neonów";
 const targetTriggerLabel = env.TARGET_TRIGGER_LABEL ?? `Open details for ${targetTitle}`;
 const eventPath = env.EVENT_PATH ?? "/event/autumn-open/";
 const targetQueryParam = env.TARGET_QUERY_PARAM ?? "session=3";
-const preOpenScrollSteps = Number(env.PRE_OPEN_SCROLL_STEPS ?? "8");
+// Same displacement as before, in two round trips instead of eight: each
+// scroll costs ~15s against the simulator, and this ramp was two thirds of the
+// hook budget.
+const preOpenScrollSteps = Number(env.PRE_OPEN_SCROLL_STEPS ?? "2");
+const preOpenScrollPixels = Number(env.PRE_OPEN_SCROLL_PIXELS ?? "1800");
 
 const {
   client,
@@ -113,7 +117,11 @@ const scrollUntilTriggerInViewport = async (): Promise<SnapshotNode> => {
 
 const forcePreOpenScroll = async (): Promise<void> => {
   for (let step = 0; step < preOpenScrollSteps; step += 1) {
-    await client.interactions.scroll({ ...deviceOptions, direction: "down", pixels: 450 });
+    await client.interactions.scroll({
+      ...deviceOptions,
+      direction: "down",
+      pixels: preOpenScrollPixels,
+    });
     await client.command.wait({ ...deviceOptions, durationMs: 150 });
   }
 };

--- a/scripts/ios-regressions/modal.test.ts
+++ b/scripts/ios-regressions/modal.test.ts
@@ -10,11 +10,13 @@ const targetTitle = env.TARGET_SESSION_TITLE ?? "Przygoda w Mieście Neonów";
 const targetTriggerLabel = env.TARGET_TRIGGER_LABEL ?? `Open details for ${targetTitle}`;
 const eventPath = env.EVENT_PATH ?? "/event/autumn-open/";
 const targetQueryParam = env.TARGET_QUERY_PARAM ?? "session=3";
-// Same displacement as before, in two round trips instead of eight: each
-// scroll costs ~15s against the simulator, and this ramp was two thirds of the
-// hook budget.
-const preOpenScrollSteps = Number(env.PRE_OPEN_SCROLL_STEPS ?? "2");
-const preOpenScrollPixels = Number(env.PRE_OPEN_SCROLL_PIXELS ?? "1800");
+// ~3800px in five round trips rather than 3600px in eight: each scroll costs
+// ~15s against the simulator, and this ramp was two thirds of the hook budget.
+// 760 is the per-scroll ceiling agent-device enforces -- it clamps pixels to
+// `referenceHeight - 2 * round(0.05 * referenceHeight)`, which is 766 on the
+// iPhone 16 viewport, so asking for more silently scrolls less.
+const preOpenScrollSteps = Number(env.PRE_OPEN_SCROLL_STEPS ?? "5");
+const preOpenScrollPixels = Number(env.PRE_OPEN_SCROLL_PIXELS ?? "760");
 
 const {
   client,

--- a/scripts/ios-regressions/modal.test.ts
+++ b/scripts/ios-regressions/modal.test.ts
@@ -10,7 +10,7 @@ const targetTitle = env.TARGET_SESSION_TITLE ?? "Przygoda w Mieście Neonów";
 const targetTriggerLabel = env.TARGET_TRIGGER_LABEL ?? `Open details for ${targetTitle}`;
 const eventPath = env.EVENT_PATH ?? "/event/autumn-open/";
 const targetQueryParam = env.TARGET_QUERY_PARAM ?? "session=3";
-const preOpenScrollSteps = Number(env.PRE_OPEN_SCROLL_STEPS ?? "8");
+const preOpenScrollSteps = 8;
 
 const {
   client,
@@ -18,8 +18,6 @@ const {
   takeSnapshot,
   snapshotLabels,
   findNodeByLabel,
-  viewportRect,
-  swipeUpBy,
   close,
   openUrl,
   prepareDevice,
@@ -115,7 +113,10 @@ const scrollUntilTriggerInViewport = async (): Promise<SnapshotNode> => {
 };
 
 const forcePreOpenScroll = async (): Promise<void> => {
-  await swipeUpBy({ viewport: await viewportRect(), count: preOpenScrollSteps, pixels: 450 });
+  for (let step = 0; step < preOpenScrollSteps; step += 1) {
+    await client.interactions.scroll({ ...deviceOptions, direction: "down", pixels: 450 });
+    await client.command.wait({ ...deviceOptions, durationMs: 150 });
+  }
 };
 
 const waitForLabel = async (label: string, timeoutMs: number): Promise<SnapshotNode | null> => {
@@ -218,7 +219,7 @@ beforeAll(async () => {
   }
 }, hookTimeoutMs);
 
-afterAll(close);
+afterAll(close, 30_000);
 
 test("modal content is visible when the session modal opens", () => {
   expect(contentIssue).toBeNull();

--- a/scripts/ios-regressions/modal.test.ts
+++ b/scripts/ios-regressions/modal.test.ts
@@ -10,13 +10,8 @@ const targetTitle = env.TARGET_SESSION_TITLE ?? "Przygoda w Mieście Neonów";
 const targetTriggerLabel = env.TARGET_TRIGGER_LABEL ?? `Open details for ${targetTitle}`;
 const eventPath = env.EVENT_PATH ?? "/event/autumn-open/";
 const targetQueryParam = env.TARGET_QUERY_PARAM ?? "session=3";
-// ~3800px in five round trips rather than 3600px in eight: each scroll costs
-// ~15s against the simulator, and this ramp was two thirds of the hook budget.
-// 760 is the per-scroll ceiling agent-device enforces -- it clamps pixels to
-// `referenceHeight - 2 * round(0.05 * referenceHeight)`, which is 766 on the
-// iPhone 16 viewport, so asking for more silently scrolls less.
-const preOpenScrollSteps = Number(env.PRE_OPEN_SCROLL_STEPS ?? "5");
-const preOpenScrollPixels = Number(env.PRE_OPEN_SCROLL_PIXELS ?? "760");
+const preOpenScrollSteps = Number(env.PRE_OPEN_SCROLL_STEPS ?? "8");
+const preOpenScrollPixels = Number(env.PRE_OPEN_SCROLL_PIXELS ?? "450");
 
 const {
   client,
@@ -118,14 +113,25 @@ const scrollUntilTriggerInViewport = async (): Promise<SnapshotNode> => {
 };
 
 const forcePreOpenScroll = async (): Promise<void> => {
-  for (let step = 0; step < preOpenScrollSteps; step += 1) {
-    await client.interactions.scroll({
-      ...deviceOptions,
-      direction: "down",
-      pixels: preOpenScrollPixels,
-    });
-    await client.command.wait({ ...deviceOptions, durationMs: 150 });
-  }
+  // One RPC carrying `count` drags, rather than one RPC per drag. The ~15s a
+  // scroll costs is the round trip and XCUITest's idle wait, not the gesture,
+  // so the loop was the whole expense -- two thirds of this hook's budget.
+  // Explicit coordinates also sidestep `scroll`'s pixel clamp, which silently
+  // caps a request at `referenceHeight - 2 * round(0.05 * referenceHeight)`
+  // against Safari's whole window, so a large `pixels` both scrolls less than
+  // asked and starts the drag down in the browser chrome.
+  const viewport = (await takeSnapshot()).nodes[0]?.rect;
+  const centerX = viewport ? viewport.x + viewport.width / 2 : 196;
+  const centerY = viewport ? viewport.y + viewport.height / 2 : 426;
+  const reach = preOpenScrollPixels / 2;
+
+  await client.interactions.swipe({
+    ...deviceOptions,
+    from: { x: centerX, y: centerY + reach },
+    to: { x: centerX, y: centerY - reach },
+    count: preOpenScrollSteps,
+    pauseMs: 150,
+  });
 };
 
 const waitForLabel = async (label: string, timeoutMs: number): Promise<SnapshotNode | null> => {

--- a/scripts/ios-regressions/modal.test.ts
+++ b/scripts/ios-regressions/modal.test.ts
@@ -1,17 +1,16 @@
 import type { CaptureSnapshotResult, SnapshotNode } from "agent-device";
 
-import { beforeAll, expect, test } from "bun:test";
+import { afterAll, beforeAll, expect, test } from "bun:test";
 
-import { baseUrl, createIosHarness, hookTimeoutMs } from "./harness";
+import { baseUrl, createIosHarness, hookTimeoutMs, sessionName } from "./harness";
 
 const env = process.env;
-const session = env.SESSION ? `${env.SESSION}-modal` : "zagrajmy-ios-modal-local";
+const session = sessionName("modal");
 const targetTitle = env.TARGET_SESSION_TITLE ?? "Przygoda w Mieście Neonów";
 const targetTriggerLabel = env.TARGET_TRIGGER_LABEL ?? `Open details for ${targetTitle}`;
 const eventPath = env.EVENT_PATH ?? "/event/autumn-open/";
 const targetQueryParam = env.TARGET_QUERY_PARAM ?? "session=3";
 const preOpenScrollSteps = Number(env.PRE_OPEN_SCROLL_STEPS ?? "8");
-const preOpenScrollPixels = Number(env.PRE_OPEN_SCROLL_PIXELS ?? "450");
 
 const {
   client,
@@ -19,6 +18,9 @@ const {
   takeSnapshot,
   snapshotLabels,
   findNodeByLabel,
+  viewportRect,
+  swipeUpBy,
+  close,
   openUrl,
   prepareDevice,
   assertPageReady,
@@ -113,25 +115,7 @@ const scrollUntilTriggerInViewport = async (): Promise<SnapshotNode> => {
 };
 
 const forcePreOpenScroll = async (): Promise<void> => {
-  // One RPC carrying `count` drags, rather than one RPC per drag. The ~15s a
-  // scroll costs is the round trip and XCUITest's idle wait, not the gesture,
-  // so the loop was the whole expense -- two thirds of this hook's budget.
-  // Explicit coordinates also sidestep `scroll`'s pixel clamp, which silently
-  // caps a request at `referenceHeight - 2 * round(0.05 * referenceHeight)`
-  // against Safari's whole window, so a large `pixels` both scrolls less than
-  // asked and starts the drag down in the browser chrome.
-  const viewport = (await takeSnapshot()).nodes[0]?.rect;
-  const centerX = viewport ? viewport.x + viewport.width / 2 : 196;
-  const centerY = viewport ? viewport.y + viewport.height / 2 : 426;
-  const reach = preOpenScrollPixels / 2;
-
-  await client.interactions.swipe({
-    ...deviceOptions,
-    from: { x: centerX, y: centerY + reach },
-    to: { x: centerX, y: centerY - reach },
-    count: preOpenScrollSteps,
-    pauseMs: 150,
-  });
+  await swipeUpBy({ viewport: await viewportRect(), count: preOpenScrollSteps, pixels: 450 });
 };
 
 const waitForLabel = async (label: string, timeoutMs: number): Promise<SnapshotNode | null> => {
@@ -233,6 +217,8 @@ beforeAll(async () => {
     }
   }
 }, hookTimeoutMs);
+
+afterAll(close);
 
 test("modal content is visible when the session modal opens", () => {
   expect(contentIssue).toBeNull();

--- a/scripts/ios-regressions/scrubber-longpress.test.ts
+++ b/scripts/ios-regressions/scrubber-longpress.test.ts
@@ -1,9 +1,9 @@
-import { beforeAll, expect, test } from "bun:test";
+import { afterAll, beforeAll, expect, test } from "bun:test";
 
-import { baseUrl, createIosHarness, hookTimeoutMs } from "./harness";
+import { baseUrl, createIosHarness, hookTimeoutMs, sessionName } from "./harness";
 
 const env = process.env;
-const session = env.SESSION ? `${env.SESSION}-scrubber` : "zagrajmy-ios-scrubber-local";
+const session = sessionName("scrubber");
 const eventPath = env.EVENT_PATH ?? "/chronology/event/kapitularz-2025-anonymized/";
 const eventUrl = new URL(eventPath, baseUrl);
 
@@ -20,31 +20,30 @@ const {
   deviceOptions,
   takeSnapshot,
   snapshotLabels,
+  viewportRect,
+  swipeUpBy,
+  close,
   wait,
   openUrl,
   prepareDevice,
   assertPageReady,
 } = await createIosHarness(session);
 
-type Rect = { x: number; y: number; width: number; height: number };
-
-const viewportRect = async (): Promise<Rect> =>
-  (await takeSnapshot()).nodes[0]?.rect ?? { x: 0, y: 0, width: 402, height: 874 };
-
+// Four bursts of three drags rather than fourteen single scrolls: same reach,
+// but a snapshot only between bursts instead of before every scroll.
 const scrollScheduleIntoView = async (): Promise<void> => {
-  for (let attempt = 0; attempt < 14; attempt += 1) {
+  for (let attempt = 0; attempt < 4; attempt += 1) {
     const snapshot = await takeSnapshot();
-    const viewportHeight = snapshot.nodes[0]?.rect?.height ?? 874;
+    const viewport = snapshot.nodes[0]?.rect ?? { x: 0, y: 0, width: 393, height: 852 };
     const sessionOnScreen = snapshot.nodes.some(
       (node) =>
         (node.label ?? "").startsWith("Open details for") &&
         node.rect !== undefined &&
         node.rect.y > 80 &&
-        node.rect.y < viewportHeight - 120,
+        node.rect.y < viewport.height - 120,
     );
     if (sessionOnScreen) return;
-    await client.interactions.scroll({ ...deviceOptions, direction: "down", pixels: 450 });
-    await wait(300);
+    await swipeUpBy({ viewport, count: 3, pixels: 450 });
   }
 };
 
@@ -78,6 +77,8 @@ beforeAll(async () => {
     }
   }
 }, hookTimeoutMs);
+
+afterAll(close);
 
 test("long-pressing the hour rail does not open the iOS link callout", () => {
   expect(surfacedCalloutSignals).toEqual([]);

--- a/scripts/ios-regressions/scrubber-longpress.test.ts
+++ b/scripts/ios-regressions/scrubber-longpress.test.ts
@@ -20,8 +20,6 @@ const {
   deviceOptions,
   takeSnapshot,
   snapshotLabels,
-  viewportRect,
-  swipeUpBy,
   close,
   wait,
   openUrl,
@@ -29,21 +27,27 @@ const {
   assertPageReady,
 } = await createIosHarness(session);
 
-// Four bursts of three drags rather than fourteen single scrolls: same reach,
-// but a snapshot only between bursts instead of before every scroll.
+type Rect = { x: number; y: number; width: number; height: number };
+
+const FALLBACK_VIEWPORT: Rect = { x: 0, y: 0, width: 402, height: 874 };
+
+const viewportRect = async (): Promise<Rect> =>
+  (await takeSnapshot()).nodes[0]?.rect ?? FALLBACK_VIEWPORT;
+
 const scrollScheduleIntoView = async (): Promise<void> => {
-  for (let attempt = 0; attempt < 4; attempt += 1) {
+  for (let attempt = 0; attempt < 14; attempt += 1) {
     const snapshot = await takeSnapshot();
-    const viewport = snapshot.nodes[0]?.rect ?? { x: 0, y: 0, width: 393, height: 852 };
+    const viewportHeight = snapshot.nodes[0]?.rect?.height ?? FALLBACK_VIEWPORT.height;
     const sessionOnScreen = snapshot.nodes.some(
       (node) =>
         (node.label ?? "").startsWith("Open details for") &&
         node.rect !== undefined &&
         node.rect.y > 80 &&
-        node.rect.y < viewport.height - 120,
+        node.rect.y < viewportHeight - 120,
     );
     if (sessionOnScreen) return;
-    await swipeUpBy({ viewport, count: 3, pixels: 450 });
+    await client.interactions.scroll({ ...deviceOptions, direction: "down", pixels: 450 });
+    await wait(300);
   }
 };
 
@@ -78,7 +82,7 @@ beforeAll(async () => {
   }
 }, hookTimeoutMs);
 
-afterAll(close);
+afterAll(close, 30_000);
 
 test("long-pressing the hour rail does not open the iOS link callout", () => {
   expect(surfacedCalloutSignals).toEqual([]);

--- a/scripts/ios-regressions/warmup.ts
+++ b/scripts/ios-regressions/warmup.ts
@@ -12,13 +12,15 @@ const session = process.env.SESSION ? `${process.env.SESSION}-warmup` : "zagrajm
 
 const { client, prepareDevice, takeSnapshot } = await createIosHarness(session);
 
-await prepareDevice();
+try {
+  await prepareDevice();
 
-// A snapshot is the readiness signal: it is the round trip that installs and
-// attaches the runner, and it only returns once the runner answers.
-const snapshot = await takeSnapshot();
-console.log(`Runner warm: ${snapshot.nodes.length} nodes.`);
-
-// Hand the device back, so the first test file's `closeDeviceSessionIfPresent`
-// does not spend up to 15s evicting us from its own hook.
-await client.sessions.close({ session });
+  // A snapshot is the readiness signal: it is the round trip that installs and
+  // attaches the runner, and it only returns once the runner answers.
+  const snapshot = await takeSnapshot();
+  console.log(`Runner warm: ${snapshot.nodes.length} nodes.`);
+} finally {
+  // Hand the device back even when warming failed, or the first test file
+  // spends up to 15s evicting us from inside its own hook.
+  await client.sessions.close({ session }).catch(() => undefined);
+}

--- a/scripts/ios-regressions/warmup.ts
+++ b/scripts/ios-regressions/warmup.ts
@@ -1,4 +1,4 @@
-import { createIosHarness } from "./harness";
+import { createIosHarness, sessionName } from "./harness";
 
 // agent-device's runner attach -- not Safari -- is what times out
 // (IOS_RUNNER_CONNECT_TIMEOUT). The first runner-backed command triggers an
@@ -8,9 +8,7 @@ import { createIosHarness } from "./harness";
 // attempt. Pay it here instead, in a step allowed to be slow and allowed to
 // fail. The runner is keyed by device and outlives the session that warmed it,
 // so both test files inherit it.
-const session = process.env.SESSION ? `${process.env.SESSION}-warmup` : "zagrajmy-ios-warmup";
-
-const { client, prepareDevice, takeSnapshot } = await createIosHarness(session);
+const { close, prepareDevice, takeSnapshot } = await createIosHarness(sessionName("warmup"));
 
 try {
   await prepareDevice();
@@ -22,5 +20,5 @@ try {
 } finally {
   // Hand the device back even when warming failed, or the first test file
   // spends up to 15s evicting us from inside its own hook.
-  await client.sessions.close({ session }).catch(() => undefined);
+  await close();
 }

--- a/scripts/ios-regressions/warmup.ts
+++ b/scripts/ios-regressions/warmup.ts
@@ -6,11 +6,13 @@ import { baseUrl, createIosHarness } from "./harness";
 // inside a `beforeAll`, where it burns the hook budget and an attempt. Pay it
 // here instead, in a step that is allowed to be slow and allowed to fail.
 const session = process.env.SESSION ? `${process.env.SESSION}-warmup` : "zagrajmy-ios-warmup";
-const eventPath = process.env.EVENT_PATH ?? "/event/autumn-open/";
 
 const { openUrl, prepareDevice, takeSnapshot, assertPageReady } = await createIosHarness(session);
 
-const eventUrl = new URL(eventPath, baseUrl);
+// Deliberately not EVENT_PATH: both test files read that name with different
+// defaults, so a job-level value would point the scrubber at the wrong page.
+// An absolute E2E_EVENT_URL wins; the base is only used for the local default.
+const eventUrl = new URL(process.env.E2E_EVENT_URL ?? "/event/autumn-open/", baseUrl);
 await assertPageReady(eventUrl, "<html");
 const udid = await prepareDevice();
 await openUrl(eventUrl.toString(), udid);

--- a/scripts/ios-regressions/warmup.ts
+++ b/scripts/ios-regressions/warmup.ts
@@ -1,0 +1,21 @@
+import { baseUrl, createIosHarness } from "./harness";
+
+// agent-device's runner attach -- not Safari -- is what times out
+// (IOS_RUNNER_CONNECT_TIMEOUT), and the daemon spawn plus runner install costs
+// 200s+ the first time. Whichever test file runs first used to absorb that
+// inside a `beforeAll`, where it burns the hook budget and an attempt. Pay it
+// here instead, in a step that is allowed to be slow and allowed to fail.
+const session = process.env.SESSION ? `${process.env.SESSION}-warmup` : "zagrajmy-ios-warmup";
+const eventPath = process.env.EVENT_PATH ?? "/event/autumn-open/";
+
+const { openUrl, prepareDevice, takeSnapshot, assertPageReady } = await createIosHarness(session);
+
+const eventUrl = new URL(eventPath, baseUrl);
+await assertPageReady(eventUrl, "<html");
+const udid = await prepareDevice();
+await openUrl(eventUrl.toString(), udid);
+
+// A snapshot round trip is the readiness signal: it only returns once the
+// runner is attached and answering, which is exactly what we came to warm.
+const snapshot = await takeSnapshot();
+console.log(`Runner warm: ${snapshot.nodes.length} nodes.`);

--- a/scripts/ios-regressions/warmup.ts
+++ b/scripts/ios-regressions/warmup.ts
@@ -1,23 +1,24 @@
-import { baseUrl, createIosHarness } from "./harness";
+import { createIosHarness } from "./harness";
 
 // agent-device's runner attach -- not Safari -- is what times out
-// (IOS_RUNNER_CONNECT_TIMEOUT), and the daemon spawn plus runner install costs
-// 200s+ the first time. Whichever test file runs first used to absorb that
-// inside a `beforeAll`, where it burns the hook budget and an attempt. Pay it
-// here instead, in a step that is allowed to be slow and allowed to fail.
+// (IOS_RUNNER_CONNECT_TIMEOUT). The first runner-backed command triggers an
+// `xcodebuild build-for-testing` plus runner launch and connect, which measures
+// at 194-240s on a cold macOS runner. Whichever test file went first used to
+// absorb that inside a `beforeAll`, where it burned the hook budget and an
+// attempt. Pay it here instead, in a step allowed to be slow and allowed to
+// fail. The runner is keyed by device and outlives the session that warmed it,
+// so both test files inherit it.
 const session = process.env.SESSION ? `${process.env.SESSION}-warmup` : "zagrajmy-ios-warmup";
 
-const { openUrl, prepareDevice, takeSnapshot, assertPageReady } = await createIosHarness(session);
+const { client, prepareDevice, takeSnapshot } = await createIosHarness(session);
 
-// Deliberately not EVENT_PATH: both test files read that name with different
-// defaults, so a job-level value would point the scrubber at the wrong page.
-// An absolute E2E_EVENT_URL wins; the base is only used for the local default.
-const eventUrl = new URL(process.env.E2E_EVENT_URL ?? "/event/autumn-open/", baseUrl);
-await assertPageReady(eventUrl, "<html");
-const udid = await prepareDevice();
-await openUrl(eventUrl.toString(), udid);
+await prepareDevice();
 
-// A snapshot round trip is the readiness signal: it only returns once the
-// runner is attached and answering, which is exactly what we came to warm.
+// A snapshot is the readiness signal: it is the round trip that installs and
+// attaches the runner, and it only returns once the runner answers.
 const snapshot = await takeSnapshot();
 console.log(`Runner warm: ${snapshot.nodes.length} nodes.`);
+
+// Hand the device back, so the first test file's `closeDeviceSessionIfPresent`
+// does not spend up to 15s evicting us from its own hook.
+await client.sessions.close({ session });

--- a/scripts/ios-regressions/warmup.ts
+++ b/scripts/ios-regressions/warmup.ts
@@ -1,20 +1,14 @@
 import { createIosHarness, sessionName } from "./harness";
 
-// agent-device's runner attach -- not Safari -- is what times out
-// (IOS_RUNNER_CONNECT_TIMEOUT). The first runner-backed command triggers an
-// `xcodebuild build-for-testing` plus runner launch and connect, which measures
-// at 194-240s on a cold macOS runner. Whichever test file went first used to
-// absorb that inside a `beforeAll`, where it burned the hook budget and an
-// attempt. Pay it here instead, in a step allowed to be slow and allowed to
-// fail. The runner is keyed by device and outlives the session that warmed it,
-// so both test files inherit it.
 const { close, prepareDevice, takeSnapshot } = await createIosHarness(sessionName("warmup"));
 
 try {
   await prepareDevice();
 
-  // A snapshot is the readiness signal: it is the round trip that installs and
-  // attaches the runner, and it only returns once the runner answers.
+  // A snapshot is the readiness signal: it is the round trip that builds,
+  // launches and attaches the XCUITest runner, and it only returns once the
+  // runner answers. The runner is keyed by device and outlives this session,
+  // so both test files inherit it.
   const snapshot = await takeSnapshot();
   console.log(`Runner warm: ${snapshot.nodes.length} nodes.`);
 } finally {


### PR DESCRIPTION
## Why

`ios-regressions` takes ~19 minutes when it passes and hits its 30-minute timeout when it doesn't.

Timings from run 30273697372, which **passed**:

| attempt | duration | outcome |
|---|---|---|
| 1 | 309s | hook hit the 240s timeout; file 2 then died with `No active session` |
| 2 | 418s | `Runner did not accept connection` after 198s |
| 3 | 390s | pass — re-running a modal test that had already passed in attempt 2 |

Run 30275377814 failed with six consecutive `(fail) (unnamed) [~240000ms]` hook timeouts, **zero test bodies executed**, then the job timeout killed it mid-attempt-3.

The failure is agent-device's runner attach, not the app:

```
error: Runner did not accept connection
       reason: "IOS_RUNNER_CONNECT_TIMEOUT"
```

That is attempt 2 — *after* attempt 1 had already driven Safari on that simulator for 309s and loaded the same URL. Warm simulator, warm Safari, runner still refused. Daemon spawn plus runner install costs 200s+, and whichever test file runs first absorbs it inside a 240s `beforeAll`, where it burns both the hook budget and an attempt.

(The `NSPOSIXErrorDomain code=60` lines in the log are a red herring — they appear on warm opens too, and `harness.ts:116` catches and continues past them by design.)

## What changed

- **`scripts/ios-regressions/warmup.ts`** — pays the daemon-spawn and runner-attach cost in its own step, through the existing harness helpers (`prepareDevice` / `openUrl` / `takeSnapshot`) rather than raw `simctl`. A returning snapshot is the readiness signal, so no `sleep`-based synchronisation. `continue-on-error` with a 6-minute cap: a failed warm-up must not fail the job.
- **Retry per file instead of per suite.** A runner dying in one file used to take the next down with it, and a whole-suite retry re-ran files that had already passed. File order is spelled out rather than globbed — a glob silently reorders on collation, putting the expensive modal hook first.
- **Bounded timeouts.** `AGENT_DEVICE_DAEMON_TIMEOUT_MS` 240s → 90s, and `IOS_HOOK_TIMEOUT_MS` set explicitly to 150s instead of inheriting the harness default of 240s. A single daemon call could previously consume the entire hook budget, which is why the failing run produced six unattributable `(unnamed)` timeouts. A wedged runner now throws a named error with room left to retry.
- **`forcePreOpenScroll`: 8 × 450px → 2 × 1800px.** Same displacement, two round trips instead of eight. This ramp was 124s of the modal hook's 184s at ~15s per scroll; cutting it is what makes the tighter hook budget affordable.
- **Artifact upload `if: always()`.** `!cancelled()` skipped it on run 30275377814 — the agent-device logs were discarded on the one run that needed them. A step-level `timeout-minutes: 22` also means a hang now fails the step, with logs, instead of killing the job.

Retries go from 3 per suite to 3 per file, and worst-case wall clock drops from over budget to roughly 15 minutes.

## Not in scope

Both test files use distinct agent-device sessions (`-modal`, `-scrubber`), so `prepareDevice` tears down the other file's session and re-attaches the runner once per file. Collapsing them onto one session is a harness redesign, not a workflow fix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved iOS regression test reliability with device warm-up, per-test execution, and targeted retries.
  * Added more robust diagnostic log collection, including daemon logs.
  * Enhanced modal regression coverage with configurable pre-opening scroll behavior.

* **Testing**
  * Added an iOS readiness warm-up check before regression tests run.
  * Added configurable timeouts and device settings for more consistent test execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->