### PR TITLE
Extract shared status-page hero partial

### DIFF
--- a/src/ludamus/locale/pl/LC_MESSAGES/django.po
+++ b/src/ludamus/locale/pl/LC_MESSAGES/django.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-07-28 19:18+0200\n"
+"POT-Creation-Date: 2026-07-29 00:14+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -3105,10 +3105,12 @@ msgid "Page Not Found"
 msgstr "Strona nie została znaleziona."
 
 #: src/ludamus/templates/404_dynamic.html
+#: src/ludamus/templates/500_dynamic.html
 msgid "Go Back"
 msgstr "Wróć"
 
 #: src/ludamus/templates/404_dynamic.html
+#: src/ludamus/templates/500_dynamic.html
 msgid "Go to Home"
 msgstr "Przejdź do strony głównej"
 
@@ -8476,6 +8478,7 @@ msgstr "Brak przechwyconych e-maili."
 #, python-format
 #~ msgid "Release %(name)s"
 #~ msgstr "Zwolnij twórcę %(name)s"
+
 #, python-format
 #~ msgid ""
 #~ "Programme and sign-ups for %(sphere)s. Every item shows its time, room "

--- a/src/ludamus/templates/404_dynamic.html
+++ b/src/ludamus/templates/404_dynamic.html
@@ -9,7 +9,7 @@
 {% block body %}
     <div class="flex-1 flex items-center justify-center">
         <div class="max-w-screen-sm xl:min-w-[600px] mx-auto px-4">
-            {% include "components/status_hero.html" with icon="question-mark-circle" icon_class="w-8 h-8 text-warning" error_code=error_code heading=title lead=message only %}
+            {% include "components/status_hero.html" with icon="question-mark-circle" icon_color="text-warning" error_code=error_code heading=title lead=message only %}
             <p class="text-sm mb-4 text-foreground-muted">{{ subtitle }}</p>
             <p class="mb-6 text-foreground">{{ guidance }}</p>
             <div class="flex flex-col sm:flex-row gap-3">

--- a/src/ludamus/templates/404_dynamic.html
+++ b/src/ludamus/templates/404_dynamic.html
@@ -9,14 +9,7 @@
 {% block body %}
     <div class="flex-1 flex items-center justify-center">
         <div class="max-w-screen-sm xl:min-w-[600px] mx-auto px-4">
-            <div class="mb-6 flex items-center gap-4">
-                <div class="w-16 h-16 rounded-2xl flex items-center justify-center bg-white dark:bg-neutral-900">
-                    {% icon "question-mark-circle" class="w-8 h-8 text-warning" %}
-                </div>
-                <span class="text-6xl font-bold text-foreground-muted">{{ error_code }}</span>
-            </div>
-            <h1 class="text-2xl font-bold mb-3">{{ title }}</h1>
-            <p class="mb-2 text-foreground-muted">{{ message }}</p>
+            {% include "components/status_hero.html" with icon="question-mark-circle" icon_class="w-8 h-8 text-warning" error_code=error_code heading=title lead=message only %}
             <p class="text-sm mb-4 text-foreground-muted">{{ subtitle }}</p>
             <p class="mb-6 text-foreground">{{ guidance }}</p>
             <div class="flex flex-col sm:flex-row gap-3">

--- a/src/ludamus/templates/500_dynamic.html
+++ b/src/ludamus/templates/500_dynamic.html
@@ -27,7 +27,7 @@
     </head>
     <body class="min-h-screen font-sans antialiased flex items-center justify-center bg-background text-foreground">
         <div class="max-w-screen-sm xl:min-w-[600px] mx-auto px-4">
-            {% include "components/status_hero.html" with icon="exclamation-triangle" icon_class="w-8 h-8 text-danger" error_code=error_code heading=title lead=message only %}
+            {% include "components/status_hero.html" with icon="exclamation-triangle" icon_color="text-danger" error_code=error_code heading=title lead=message only %}
             <p class="text-sm mb-4 text-foreground-muted">{{ subtitle }}</p>
             <p class="mb-2 text-foreground">{{ guidance }}</p>
             <p class="mb-6 text-sm text-foreground-muted">

