### PR TITLE
Type-check the iOS regression scripts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,8 +82,8 @@ jobs:
       - name: Lint frontend TypeScript (oxlint)
         run: mise run lint-client
       # The iOS specs consume `IosHarness` by destructuring it. Unchecked, a
-      # typo there only surfaces as a TypeError deep inside an 18-minute
-      # macOS job.
+      # typo there only surfaces as a TypeError deep inside a macOS job that
+      # takes 20+ minutes.
       - name: Type-check the iOS regression scripts
         run: mise run ts-check:ios
       # Non-blocking: fallow surfaces dead code, duplication, and

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,6 +81,11 @@ jobs:
       # errors and zero warnings before the build is considered green.
       - name: Lint frontend TypeScript (oxlint)
         run: mise run lint-client
+      # The iOS specs consume `IosHarness` by destructuring it. Unchecked, a
+      # typo there only surfaces as a TypeError deep inside an 18-minute
+      # macOS job.
+      - name: Type-check the iOS regression scripts
+        run: mise run ts-check:ios
       # Non-blocking: fallow surfaces dead code, duplication, and
       # complexity hotspots as a report without failing the build.
       - name: Analyze frontend TypeScript (fallow)

--- a/.github/workflows/mobile.yml
+++ b/.github/workflows/mobile.yml
@@ -39,6 +39,19 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Check the iOS spec budget
+        run: |
+          shopt -s nullglob
+          files=(scripts/ios-regressions/*.test.ts)
+          if [ ${#files[@]} -eq 0 ]; then
+            echo "::error::no iOS regression test files found"
+            exit 1
+          fi
+          if [ ${#files[@]} -gt 2 ]; then
+            echo "::error::${#files[@]} iOS specs found; the budget is sized for 2. Raise timeout-minutes on the test step and the job, and the 2 in this guard."
+            exit 1
+          fi
+
       - uses: jdx/mise-action@v2
         with:
           # ponytail: macOS poetry venv links to Homebrew's python framework;
@@ -50,9 +63,6 @@ jobs:
 
       - run: mise install
       - run: mise exec -- poetry install
-
-      - name: Install agent-device
-        run: bun install -g agent-device@0.14.7
 
       - name: Prepare iOS simulator
         run: |
@@ -74,7 +84,7 @@ jobs:
               for device in runtime_devices
               if device.get("isAvailable") and "iPhone" in device.get("name", "")
           ]
-          preferred = next((device for device in devices if device["name"] == "iPhone 16"), None)
+          preferred = next((d for d in devices if d["name"] == "iPhone 17 Pro"), None)
           selected = preferred or devices[0]
           print(selected["udid"])
           PY
@@ -123,14 +133,6 @@ jobs:
         run: |
           shopt -s nullglob
           files=(scripts/ios-regressions/*.test.ts)
-          if [ ${#files[@]} -eq 0 ]; then
-            echo "::error::no iOS regression test files found"
-            exit 1
-          fi
-          if [ ${#files[@]} -gt 2 ]; then
-            echo "::error::${#files[@]} iOS specs found; the budget here is sized for 2. Raise timeout-minutes on this step and on the job."
-            exit 1
-          fi
 
           # Per file rather than per suite, so a retry re-runs only what failed.
           # Two attempts each is what fits the step budget above.

--- a/.github/workflows/mobile.yml
+++ b/.github/workflows/mobile.yml
@@ -35,9 +35,6 @@ jobs:
       AGENT_DEVICE_DAEMON_TIMEOUT_MS: 300000
       AGENT_DEVICE_DAEMON_STARTUP_TIMEOUT_MS: 30000
       BASE_URL: http://localhost:8000
-      # Only used for local runs: the prepare step below picks a UDID from
-      # whatever the runner image ships, and a UDID takes precedence.
-      IOS_DEVICE_NAME: iPhone 16
       SESSION: ios-regressions
     steps:
       - uses: actions/checkout@v4
@@ -121,13 +118,17 @@ jobs:
         timeout-minutes: 28
         env:
           # Per-attempt cap, sized so four attempts fit the step budget above.
-          # The slowest healthy hook measures 289s.
+          # The slowest healthy hook measures 316s.
           IOS_HOOK_TIMEOUT_MS: 360000
         run: |
           shopt -s nullglob
           files=(scripts/ios-regressions/*.test.ts)
           if [ ${#files[@]} -eq 0 ]; then
             echo "::error::no iOS regression test files found"
+            exit 1
+          fi
+          if [ ${#files[@]} -gt 2 ]; then
+            echo "::error::${#files[@]} iOS specs found; the budget here is sized for 2. Raise timeout-minutes on this step and on the job."
             exit 1
           fi
 

--- a/aube-lock.yaml
+++ b/aube-lock.yaml
@@ -12,7 +12,7 @@ importers:
   .:
     devDependencies:
       '@types/bun':
-        specifier: ^1.3.0
+        specifier: 1.3.14
         version: 1.3.14
       agent-device:
         specifier: 0.14.7

--- a/aube-lock.yaml
+++ b/aube-lock.yaml
@@ -11,6 +11,12 @@ importers:
 
   .:
     devDependencies:
+      '@types/bun':
+        specifier: ^1.3.0
+        version: 1.3.14
+      agent-device:
+        specifier: 0.14.7
+        version: 0.14.7
       dclint:
         specifier: 3.1.0
         version: 3.1.0(typescript@5.9.3)
@@ -26,6 +32,9 @@ importers:
       portless:
         specifier: 0.13.0
         version: 0.13.0
+      typescript:
+        specifier: 5.9.3
+        version: 5.9.3
       varlock:
         specifier: 1.12.0
         version: 1.12.0
@@ -263,6 +272,9 @@ packages:
 
   '@jsdevtools/ono@7.1.3':
     resolution: {integrity: sha512-4JQNk+3mVzK3xh2rqd6RB4J46qUR19azEHBneZyTZM+c456qOrbbM/5xcR8huNCCcbVt7+UmizG6GuUvPvKUYg==}
+
+  '@nodable/entities@3.0.0':
+    resolution: {integrity: sha512-8L9xFeTYKhm49xfIypoe2W5wV1m/3Z58kT+7kR9A8OyFxcPduI4VmxaUMQyKYrRjUoLLSXv6EKKID5Tvj9cUVw==}
 
   '@oxc-project/types@0.133.0':
     resolution: {integrity: sha512-KzkdCd6Uxqnf6l3HOw1xfatAlUURA0g14cvBYFyJ5SaNOQbOUvBr9PKArcPcrNIeRsBdgcUzOGrhKveVpvOIGA==}
@@ -563,6 +575,9 @@ packages:
     peerDependencies:
       vite: ^5.2.0 || ^6 || ^7 || ^8
 
+  '@types/bun@1.3.14':
+    resolution: {integrity: sha512-h1hFqFVcvAvD9j9K7ZW7vd82aSA+rTdznZa+5bwvCwqSB1jmmfLcbIWhOLx1/+boy/xmjgCs/OMUL8hRJSmnPw==}
+
   '@types/estree@1.0.9':
     resolution: {integrity: sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==}
 
@@ -639,6 +654,11 @@ packages:
     engines: {node: '>=0.4.0'}
     hasBin: true
 
+  agent-device@0.14.7:
+    resolution: {integrity: sha512-01kkWAoUZARhfhSvyDdhJiaVuV0aNIr4KkVHQ9XYMcI05Z2ckb9Bx42axTzrmsbDQXADkBPgBRh972WAlMUQlA==}
+    engines: {node: '>=22.19'}
+    hasBin: true
+
   ajv-formats@2.1.1:
     resolution: {integrity: sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==}
     peerDependencies:
@@ -672,6 +692,9 @@ packages:
   ansi-styles@6.2.3:
     resolution: {integrity: sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==}
     engines: {node: '>=12'}
+
+  anynum@1.0.1:
+    resolution: {integrity: sha512-N6//FLET/tXYNM/F6ABca1oH6fWB+KlTt909Le28WMDBk8oaT4vY17DCrwg2MvmuqUKt3Ni4N5dGJ/EoBgcO6A==}
 
   argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
@@ -718,6 +741,9 @@ packages:
   builtin-modules@3.3.0:
     resolution: {integrity: sha512-zhaCDicdLuWN5UbN5IMnFqNMhNfo919sH85y2/ea+5Yg9TsTkeZxpL+JLbp6cgYFS4sRLp3YV4S6yDuqVWHYOw==}
     engines: {node: '>=6'}
+
+  bun-types@1.3.14:
+    resolution: {integrity: sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ==}
 
   bytes@3.1.2:
     resolution: {integrity: sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==}
@@ -1007,6 +1033,13 @@ packages:
   fast-uri@3.1.2:
     resolution: {integrity: sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==}
 
+  fast-xml-builder@1.3.0:
+    resolution: {integrity: sha512-F74cZEdCvuw9P41GAC3rod4X04jjWGM1JPEv/GWSqFTWLsdyMSBMBMlm9Hk3GLBgLBbdBNY8yee0pQh2RBVESQ==}
+
+  fast-xml-parser@5.10.1:
+    resolution: {integrity: sha512-IEMIf7298kXuZSRFoGfMYrl7is8LpavODgbNz1cwIudv7KwVFnuU+UsMporfq6PD6aXSlawZlARiA3UywCTfMw==}
+    hasBin: true
+
   fdir@6.5.0:
     resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
     engines: {node: '>=12.0.0'}
@@ -1184,6 +1217,9 @@ packages:
 
   is-promise@4.0.0:
     resolution: {integrity: sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==}
+
+  is-unsafe@2.0.0:
+    resolution: {integrity: sha512-2LdV822R+wmI86unXA93WCFpL6g+av8ynWk0nrHyJqGop5VoocYsSLFgN8jrfalT6iGeLNM4KXuVSsULP53kEA==}
 
   isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
@@ -1508,6 +1544,10 @@ packages:
     resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
     engines: {node: '>=8'}
 
+  path-expression-matcher@1.6.2:
+    resolution: {integrity: sha512-enSlaiat05iasnzmgNxRj8reFdj3puY2QpNgP1aPIaVfT6nn9ICuPoFlKHk8EN22HcwewshO+mN2DGbkCEOtqQ==}
+    engines: {node: '>=14.0.0'}
+
   path-key@3.1.1:
     resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
     engines: {node: '>=8'}
@@ -1540,6 +1580,10 @@ packages:
     resolution: {integrity: sha512-vA30H8Nvkq/cPBnNw4Q8TWz1EJyqgpuinBcHET0YVJVFldr8JDNiU9LaWAE1KqSkRYazuaBhTpB5ZzShOezQ6A==}
     engines: {node: '>=18'}
     hasBin: true
+
+  pngjs@7.0.0:
+    resolution: {integrity: sha512-LKWqWJRhstyYo9pGvgor/ivk2w94eSjE3RGVuzLGlr3NmD8bf7RcYGze1mNdEHRP6TRP6rMuDHk5t44hnTRyow==}
+    engines: {node: '>=14.19.0'}
 
   portless@0.13.0:
     resolution: {integrity: sha512-PxMZ5BHH+ZZi9rTq4T8m003aZxh56qI0aBdNsxLn7jrTtvNJYBWYD3lc5PuQrom/aVh6z8iLb+tKUI6b7QNYQw==}
@@ -1721,6 +1765,9 @@ packages:
     resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
     engines: {node: '>=8'}
 
+  strnum@2.4.1:
+    resolution: {integrity: sha512-M9eUSMT2dCB2cTNPG7UYj6KuK7RJR2SN2+yCV/fTW3xzTCS6EaGZ5pSMgDIjB7r8zSfTGk+dvvn9rTjpVS9Mwg==}
+
   supports-color@7.2.0:
     resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
     engines: {node: '>=8'}
@@ -1887,6 +1934,10 @@ packages:
 
   wrappy@1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
+
+  xml-naming@0.3.0:
+    resolution: {integrity: sha512-ghig2TBE/H11aOVgmahA3MhimvkBr6JIYknH/Dhdk10nXwdbIqBJsbfMxpvFPG8bAw77gN29aQWvKpmVoPlvPQ==}
+    engines: {node: '>=16.0.0'}
 
   y18n@5.0.8:
     resolution: {integrity: sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==}
@@ -2059,6 +2110,8 @@ snapshots:
       '@jridgewell/sourcemap-codec': 1.5.5
 
   '@jsdevtools/ono@7.1.3': {}
+
+  '@nodable/entities@3.0.0': {}
 
   '@oxc-project/types@0.133.0': {}
 
@@ -2256,6 +2309,10 @@ snapshots:
       tailwindcss: 4.2.4
       vite: 8.0.16(@types/node@24.10.1)(jiti@2.7.0)(yaml@2.9.0)
 
+  '@types/bun@1.3.14':
+    dependencies:
+      bun-types: 1.3.14
+
   '@types/estree@1.0.9': {}
 
   '@types/http-proxy@1.17.17':
@@ -2338,6 +2395,11 @@ snapshots:
 
   acorn@8.17.0: {}
 
+  agent-device@0.14.7:
+    dependencies:
+      fast-xml-parser: 5.10.1
+      pngjs: 7.0.0
+
   ajv-formats@2.1.1(ajv@8.20.0):
     dependencies:
       ajv: 8.20.0
@@ -2367,6 +2429,8 @@ snapshots:
       color-convert: 2.0.1
 
   ansi-styles@6.2.3: {}
+
+  anynum@1.0.1: {}
 
   argparse@2.0.1: {}
 
@@ -2411,6 +2475,10 @@ snapshots:
   buffer-equal-constant-time@1.0.1: {}
 
   builtin-modules@3.3.0: {}
+
+  bun-types@1.3.14:
+    dependencies:
+      '@types/node': 24.10.1
 
   bytes@3.1.2: {}
 
@@ -2729,6 +2797,20 @@ snapshots:
 
   fast-uri@3.1.2: {}
 
+  fast-xml-builder@1.3.0:
+    dependencies:
+      path-expression-matcher: 1.6.2
+      xml-naming: 0.3.0
+
+  fast-xml-parser@5.10.1:
+    dependencies:
+      '@nodable/entities': 3.0.0
+      fast-xml-builder: 1.3.0
+      is-unsafe: 2.0.0
+      path-expression-matcher: 1.6.2
+      strnum: 2.4.1
+      xml-naming: 0.3.0
+
   fdir@6.5.0(picomatch@4.0.4):
     dependencies:
       picomatch: 4.0.4
@@ -2885,6 +2967,8 @@ snapshots:
   is-plain-object@5.0.0: {}
 
   is-promise@4.0.0: {}
+
+  is-unsafe@2.0.0: {}
 
   isexe@2.0.0: {}
 
@@ -3202,6 +3286,8 @@ snapshots:
 
   path-exists@4.0.0: {}
 
+  path-expression-matcher@1.6.2: {}
+
   path-key@3.1.1: {}
 
   path-to-regexp@8.4.2: {}
@@ -3223,6 +3309,8 @@ snapshots:
     optionalDependencies:
       fsevents: 2.3.2
     optional: true
+
+  pngjs@7.0.0: {}
 
   portless@0.13.0: {}
 
@@ -3407,6 +3495,10 @@ snapshots:
 
   strip-json-comments@3.1.1: {}
 
+  strnum@2.4.1:
+    dependencies:
+      anynum: 1.0.1
+
   supports-color@7.2.0:
     dependencies:
       has-flag: 4.0.0
@@ -3513,6 +3605,8 @@ snapshots:
       strip-ansi: 7.2.0
 
   wrappy@1.0.2: {}
+
+  xml-naming@0.3.0: {}
 
   y18n@5.0.8: {}
 

--- a/mise.toml
+++ b/mise.toml
@@ -406,6 +406,10 @@ run = "lsof -ti :8000 | xargs kill -9 2>/dev/null; lsof -ti :5173 | xargs kill -
 description = "Type-check frontend TypeScript"
 run = "aubr -C src/ludamus/client typecheck"
 
+[tasks."ts-check:ios"]
+description = "Type-check the iOS regression scripts"
+run = "aube exec tsc -p scripts/ios-regressions/tsconfig.json"
+
 [tasks.fallow]
 description = "Analyze frontend TypeScript: dead code, duplication, complexity"
 run = "aube exec -C src/ludamus/client fallow"

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "varlock": "varlock run --"
   },
   "devDependencies": {
-    "@types/bun": "^1.3.0",
+    "@types/bun": "1.3.14",
     "agent-device": "0.14.7",
     "dclint": "3.1.0",
     "fallow": "2.73.0",

--- a/package.json
+++ b/package.json
@@ -7,17 +7,15 @@
   "scripts": {
     "varlock": "varlock run --"
   },
-  "pnpm": {
-    "overrides": {
-      "synckit": "0.11.13"
-    }
-  },
   "devDependencies": {
+    "@types/bun": "^1.3.0",
+    "agent-device": "0.14.7",
     "dclint": "3.1.0",
     "fallow": "2.73.0",
     "oxfmt": "0.56.0",
     "oxlint": "1.70.0",
     "portless": "0.13.0",
+    "typescript": "5.9.3",
     "varlock": "1.12.0"
   },
   "pnpm": {

--- a/scripts/ios-regressions/harness.ts
+++ b/scripts/ios-regressions/harness.ts
@@ -7,10 +7,7 @@ import type {
 } from "agent-device";
 
 import { execFileSync } from "node:child_process";
-import { existsSync } from "node:fs";
-import { pathToFileURL } from "node:url";
 
-type AgentDeviceModule = typeof import("agent-device");
 type IosDeviceOptions = AgentDeviceSelectionOptions & { platform: "ios" };
 
 const env = process.env;
@@ -32,32 +29,9 @@ export type Rect = { x: number; y: number; width: number; height: number };
 // `deviceName` below, because the workflow picks a UDID and passes it in.
 const FALLBACK_VIEWPORT: Rect = { x: 0, y: 0, width: 402, height: 874 };
 
-const deviceName = env.IOS_DEVICE_NAME ?? "iPhone 16";
+const deviceName = env.IOS_DEVICE_NAME ?? "iPhone 17 Pro";
 const runtime = env.IOS_RUNTIME;
 const providedUdid = env.UDID;
-
-const importAgentDevice = async (): Promise<AgentDeviceModule> => {
-  try {
-    return await import("agent-device");
-  } catch (error) {
-    const candidates: string[] = [];
-    try {
-      const npmRoot = execFileSync("npm", ["root", "-g"], { encoding: "utf8" }).trim();
-      candidates.push(`${npmRoot}/agent-device/dist/src/index.js`);
-    } catch {}
-    if (env.HOME) {
-      candidates.push(
-        `${env.HOME}/.bun/install/global/node_modules/agent-device/dist/src/index.js`,
-      );
-    }
-    for (const candidate of candidates) {
-      if (existsSync(candidate)) {
-        return (await import(pathToFileURL(candidate).href)) as AgentDeviceModule;
-      }
-    }
-    throw error;
-  }
-};
 
 export type IosHarness = {
   client: AgentDeviceClient;
@@ -75,7 +49,7 @@ export type IosHarness = {
 };
 
 export const createIosHarness = async (session: string): Promise<IosHarness> => {
-  const { createAgentDeviceClient, isAgentDeviceError } = await importAgentDevice();
+  const { createAgentDeviceClient, isAgentDeviceError } = await import("agent-device");
   const client: AgentDeviceClient = createAgentDeviceClient({ session });
 
   const deviceOptions: IosDeviceOptions = providedUdid

--- a/scripts/ios-regressions/tsconfig.json
+++ b/scripts/ios-regressions/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "noEmit": true,
+    "strict": true,
+    "target": "es2024",
+    "module": "preserve",
+    "moduleResolution": "bundler",
+    "moduleDetection": "force",
+    "types": [
+      "bun"
+    ],
+    "lib": [
+      "es2024"
+    ],
+    "skipLibCheck": true
+  },
+  "include": [
+    "*.ts"
+  ]
+}

--- a/scripts/ios-regressions/tsconfig.json
+++ b/scripts/ios-regressions/tsconfig.json
@@ -6,15 +6,9 @@
     "module": "preserve",
     "moduleResolution": "bundler",
     "moduleDetection": "force",
-    "types": [
-      "bun"
-    ],
-    "lib": [
-      "es2024"
-    ],
+    "types": ["bun"],
+    "lib": ["es2024"],
     "skipLibCheck": true
   },
-  "include": [
-    "*.ts"
-  ]
+  "include": ["**/*.ts"]
 }


