### PR TITLE
Keep overnight slots on the day they start; make the timetable calendar a capped scroller

### DIFF
--- a/src/ludamus/mills/timeslots.py
+++ b/src/ludamus/mills/timeslots.py
@@ -12,22 +12,29 @@ if TYPE_CHECKING:
 type SlotWindow = tuple[datetime, datetime]
 
 
+def slot_windows(slot: TimeSlotDTO, tz: tzinfo) -> list[SlotWindow]:
+    # A slot spanning multiple local dates contributes one (start, end) window
+    # to each date it touches, clamped to that date's [00:00, 24:00) range.
+    local_start = slot.start_time.astimezone(tz)
+    local_end = slot.end_time.astimezone(tz)
+    windows: list[SlotWindow] = []
+    days_span = (local_end.date() - local_start.date()).days + 1
+    for offset in range(days_span):
+        cursor_date = local_start.date() + timedelta(days=offset)
+        day_start = datetime.combine(cursor_date, datetime.min.time(), tzinfo=tz)
+        day_end = day_start + timedelta(days=1)
+        window_start = max(local_start, day_start)
+        window_end = min(local_end, day_end)
+        if window_start < window_end:
+            windows.append((window_start, window_end))
+    return windows
+
+
 def slot_windows_by_local_date(
     slots: list[TimeSlotDTO], tz: tzinfo
 ) -> dict[date, list[SlotWindow]]:
-    # A slot spanning multiple local dates contributes one (start, end) window
-    # to each date it touches, clamped to that date's [00:00, 24:00) range.
     grouped: dict[date, list[SlotWindow]] = defaultdict(list)
     for slot in slots:
-        local_start = slot.start_time.astimezone(tz)
-        local_end = slot.end_time.astimezone(tz)
-        days_span = (local_end.date() - local_start.date()).days + 1
-        for offset in range(days_span):
-            cursor_date = local_start.date() + timedelta(days=offset)
-            day_start = datetime.combine(cursor_date, datetime.min.time(), tzinfo=tz)
-            day_end = day_start + timedelta(days=1)
-            window_start = max(local_start, day_start)
-            window_end = min(local_end, day_end)
-            if window_start < window_end:
-                grouped[cursor_date].append((window_start, window_end))
+        for window in slot_windows(slot, tz):
+            grouped[window[0].date()].append(window)
     return grouped

--- a/src/ludamus/mills/timetable.py
+++ b/src/ludamus/mills/timetable.py
@@ -138,9 +138,7 @@ class TimetableService:
         )
         total_minutes = grid_end_minute - grid_start_minute
         day_range_starts = [
-            datetime.combine(
-                day, datetime.min.time(), tzinfo=windows_by_date[day][0][0].tzinfo
-            )
+            datetime.combine(day, datetime.min.time(), tzinfo=tz)
             + timedelta(minutes=grid_start_minute)
             for day in dates_to_render
         ]
@@ -163,13 +161,8 @@ class TimetableService:
                 )
             )
         time_labels: list[TimeLabelDTO] = []