--- a/src/ludamus/templates/500_dynamic.html
+++ b/src/ludamus/templates/500_dynamic.html
@@ -1,6 +1,7 @@
 {% load static %}
 {% load django_vite %}
 {% load i18n %}
+{% load tessera %}
 <!DOCTYPE html>
 <html lang="en">
     <head>
@@ -26,21 +27,7 @@
     </head>
     <body class="min-h-screen font-sans antialiased flex items-center justify-center bg-background text-foreground">
         <div class="max-w-screen-sm xl:min-w-[600px] mx-auto px-4">
-            <div class="mb-6 flex items-center gap-4">
-                <div class="w-16 h-16 rounded-2xl flex items-center justify-center bg-white dark:bg-neutral-900">
-                    <svg xmlns="http://www.w3.org/2000/svg"
-                         fill="none"
-                         viewBox="0 0 24 24"
-                         stroke-width="1.5"
-                         stroke="currentColor"
-                         class="w-8 h-8 text-danger">
-                        <path stroke-linecap="round" stroke-linejoin="round" d="M12 9v3.75m-9.303 3.376c-.866 1.5.217 3.374 1.948 3.374h14.71c1.73 0 2.813-1.874 1.948-3.374L13.949 3.378c-.866-1.5-3.032-1.5-3.898 0L2.697 16.126ZM12 15.75h.007v.008H12v-.008Z" />
-                    </svg>
-                </div>
-                <span class="text-6xl font-bold text-foreground-muted">{{ error_code }}</span>
-            </div>
-            <h1 class="text-2xl font-bold mb-3">{{ title }}</h1>
-            <p class="mb-2 text-foreground-muted">{{ message }}</p>
+            {% include "components/status_hero.html" with icon="exclamation-triangle" icon_class="w-8 h-8 text-danger" error_code=error_code heading=title lead=message only %}
             <p class="text-sm mb-4 text-foreground-muted">{{ subtitle }}</p>
             <p class="mb-2 text-foreground">{{ guidance }}</p>
             <p class="mb-6 text-sm text-foreground-muted">
@@ -49,26 +36,12 @@
             </p>
             <div class="flex flex-col sm:flex-row gap-3">
                 <button onclick="history.back()" class="btn btn-secondary">
-                    <svg xmlns="http://www.w3.org/2000/svg"
-                         fill="none"
-                         viewBox="0 0 24 24"
-                         stroke-width="1.5"
-                         stroke="currentColor"
-                         class="w-5 h-5">
-                        <path stroke-linecap="round" stroke-linejoin="round" d="M10.5 19.5 3 12m0 0 7.5-7.5M3 12h18" />
-                    </svg>
-                    Go Back
+                    {% icon "arrow-left" class="w-5 h-5" %}
+                    {% translate "Go Back" %}
                 </button>
                 <a href="/" class="btn btn-primary">
-                    <svg xmlns="http://www.w3.org/2000/svg"
-                         fill="none"
-                         viewBox="0 0 24 24"
-                         stroke-width="1.5"
-                         stroke="currentColor"
-                         class="w-5 h-5">
-                        <path stroke-linecap="round" stroke-linejoin="round" d="m2.25 12 8.954-8.955c.44-.439 1.152-.439 1.591 0L21.75 12M4.5 9.75v10.125c0 .621.504 1.125 1.125 1.125H9.75v-4.875c0-.621.504-1.125 1.125-1.125h2.25c.621 0 1.125.504 1.125 1.125V21h4.125c.621 0 1.125-.504 1.125-1.125V9.75M8.25 21h8.25" />
-                    </svg>
-                    Go to Home
+                    {% icon "home" class="w-5 h-5" %}
+                    {% translate "Go to Home" %}
                 </a>
             </div>
         </div>

--- a/src/ludamus/templates/components/status_hero.html
+++ b/src/ludamus/templates/components/status_hero.html
@@ -8,7 +8,7 @@ pages add below. Action buttons stay at the call site — they differ
 structurally per page.{% endcomment %}
 <div class="mb-6{% if error_code %} flex items-center gap-4{% endif %}">
     <div class="w-16 h-16 rounded-2xl flex items-center justify-center bg-white dark:bg-neutral-900">