### PR DESCRIPTION
`scripts/ios-regressions/*.ts` was outside every typecheck task, so the `IosHarness` contract those specs destructure was verified by nothing. A typo'd member only surfaced as a runtime `TypeError` deep inside an 18-minute macOS job.

Linting was already covered — the `checks` job runs `mise run lint` → `hk check --all`, whose oxfmt/oxlint globs are repo-wide `**/*.ts` (73 files). Only typechecking was missing.

## What this adds

- `scripts/ios-regressions/tsconfig.json`, strict, `types: ["bun"]` for `bun:test` and the Bun globals.
- `mise run ts-check:ios`, wired into the `frontend-analysis` job next to `lint-client` — that job already runs `aube install`, which the typecheck needs and the `checks` job does not do.
- `agent-device` as a root devDependency, **pinned to 0.14.7** to match what the Mobile workflow installs, so the specs are checked against the types they run against. Plus `typescript` and `@types/bun`.

Verified it catches the intended bug class — renaming one destructured member to `viewportOff`:

```
modal.test.ts(21,3): error TS2339: Property 'viewportOff' does not exist on type 'IosHarness'.
modal.test.ts(60,26): error TS2552: Cannot find name 'viewportOf'. Did you mean 'viewportOff'?
```

Clean on the current tree.

## Batched in, since editing `mobile.yml` re-triggers the 18-minute Mobile workflow anyway

These are the three findings #710's review deferred rather than spend separate CI cycles on:

- **`IOS_DEVICE_NAME: iPhone 16` deleted.** It was unconditionally dead: a workflow `env:` never reaches local runs, CI always sets `UDID` and the harness prefers it, and the value was character-identical to the harness default. It is also what made an earlier review round conclude the fallback viewport was wrong — CI actually boots `iPhone 17 Pro` (402x874).
- **`289s` → `316s`** in the `IOS_HOOK_TIMEOUT_MS` rationale. #710's own run recorded 316s, so the old figure implied 71s of margin where there are 44.
- **Upper-bound spec guard.** Discovery made the file count dynamic while the step and job caps stayed static; a third spec would blow the 28-minute step with no indication why. Now fails fast naming the fix. Both guards verified under `bash -e`.

## Unrelated fix

`package.json` had `"pnpm"` twice — the second silently won. They were identical, so no behaviour change.