-        if dates_to_render:
-            first_date = dates_to_render[0]
-            first_window_start = windows_by_date[first_date][0][0]
-            first_midnight = datetime.combine(
-                first_date, datetime.min.time(), tzinfo=first_window_start.tzinfo
-            )
-            label_start = first_midnight + timedelta(minutes=grid_start_minute)
+        if day_range_starts:
+            label_start = day_range_starts[0]
             slot_delta = timedelta(minutes=TIMETABLE_SLOT_MINUTES)
             time_labels = [
                 TimeLabelDTO(

--- a/src/ludamus/mills/timetable.py
+++ b/src/ludamus/mills/timetable.py
@@ -3,7 +3,7 @@ from collections import defaultdict
 from datetime import date, datetime, timedelta, tzinfo
 from typing import TYPE_CHECKING
 
-from ludamus.mills.timeslots import SlotWindow, slot_windows_by_local_date
+from ludamus.mills.timeslots import SlotWindow, slot_windows
 from ludamus.pacts import (
     NotFoundError,
     ScheduleChangeAction,
@@ -29,23 +29,24 @@ from ludamus.specs.timetable import (
 if TYPE_CHECKING:
     from ludamus.pacts import AgendaItemDTO, SpaceDTO, TimeSlotDTO, UnitOfWorkProtocol
 
+_WINDOWS_ACROSS_ONE_MIDNIGHT = 2
+
 
 def _slot_windows_by_grid_date(
     slots: list[TimeSlotDTO], tz: tzinfo
 ) -> dict[date, list[SlotWindow]]:
-    # A slot that crosses one midnight stays whole on the day it starts, so
-    # night program extends that day's column past 24:00. Splitting it at
-    # midnight would mint a 00:00-anchored phantom day and stretch the grid's
-    # shared time axis to a full 24 hours.
+    # A slot that crosses one midnight — exactly two per-date windows — stays
+    # whole on the day it starts, so night program extends that day's column
+    # past 24:00. Splitting it would mint a 00:00-anchored phantom day and
+    # stretch the grid's shared time axis to a full 24 hours. Slots touching
+    # more dates keep the per-date windows.
     grouped: dict[date, list[SlotWindow]] = defaultdict(list)
     for slot in slots:
-        local_start = slot.start_time.astimezone(tz)
-        local_end = slot.end_time.astimezone(tz)
-        if (local_end.date() - local_start.date()).days <= 1:
-            grouped[local_start.date()].append((local_start, local_end))
-        else:
-            for day, windows in slot_windows_by_local_date([slot], tz).items():
-                grouped[day].extend(windows)
+        windows = slot_windows(slot, tz)
+        if len(windows) == _WINDOWS_ACROSS_ONE_MIDNIGHT:
+            windows = [(windows[0][0], windows[1][1])]
+        for window in windows:
+            grouped[window[0].date()].append(window)
     return grouped
 
 
@@ -136,16 +137,31 @@ class TimetableService:
             dates_to_render, windows_by_date
         )
         total_minutes = grid_end_minute - grid_start_minute
-        days = [
-            self._build_day_grid(
-                date_to_render=date_to_render,
-                day_windows=windows_by_date[date_to_render],
-                spaces=spaces,
-                all_items=all_items,
-                grid_minute_bounds=(grid_start_minute, grid_end_minute),
+        day_range_starts = [
+            datetime.combine(
+                day, datetime.min.time(), tzinfo=windows_by_date[day][0][0].tzinfo
             )
-            for date_to_render in dates_to_render
+            + timedelta(minutes=grid_start_minute)
+            for day in dates_to_render
         ]
+        days: list[TimetableDayGridDTO] = []
+        for index, date_to_render in enumerate(dates_to_render):
+            range_start = day_range_starts[index]
+            range_end = range_start + timedelta(minutes=total_minutes)
+            # Past-midnight ranges can reach into the next rendered day. The
+            # next day owns everything from its own range start, so capping
+            # here makes the day filters a partition — a night session never
+            # renders in two columns.
+            if index + 1 < len(day_range_starts):
+                range_end = min(range_end, day_range_starts[index + 1])
+            days.append(
+                self._build_day_grid(
+                    date_to_render=date_to_render,
+                    day_range=(range_start, range_end),
+                    spaces=spaces,
+                    all_items=all_items,
+                )
+            )
         time_labels: list[TimeLabelDTO] = []
         if dates_to_render:
             first_date = dates_to_render[0]
@@ -186,17 +202,11 @@ class TimetableService:
     def _build_day_grid(
         *,
         date_to_render: date,
-        day_windows: list[tuple[datetime, datetime]],
+        day_range: tuple[datetime, datetime],
         spaces: list[SpaceDTO],
         all_items: list[AgendaItemDTO],
-        grid_minute_bounds: tuple[int, int],
     ) -> TimetableDayGridDTO:
-        grid_start_minute, grid_end_minute = grid_minute_bounds
-        day_midnight = datetime.combine(
-            date_to_render, datetime.min.time(), tzinfo=day_windows[0][0].tzinfo
-        )
-        grid_start = day_midnight + timedelta(minutes=grid_start_minute)
-        grid_end = day_midnight + timedelta(minutes=grid_end_minute)
+        grid_start, grid_end = day_range
 
         space_pk_set = {space.pk for space in spaces}
         space_items: dict[int, list[AgendaItemDTO]] = defaultdict(list)

--- a/src/ludamus/mills/timetable.py
+++ b/src/ludamus/mills/timetable.py
@@ -3,7 +3,7 @@ from collections import defaultdict
 from datetime import date, datetime, timedelta, tzinfo
 from typing import TYPE_CHECKING
 
-from ludamus.mills.timeslots import slot_windows_by_local_date
+from ludamus.mills.timeslots import SlotWindow, slot_windows_by_local_date
 from ludamus.pacts import (
     NotFoundError,
     ScheduleChangeAction,
@@ -27,7 +27,26 @@ from ludamus.specs.timetable import (
 )
 
 if TYPE_CHECKING:
-    from ludamus.pacts import AgendaItemDTO, SpaceDTO, UnitOfWorkProtocol
+    from ludamus.pacts import AgendaItemDTO, SpaceDTO, TimeSlotDTO, UnitOfWorkProtocol
+
+
+def _slot_windows_by_grid_date(
+    slots: list[TimeSlotDTO], tz: tzinfo
+) -> dict[date, list[SlotWindow]]:
+    # A slot that crosses one midnight stays whole on the day it starts, so
+    # night program extends that day's column past 24:00. Splitting it at
+    # midnight would mint a 00:00-anchored phantom day and stretch the grid's
+    # shared time axis to a full 24 hours.
+    grouped: dict[date, list[SlotWindow]] = defaultdict(list)
+    for slot in slots:
+        local_start = slot.start_time.astimezone(tz)
+        local_end = slot.end_time.astimezone(tz)
+        if (local_end.date() - local_start.date()).days <= 1:
+            grouped[local_start.date()].append((local_start, local_end))
+        else:
+            for day, windows in slot_windows_by_local_date([slot], tz).items():
+                grouped[day].extend(windows)
+    return grouped
 
 
 def _position_sessions(
@@ -99,7 +118,7 @@ class TimetableService:
         spaces = leaf_spaces[start : start + TIMETABLE_ROOM_PAGE_SIZE]
 
         all_slots = self._uow.time_slots.list_by_event(event_pk)
-        windows_by_date = slot_windows_by_local_date(all_slots, tz)
+        windows_by_date = _slot_windows_by_grid_date(all_slots, tz)
         available_dates = sorted(windows_by_date)
         if date_selection != "all" and date_selection not in windows_by_date:
             date_selection = available_dates[0] if available_dates else "all"
@@ -219,20 +238,20 @@ class TimetableService:
         for day in dates_to_render:
             for window_start, window_end in windows_by_date[day]:
                 start_minutes.append(window_start.hour * 60 + window_start.minute)
-                if window_end.date() > day:
-                    end_minutes.append(24 * 60)
-                else:
-                    end_minutes.append(
-                        math.ceil(
-                            (
-                                window_end.hour * 60
-                                + window_end.minute
-                                + window_end.second / 60
-                            )
-                            / TIMETABLE_SLOT_MINUTES
+                # An overnight window ends past 24:00 on its own day's clock.
+                days_past_midnight = (window_end.date() - day).days
+                end_minutes.append(
+                    math.ceil(
+                        (
+                            days_past_midnight * 24 * 60
+                            + window_end.hour * 60
+                            + window_end.minute
+                            + window_end.second / 60
                         )
-                        * TIMETABLE_SLOT_MINUTES
+                        / TIMETABLE_SLOT_MINUTES
                     )
+                    * TIMETABLE_SLOT_MINUTES
+                )
 
         return (
             min(start_minutes) // TIMETABLE_SLOT_MINUTES * TIMETABLE_SLOT_MINUTES,

--- a/src/ludamus/templates/panel/parts/timetable-grid.html
+++ b/src/ludamus/templates/panel/parts/timetable-grid.html
@@ -36,7 +36,13 @@
     {% endif %}
     {% translate "Column width" as t_column_width %}
     {% translate "Drag, or use the arrow keys, to resize every column. Double-click to reset." as t_column_width_hint %}
-    <div class="timetable-calendar overflow-auto overscroll-contain border border-border rounded-lg select-none"
+    {% comment %}
+    The calendar is its own two-axis scroller: the viewport cap makes it
+    actually scroll vertically, which is what lets the sticky day/room header
+    engage. Containment is x-only — y-containment would swallow wheel events
+    whenever the grid can't consume them and lock the page under the cursor.
+    {% endcomment %}
+    <div class="timetable-calendar max-h-[calc(100dvh-5rem)] overflow-auto overscroll-x-contain border border-border rounded-lg select-none"
          data-timetable-days
          style="--grid-extent: {{ grid.total_minutes }};
                 --total-columns: {{ grid.total_columns }};

--- a/src/ludamus/templates/panel/parts/timetable-grid.html
+++ b/src/ludamus/templates/panel/parts/timetable-grid.html
@@ -39,8 +39,8 @@
     {% comment %}
     The calendar is its own two-axis scroller: the viewport cap makes it
     actually scroll vertically, which is what lets the sticky day/room header
-    engage. Containment is x-only — y-containment would swallow wheel events
-    whenever the grid can't consume them and lock the page under the cursor.
+    engage even on an overnight-length grid. Containment is x-only so vertical
+    scrolling always chains to the page when the grid cannot consume it.
     {% endcomment %}
     <div class="timetable-calendar max-h-[calc(100dvh-5rem)] overflow-auto overscroll-x-contain border border-border rounded-lg select-none"
          data-timetable-days

--- a/tests/e2e/tests/timetable.spec.ts
+++ b/tests/e2e/tests/timetable.spec.ts
@@ -76,6 +76,40 @@ test.describe("Timetable", () => {
     expect(Math.abs(rightEdges.gridRight - rightEdges.calendarRight)).toBeLessThanOrEqual(2);
   });
 
+  test("calendar is a capped scroller that never contains vertical scroll", async ({ page }) => {
+    // Narrow enough that the calendar overflows horizontally — the shape in
+    // which overscroll-y containment used to trap wheel input over the grid.
+    await page.setViewportSize({ width: 1100, height: 700 });
+    await page.goto("/panel/event/sunhaven-festival/timetable/?date=all");
+
+    const calendar = page.locator(".timetable-calendar");
+    await expect(calendar).toBeVisible();
+
+    // The shipped contract: the calendar caps itself to the viewport (so a
+    // 24h-scale grid scrolls internally under its sticky header) and never
+    // contains vertical overscroll (so the page scrolls when it cannot).
+    const contract = await calendar.evaluate((el) => {
+      const style = getComputedStyle(el);
+      return { maxHeight: style.maxHeight, overscrollY: style.overscrollBehaviorY };
+    });
+    expect(contract.overscrollY).toBe("auto");
+    expect(contract.maxHeight).not.toBe("none");
+    expect(Number.parseFloat(contract.maxHeight)).toBeLessThanOrEqual(700);
+
+    // And wheel input over the grid must reach something scrollable.
+    await calendar.hover({ position: { x: 100, y: 50 } });
+    await page.mouse.wheel(0, 600);
+    await expect
+      .poll(() =>
+        page.evaluate(() => {
+          const app = document.getElementById("app-scroll");
+          const cal = document.querySelector(".timetable-calendar");
+          return (app?.scrollTop ?? 0) + (cal?.scrollTop ?? 0);
+        }),
+      )
+      .toBeGreaterThan(0);
+  });
+
   test("all days stay side-by-side and assign into the selected day", async ({ page }) => {
     await page.goto("/panel/event/sunhaven-festival/timetable/?date=all");
 

--- a/tests/unit/test_chronology_mills.py
+++ b/tests/unit/test_chronology_mills.py
@@ -265,6 +265,59 @@ class TestBuildGridOverlappingSessions:
         assert [pos.start_minutes for pos in day_one.columns[0].sessions] == [12 * 60]
         assert day_two.columns[0].sessions == []
 
+    def test_overlapping_day_ranges_render_each_item_in_exactly_one_column(self):
+        uow = MagicMock()
+        now = datetime(2026, 1, 1, 10, 0, tzinfo=UTC)
+        space = SpaceDTO(
+            capacity=None,
+            creation_time=now,
+            modification_time=now,
+            name="Room 1",
+            order=0,
+            pk=1,
+            slug="room-1",
+        )
+        uow.spaces.list_by_event.return_value = [space]
+        uow.time_slots.list_by_event.return_value = [
+            TimeSlotDTO(
+                pk=1,
+                start_time=datetime(2026, 1, 1, 18, 0, tzinfo=UTC),
+                end_time=datetime(2026, 1, 2, 1, 0, tzinfo=UTC),
+            ),
+            TimeSlotDTO(
+                pk=2,
+                start_time=datetime(2026, 1, 2, 0, 30, tzinfo=UTC),
+                end_time=datetime(2026, 1, 2, 2, 0, tzinfo=UTC),
+            ),
+        ]
+        first_night = _make_item(
+            pk=1,
+            start_time=datetime(2026, 1, 2, 0, 15, tzinfo=UTC),
+            end_time=datetime(2026, 1, 2, 0, 30, tzinfo=UTC),
+        )
+        second_night = _make_item(
+            pk=2,
+            session_id=2,
+            start_time=datetime(2026, 1, 2, 0, 30, tzinfo=UTC),
+            end_time=datetime(2026, 1, 2, 1, 30, tzinfo=UTC),
+        )
+        uow.agenda_items.list_by_event.return_value = [first_night, second_night]
+
+        grid = TimetableService(uow).build_grid(
+            event_pk=1, tz=UTC, date_selection="all"
+        )
+
+        day_one, day_two = grid.days
+        # Day one's range reaches 01:00 of Jan 2 while day two's starts at
+        # midnight (00:30 floored to the hour grid), so both contain the two
+        # night items; the later day owns the overlap instead of rendering
+        # the items in both columns.
+        assert day_one.columns[0].sessions == []
+        assert [
+            (pos.agenda_item.pk, pos.start_minutes)
+            for pos in day_two.columns[0].sessions
+        ] == [(1, 15), (2, 30)]
+
 
 class TestRevertChange:
     @pytest.fixture

--- a/tests/unit/test_chronology_mills.py
+++ b/tests/unit/test_chronology_mills.py
@@ -217,7 +217,53 @@ class TestBuildGridOverlappingSessions:
         )
 
         assert grid.date_selection == date(2026, 1, 1)
-        assert grid.total_minutes == 2 * 60
+        assert grid.total_minutes == 4 * 60
+
+    def test_overnight_slot_extends_its_day_instead_of_adding_a_24h_day(self):
+        uow = MagicMock()
+        now = datetime(2026, 1, 1, 10, 0, tzinfo=UTC)
+        space = SpaceDTO(
+            capacity=None,
+            creation_time=now,
+            modification_time=now,
+            name="Room 1",
+            order=0,
+            pk=1,
+            slug="room-1",
+        )
+        uow.spaces.list_by_event.return_value = [space]
+        uow.time_slots.list_by_event.return_value = [
+            TimeSlotDTO(
+                pk=1,
+                start_time=datetime(2026, 1, 1, 12, 0, tzinfo=UTC),
+                end_time=datetime(2026, 1, 2, 1, 0, tzinfo=UTC),
+            ),
+            TimeSlotDTO(
+                pk=2,
+                start_time=datetime(2026, 1, 2, 12, 0, tzinfo=UTC),
+                end_time=datetime(2026, 1, 2, 22, 0, tzinfo=UTC),
+            ),
+        ]
+        night_owl = _make_item(
+            start_time=datetime(2026, 1, 2, 0, 0, tzinfo=UTC),
+            end_time=datetime(2026, 1, 2, 1, 0, tzinfo=UTC),
+        )
+        uow.agenda_items.list_by_event.return_value = [night_owl]
+
+        grid = TimetableService(uow).build_grid(
+            event_pk=1, tz=UTC, date_selection="all"
+        )
+
+        assert grid.available_dates == [date(2026, 1, 1), date(2026, 1, 2)]
+        assert grid.total_minutes == 13 * 60
+        assert [label.time.strftime("%H:%M") for label in grid.time_labels][:2] == [
+            "12:00",
+            "13:00",
+        ]
+        assert grid.time_labels[-1].time.strftime("%H:%M") == "01:00"
+        day_one, day_two = grid.days
+        assert [pos.start_minutes for pos in day_one.columns[0].sessions] == [12 * 60]
+        assert day_two.columns[0].sessions == []
 
 
 class TestRevertChange:


### PR DESCRIPTION
Setting a time slot that ends at 1 AM stretched the panel timetable to a full 24 h and the page could not be scrolled with the cursor over the grid.

## What was wrong

- `slot_windows_by_local_date` splits a slot crossing midnight into a "until 24:00" window plus a phantom next-day window anchored at 00:00. The grid's time axis is shared across all rendered days (min start → max end), so one overnight slot forced 00:00–24:00 bounds for every day.
- `.timetable-calendar` was `overflow-auto overscroll-contain` with no height cap: it never scrolled vertically itself (so its sticky day/room header never engaged), while vertical overscroll containment could trap wheel input over the grid — which at 24 h scale filled the whole viewport.

## What changed

- **Grid axis** (`mills/timetable.py`): a slot crossing exactly one midnight stays whole on the day it starts, extending that day's column past 24:00 (labels wrap to 00:00, 01:00). Slots touching more dates keep the per-date clamped windows. The old `if window_end.date() > day` special case in `_grid_minute_bounds` collapsed into one day-relative formula.
- **Partition of night sessions**: day ranges can now overlap around the small hours, so each day's item filter is capped at the next day's range start — a session renders in exactly one column. Covered by a unit test.
- **Shared derivation** (`mills/timeslots.py`): new per-slot `slot_windows()` helper owns the clamping loop; `slot_windows_by_local_date` and the grid's grouper both build on it (behavior-identical for the printing/heatmap callers).
- **Calendar scroller** (`timetable-grid.html`): `max-h-[calc(100dvh-5rem)]` makes the calendar its own vertical scroller — the sticky header finally engages, and an overnight-length grid stays usable — and containment narrows to `overscroll-x-contain` so vertical scrolling always chains to the page. An e2e test pins this contract (verified to fail against the old classes).

Manually verified with a 12:00→01:00 slot: axis runs 10:00–01:00 (15 h shared, not 24 h), the calendar scrolls internally under its sticky header, and the phantom next day is gone from the day picker (screenshots shared in the session; `screenshots/` is gitignored).

## Deliberate scope notes

- The organizer-overview heatmap and print timetables still split overnight slots at midnight — they render each day independently, so the 24 h stretch never applied there. The two surfaces now disagree about which day owns night program; unifying that is a product decision left out of this fix.
- A session *straddling* a day-range cut point can still match two days' broad-phase filters — a pre-existing edge (present before this branch) that the new capping strictly shrinks.

Two rounds of strict code-quality review ran on this branch; round 2 approved with no blocking findings. Full local suite green: 3242 unit/integration + 24 timetable e2e.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EW2x2vKjWpsLBc2WUNuj3b