-        {% icon icon class=icon_class %}
+        {% icon icon class="w-8 h-8 "|add:icon_color %}
     </div>
     {% if error_code %}
         <span class="text-6xl font-bold text-foreground-muted">{{ error_code }}</span>

--- a/src/ludamus/templates/components/status_hero.html
+++ b/src/ludamus/templates/components/status_hero.html
@@ -1,0 +1,18 @@
+{% load tessera %}
+{% comment %}Status-page hero: icon in a rounded tile, heading, muted lead.
+Every variable is required at the call site (strict template checker) — pass
+error_code="" when there is no HTTP status to show. A non-empty error_code
+switches to the compact variant: the code sits beside the tile and the
+heading/lead tighten up to leave room for the follow-up paragraphs error
+pages add below. Action buttons stay at the call site — they differ
+structurally per page.{% endcomment %}
+<div class="mb-6{% if error_code %} flex items-center gap-4{% endif %}">
+    <div class="w-16 h-16 rounded-2xl flex items-center justify-center bg-white dark:bg-neutral-900">
+        {% icon icon class=icon_class %}
+    </div>
+    {% if error_code %}
+        <span class="text-6xl font-bold text-foreground-muted">{{ error_code }}</span>
+    {% endif %}
+</div>
+<h1 class="{% if error_code %}text-2xl{% else %}text-3xl{% endif %} font-bold mb-3 text-foreground">{{ heading }}</h1>
+<p class="{% if error_code %}mb-2{% else %}text-lg mb-6{% endif %} text-foreground-muted">{{ lead }}</p>

--- a/src/ludamus/templates/crowd/auth_error.html
+++ b/src/ludamus/templates/crowd/auth_error.html
@@ -9,15 +9,9 @@
 {% block body %}
     <div class="flex-1 flex items-center justify-center">
         <div class="max-w-md mx-auto px-4">
-            <div class="mb-6">
-                <div class="w-16 h-16 rounded-2xl flex items-center justify-center bg-white dark:bg-neutral-900">
-                    {% icon "exclamation-triangle" class="w-8 h-8 text-primary" %}
-                </div>
-            </div>
-            <h1 class="text-3xl font-bold mb-3 text-foreground">{% translate "Login failed" %}</h1>
-            <p class="text-lg mb-6 text-foreground-muted">
-                {% translate "Something interrupted the login. This can happen after going back to an old login page, waiting too long, or when your browser blocks cookies. Trying again usually helps." %}
-            </p>
+            {% translate "Login failed" as heading %}
+            {% translate "Something interrupted the login. This can happen after going back to an old login page, waiting too long, or when your browser blocks cookies. Trying again usually helps." as lead %}
+            {% include "components/status_hero.html" with icon="exclamation-triangle" icon_class="w-8 h-8 text-primary" error_code="" heading=heading lead=lead only %}
             <div class="flex flex-col sm:flex-row items-start gap-3">
                 {% url 'web:index' as home_url %}
                 {% translate "Log in again" as login_again %}

--- a/src/ludamus/templates/crowd/auth_error.html
+++ b/src/ludamus/templates/crowd/auth_error.html
@@ -11,7 +11,7 @@
         <div class="max-w-md mx-auto px-4">
             {% translate "Login failed" as heading %}
             {% translate "Something interrupted the login. This can happen after going back to an old login page, waiting too long, or when your browser blocks cookies. Trying again usually helps." as lead %}
-            {% include "components/status_hero.html" with icon="exclamation-triangle" icon_class="w-8 h-8 text-primary" error_code="" heading=heading lead=lead only %}
+            {% include "components/status_hero.html" with icon="exclamation-triangle" icon_color="text-primary" error_code="" heading=heading lead=lead only %}
             <div class="flex flex-col sm:flex-row items-start gap-3">
                 {% url 'web:index' as home_url %}
                 {% translate "Log in again" as login_again %}

