### PR TITLE
Tidy up the iOS regression harness

### DIFF
--- a/.github/workflows/mobile.yml
+++ b/.github/workflows/mobile.yml
@@ -113,22 +113,30 @@ jobs:
         run: bun run scripts/ios-regressions/warmup.ts
 
       - name: Run iOS Safari regressions
-        # 2 files x 2 attempts x ~370s = 24.7min worst case, so this binds only
-        # on a genuine hang.
-        timeout-minutes: 26
+        # A worst-case attempt is the 360s hook plus the 30s afterAll and bun's
+        # own start and teardown, so 2 files x 2 attempts is ~26.3min. This
+        # binds only on a genuine hang.
+        timeout-minutes: 28
         env:
           # Per-attempt cap, sized so four attempts fit the step budget above.
           # The slowest healthy hook measures 289s.
           IOS_HOOK_TIMEOUT_MS: 360000
         run: |
+          shopt -s nullglob
+          files=(scripts/ios-regressions/*.test.ts)
+          if [ ${#files[@]} -eq 0 ]; then
+            echo "::error::no iOS regression test files found"
+            exit 1
+          fi
+
           # Per file rather than per suite, so a retry re-runs only what failed.
           # Two attempts each is what fits the step budget above.
           run_file() {
             for attempt in 1 2; do
-              if bun test "scripts/ios-regressions/$1.test.ts"; then
+              if bun test "$1"; then
                 return 0
               fi
-              echo "::warning::$1 attempt ${attempt}/2 failed"
+              echo "::warning::$(basename "$1") attempt ${attempt}/2 failed"
               # Retrying into a Safari left mid-gesture wastes the second
               # attempt.
               xcrun simctl terminate "$UDID" com.apple.mobilesafari || true
@@ -137,7 +145,7 @@ jobs:
           }
 
           status=0
-          for file in scrubber-longpress modal; do
+          for file in "${files[@]}"; do
             run_file "$file" || status=1
           done
           exit "$status"

--- a/.github/workflows/mobile.yml
+++ b/.github/workflows/mobile.yml
@@ -17,7 +17,7 @@ permissions:
 jobs:
   ios-regressions:
     runs-on: macos-latest
-    # 6.5 setup + 7 warm-up + 26 tests + 1.5 teardown and upload, leaving the
+    # 6.5 setup + 7 warm-up + 28 tests + 1.5 teardown and upload, leaving the
     # step timeouts to bind first.
     timeout-minutes: 46
     env:
@@ -35,6 +35,8 @@ jobs:
       AGENT_DEVICE_DAEMON_TIMEOUT_MS: 300000
       AGENT_DEVICE_DAEMON_STARTUP_TIMEOUT_MS: 30000
       BASE_URL: http://localhost:8000
+      # Only used for local runs: the prepare step below picks a UDID from
+      # whatever the runner image ships, and a UDID takes precedence.
       IOS_DEVICE_NAME: iPhone 16
       SESSION: ios-regressions
     steps:
@@ -114,8 +116,8 @@ jobs:
 
       - name: Run iOS Safari regressions
         # A worst-case attempt is the 360s hook plus the 30s afterAll and bun's
-        # own start and teardown, so 2 files x 2 attempts is ~26.3min. This
-        # binds only on a genuine hang.
+        # own start and teardown, so ~13.2min per discovered spec at two
+        # attempts each. Raise this and the job cap when adding a third.
         timeout-minutes: 28
         env:
           # Per-attempt cap, sized so four attempts fit the step budget above.

--- a/scripts/ios-regressions/harness.ts
+++ b/scripts/ios-regressions/harness.ts
@@ -19,6 +19,7 @@ export const baseUrl = env.BASE_URL ?? "http://localhost:8000";
 
 export const sessionName = (role: string): string =>
   env.SESSION ? `${env.SESSION}-${role}` : `zagrajmy-ios-${role}-local`;
+
 // The workflow sets this per attempt. The default only applies to local runs,
 // where nothing has paid the 194-240s cold runner attach yet -- run
 // `bun run scripts/ios-regressions/warmup.ts` first, or raise it.
@@ -26,9 +27,10 @@ export const hookTimeoutMs = Number(env.IOS_HOOK_TIMEOUT_MS ?? "300000");
 
 export type Rect = { x: number; y: number; width: number; height: number };
 
-// Safari's window on the configured simulator, used only when a snapshot comes
-// back without a root rect.
-export const FALLBACK_VIEWPORT: Rect = { x: 0, y: 0, width: 402, height: 874 };
+// Only reached when a snapshot comes back without a root rect. Sized for the
+// iPhone 17 Pro the macOS runner image actually provides -- CI ignores
+// `deviceName` below, because the workflow picks a UDID and passes it in.
+const FALLBACK_VIEWPORT: Rect = { x: 0, y: 0, width: 402, height: 874 };
 
 const deviceName = env.IOS_DEVICE_NAME ?? "iPhone 16";
 const runtime = env.IOS_RUNTIME;
@@ -61,6 +63,8 @@ export type IosHarness = {
   client: AgentDeviceClient;
   deviceOptions: IosDeviceOptions;
   takeSnapshot: () => Promise<CaptureSnapshotResult>;
+  viewportOf: (snapshot: CaptureSnapshotResult) => Rect;
+  viewportRect: () => Promise<Rect>;
   close: () => Promise<void>;
   snapshotLabels: () => Promise<string[]>;
   findNodeByLabel: (label: string) => Promise<SnapshotNode | null>;
@@ -85,6 +89,11 @@ export const createIosHarness = async (session: string): Promise<IosHarness> => 
     const snapshot = await takeSnapshot();
     return snapshot.nodes.map((node) => node.label ?? node.value ?? "").filter(Boolean);
   };
+
+  const viewportOf = (snapshot: CaptureSnapshotResult): Rect =>
+    snapshot.nodes[0]?.rect ?? FALLBACK_VIEWPORT;
+
+  const viewportRect = async (): Promise<Rect> => viewportOf(await takeSnapshot());
 
   const close = async (): Promise<void> => {
     try {
@@ -223,6 +232,8 @@ export const createIosHarness = async (session: string): Promise<IosHarness> => 
     client,
     deviceOptions,
     takeSnapshot,
+    viewportOf,
+    viewportRect,
     close,
     snapshotLabels,
     findNodeByLabel,

--- a/scripts/ios-regressions/harness.ts
+++ b/scripts/ios-regressions/harness.ts
@@ -19,7 +19,16 @@ export const baseUrl = env.BASE_URL ?? "http://localhost:8000";
 
 export const sessionName = (role: string): string =>
   env.SESSION ? `${env.SESSION}-${role}` : `zagrajmy-ios-${role}-local`;
+// The workflow sets this per attempt. The default only applies to local runs,
+// where nothing has paid the 194-240s cold runner attach yet -- run
+// `bun run scripts/ios-regressions/warmup.ts` first, or raise it.
 export const hookTimeoutMs = Number(env.IOS_HOOK_TIMEOUT_MS ?? "300000");
+
+export type Rect = { x: number; y: number; width: number; height: number };
+
+// Safari's window on the configured simulator, used only when a snapshot comes
+// back without a root rect.
+export const FALLBACK_VIEWPORT: Rect = { x: 0, y: 0, width: 402, height: 874 };
 
 const deviceName = env.IOS_DEVICE_NAME ?? "iPhone 16";
 const runtime = env.IOS_RUNTIME;

--- a/scripts/ios-regressions/modal.test.ts
+++ b/scripts/ios-regressions/modal.test.ts
@@ -2,13 +2,7 @@ import type { CaptureSnapshotResult, SnapshotNode } from "agent-device";
 
 import { afterAll, beforeAll, expect, test } from "bun:test";
 
-import {
-  baseUrl,
-  createIosHarness,
-  FALLBACK_VIEWPORT,
-  hookTimeoutMs,
-  sessionName,
-} from "./harness";
+import { baseUrl, createIosHarness, hookTimeoutMs, sessionName } from "./harness";
 
 const env = process.env;
 const session = sessionName("modal");
@@ -24,6 +18,7 @@ const {
   takeSnapshot,
   snapshotLabels,
   findNodeByLabel,
+  viewportOf,
   close,
   openUrl,
   prepareDevice,
@@ -62,7 +57,7 @@ const describeNode = (node: SnapshotNode): string => {
 
 const isNodeInViewport = (snapshot: CaptureSnapshotResult, node: SnapshotNode): boolean => {
   if (!node.rect) return false;
-  const viewportHeight = snapshot.nodes[0]?.rect?.height ?? FALLBACK_VIEWPORT.height;
+  const viewportHeight = viewportOf(snapshot).height;
   const centerY = node.rect.y + node.rect.height / 2;
   return centerY >= 80 && centerY <= viewportHeight - 120;
 };
@@ -105,7 +100,7 @@ const scrollUntilTriggerInViewport = async (): Promise<SnapshotNode> => {
       snapshot.nodes.find(
         (candidate) => candidate.label === targetTriggerLabel && !isHiddenDialogLabel(candidate),
       ) ?? snapshot.nodes.find(isTargetTitleNode);
-    const viewportHeight = snapshot.nodes[0]?.rect?.height ?? FALLBACK_VIEWPORT.height;
+    const viewportHeight = viewportOf(snapshot).height;
     const centerY = node?.rect ? node.rect.y + node.rect.height / 2 : viewportHeight;
     await client.interactions.scroll({
       ...deviceOptions,

--- a/scripts/ios-regressions/modal.test.ts
+++ b/scripts/ios-regressions/modal.test.ts
@@ -2,7 +2,13 @@ import type { CaptureSnapshotResult, SnapshotNode } from "agent-device";
 
 import { afterAll, beforeAll, expect, test } from "bun:test";
 
-import { baseUrl, createIosHarness, hookTimeoutMs, sessionName } from "./harness";
+import {
+  baseUrl,
+  createIosHarness,
+  FALLBACK_VIEWPORT,
+  hookTimeoutMs,
+  sessionName,
+} from "./harness";
 
 const env = process.env;
 const session = sessionName("modal");
@@ -56,7 +62,7 @@ const describeNode = (node: SnapshotNode): string => {
 
 const isNodeInViewport = (snapshot: CaptureSnapshotResult, node: SnapshotNode): boolean => {
   if (!node.rect) return false;
-  const viewportHeight = snapshot.nodes[0]?.rect?.height ?? 852;
+  const viewportHeight = snapshot.nodes[0]?.rect?.height ?? FALLBACK_VIEWPORT.height;
   const centerY = node.rect.y + node.rect.height / 2;
   return centerY >= 80 && centerY <= viewportHeight - 120;
 };
@@ -99,7 +105,7 @@ const scrollUntilTriggerInViewport = async (): Promise<SnapshotNode> => {
       snapshot.nodes.find(
         (candidate) => candidate.label === targetTriggerLabel && !isHiddenDialogLabel(candidate),
       ) ?? snapshot.nodes.find(isTargetTitleNode);
-    const viewportHeight = snapshot.nodes[0]?.rect?.height ?? 852;
+    const viewportHeight = snapshot.nodes[0]?.rect?.height ?? FALLBACK_VIEWPORT.height;
     const centerY = node?.rect ? node.rect.y + node.rect.height / 2 : viewportHeight;
     await client.interactions.scroll({
       ...deviceOptions,

--- a/scripts/ios-regressions/scrubber-longpress.test.ts
+++ b/scripts/ios-regressions/scrubber-longpress.test.ts
@@ -1,6 +1,14 @@
 import { afterAll, beforeAll, expect, test } from "bun:test";
 
-import { baseUrl, createIosHarness, hookTimeoutMs, sessionName } from "./harness";
+import type { Rect } from "./harness";
+
+import {
+  baseUrl,
+  createIosHarness,
+  FALLBACK_VIEWPORT,
+  hookTimeoutMs,
+  sessionName,
+} from "./harness";
 
 const env = process.env;
 const session = sessionName("scrubber");
@@ -26,10 +34,6 @@ const {
   prepareDevice,
   assertPageReady,
 } = await createIosHarness(session);
-
-type Rect = { x: number; y: number; width: number; height: number };
-
-const FALLBACK_VIEWPORT: Rect = { x: 0, y: 0, width: 402, height: 874 };
 
 const viewportRect = async (): Promise<Rect> =>
   (await takeSnapshot()).nodes[0]?.rect ?? FALLBACK_VIEWPORT;

--- a/scripts/ios-regressions/scrubber-longpress.test.ts
+++ b/scripts/ios-regressions/scrubber-longpress.test.ts
@@ -1,14 +1,6 @@
 import { afterAll, beforeAll, expect, test } from "bun:test";
 
-import type { Rect } from "./harness";
-
-import {
-  baseUrl,
-  createIosHarness,
-  FALLBACK_VIEWPORT,
-  hookTimeoutMs,
-  sessionName,
-} from "./harness";
+import { baseUrl, createIosHarness, hookTimeoutMs, sessionName } from "./harness";
 
 const env = process.env;
 const session = sessionName("scrubber");
@@ -28,6 +20,8 @@ const {
   deviceOptions,
   takeSnapshot,
   snapshotLabels,
+  viewportOf,
+  viewportRect,
   close,
   wait,
   openUrl,
@@ -35,13 +29,10 @@ const {
   assertPageReady,
 } = await createIosHarness(session);
 
-const viewportRect = async (): Promise<Rect> =>
-  (await takeSnapshot()).nodes[0]?.rect ?? FALLBACK_VIEWPORT;
-
 const scrollScheduleIntoView = async (): Promise<void> => {
   for (let attempt = 0; attempt < 14; attempt += 1) {
     const snapshot = await takeSnapshot();
-    const viewportHeight = snapshot.nodes[0]?.rect?.height ?? FALLBACK_VIEWPORT.height;
+    const viewportHeight = viewportOf(snapshot).height;
     const sessionOnScreen = snapshot.nodes.some(
       (node) =>
         (node.label ?? "").startsWith("Open details for") &&


### PR DESCRIPTION
Follow-ups from the review of #706, which classed all of them as non-blocking polish. No behavioural change to the tests.

## Auto-discover the spec files

#706 replaced `bun test scripts/ios-regressions/` with a hardcoded `for file in scrubber-longpress modal`, to stop a glob silently reordering execution. Ordering turned out not to matter — the "whichever file runs second fails" theory was disproven, and the warm-up step now pays the cold runner attach before either file starts — so the list bought nothing and would have meant a third `*.test.ts` never running in CI, with nothing failing to say so.

Back to a glob, with `nullglob` and an explicit guard so a zero-match pattern fails with `::error::no iOS regression test files found` rather than bun's "filters did not match".

## Correct the step budget

The comment computed `2 files x 2 attempts x ~370s = 24.7min` against a 26-minute cap. A worst-case attempt is the 360s hook plus the 30s `afterAll` plus bun's start and teardown, so it is really ~26.3min — just over. Step raised to 28, and the comment now states the **per-spec** rate rather than a total, since discovery makes the file count dynamic.

Raising the step rather than shrinking `IOS_HOOK_TIMEOUT_MS`, which would eat margin over the 289s slowest healthy hook.

## One viewport fallback, behind a helper

`modal.test.ts` carried two bare `852` literals while `scrubber-longpress.test.ts` used `402x874`. Rather than export the constant and leave `snapshot.nodes[0]?.rect?.height ?? FALLBACK_VIEWPORT.height` duplicated at four call sites, the harness now owns `viewportOf(snapshot)` and `viewportRect()`. `FALLBACK_VIEWPORT` is no longer exported and the magic number exists once.

`874` is the correct value, and the comment that previously called it "the configured simulator" was what made that hard to check. CI does **not** run the configured `IOS_DEVICE_NAME: iPhone 16` — the prepare step picks a UDID from whatever the runner image ships, and a UDID takes precedence in the harness. Run 30285889713 boots `iPhone 17 Pro`, which is 402x874, matching the `x=398` (`402 - 4`) in the long-press coordinates. `IOS_DEVICE_NAME` now says it only applies to local runs.

## Point local runs at the warm-up

`hookTimeoutMs`'s 300s default only applies locally, where nothing has paid the 194-240s cold attach — so a cold `bun test scripts/ios-regressions/` needs ~480-530s and gets 300s. Now says so, and names `warmup.ts` as the prelude.