--- a/src/ludamus/templates/crowd/login_required.html
+++ b/src/ludamus/templates/crowd/login_required.html
@@ -9,13 +9,9 @@
 {% block body %}
     <div class="flex-1 flex items-center justify-center">
         <div class="max-w-md mx-auto px-4">
-            <div class="mb-6">
-                <div class="w-16 h-16 rounded-2xl flex items-center justify-center bg-white dark:bg-neutral-900">
-                    {% icon "lock-closed" class="w-8 h-8 text-primary" %}
-                </div>
-            </div>
-            <h1 class="text-3xl font-bold mb-3 text-foreground">{% translate "Login Required" %}</h1>
-            <p class="text-lg mb-6 text-foreground-muted">{% translate "You need to be logged in to access this page." %}</p>
+            {% translate "Login Required" as heading %}
+            {% translate "You need to be logged in to access this page." as lead %}
+            {% include "components/status_hero.html" with icon="lock-closed" icon_class="w-8 h-8 text-primary" error_code="" heading=heading lead=lead only %}
             <div class="flex flex-col sm:flex-row items-start gap-3">
                 {% include "components/login_button.html" with next=next show_icon=True text="" extra_class="" %}
                 <a href="{% url 'web:index' %}" class="btn btn-secondary">

--- a/src/ludamus/templates/crowd/login_required.html
+++ b/src/ludamus/templates/crowd/login_required.html
@@ -11,7 +11,7 @@
         <div class="max-w-md mx-auto px-4">
             {% translate "Login Required" as heading %}
             {% translate "You need to be logged in to access this page." as lead %}
-            {% include "components/status_hero.html" with icon="lock-closed" icon_class="w-8 h-8 text-primary" error_code="" heading=heading lead=lead only %}
+            {% include "components/status_hero.html" with icon="lock-closed" icon_color="text-primary" error_code="" heading=heading lead=lead only %}
             <div class="flex flex-col sm:flex-row items-start gap-3">
                 {% include "components/login_button.html" with next=next show_icon=True text="" extra_class="" %}
                 <a href="{% url 'web:index' %}" class="btn btn-secondary">


### PR DESCRIPTION
## Problem

Four pages hand-rolled the same hero shell — icon in a rounded tile, heading, muted lead: `login_required.html`, `auth_error.html` (its third copy triggered the rule of three in the #713 reviews), `404_dynamic.html`, and `500_dynamic.html` (which also duplicated inline SVGs and untranslated button labels).

## Change

- New `components/status_hero.html`: icon tile + optional error-code chip + heading + lead. A non-empty `error_code` selects the compact variant (code beside the tile, tighter heading/lead) — the real existing distinction between the auth pages and the error pages, driven by one input instead of class-string params.
- All four pages converted. Action-button rows stay at the call sites — they differ structurally (login-button component vs plain links vs `history.back()`).
- Every partial input is passed explicitly with `only` at each call site (the strict template checker requires it; `error_code=""` where there's no HTTP status).
- Bonus on the 500 page: hero and buttons now use `{% icon %}` + `{% translate %}` like the 404 page (msgids already had PL translations).

Rendered output is byte-identical for the base-extending pages, except the error-page `h1` gains a redundant `text-foreground` (already set on `body`; zero visual change).

Net −23 lines.

## Verification

- Full `test:py` suite: 3291 passed (page tests render through the partial, so the strict checker validated every input).
- `mise run lint`, `tingle check` (no new debt), `messages-check` (catalog fresh, no new msgids) all green.
- Screenshots of login-required, auth-error, and 404 captured on the branch — pages render identically through the partial.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015rbYdbfV2KQwnQpsLL32LT

---
_Generated by [Claude Code](https://claude.ai/code/session_015rbYdbfV2KQwnQpsLL32LT)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **UI Improvements**
  - Updated 404 and 500 error pages with a consistent status layout and clearer visual presentation.
  - Refreshed login-required and authentication error screens using the same polished status design.
  - Improved error-page actions with consistent icons and translated “Go Back” and “Go to Home” labels.
  - Adjusted layouts for error codes, headings, and supporting messages to improve readability across screen sizes.
- **Localization**
  - Updated translation references for the “Go Back” message used on error pages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->