### PR TITLE
Print page: session-time rows, self-applying controls, descriptions checkbox

### DIFF
--- a/PAPERCUTS.md
+++ b/PAPERCUTS.md
@@ -225,3 +225,8 @@ If you fix a papercut, remove it.
   ~/.portless certs, and Python 3.14 rejects a bare self-signed CA without
   keyUsage=keyCertSign, so the first cert attempt failed with
   CERTIFICATE_VERIFY_FAILED.
+- 2026-07-29: ran mise run shots -- '/event/x/print/?material=timetable' — task
+  warned 'not reachable' although the server was up; $usage_targets keeps the
+  shell quotes around each arg, so the URL becomes
+  <http://localhost:8000'/event/>...'. Worked around by calling aubx agent-browser
+  directly.

--- a/PAPERCUTS.md
+++ b/PAPERCUTS.md
@@ -230,3 +230,7 @@ If you fix a papercut, remove it.
   shell quotes around each arg, so the URL becomes
   <http://localhost:8000'/event/>...'. Worked around by calling aubx agent-browser
   directly.
+- 2026-07-29: rebuilt the vite client while test:e2e:serve was running —
+  django_vite's cached manifest kept serving deleted hashed JS, pages silently
+  lost their scripts until a manual server restart. Fixed test:e2e:serve to
+  watch manifest.json and bounce itself.

--- a/mise.toml
+++ b/mise.toml
@@ -255,8 +255,33 @@ description = "Kill the e2e dev server (Django on :8000)"
 run = "lsof -ti :8000 | xargs -r kill -9 2>/dev/null; echo 'E2E server killed'"
 
 [tasks."test:e2e:serve"]
-description = "Run the e2e dev server (assumes `test:e2e:prep` has run)"
-run = "coverage run --source=src -m django runserver --insecure --noreload localhost:8000"
+description = "Run the e2e dev server (assumes `test:e2e:prep` has run); restarts itself when a client rebuild replaces the Vite manifest"
+run = '''
+set -eu
+# django_vite parses the manifest once per process, so a `vite build` while
+# the server runs would leave it serving hashed asset URLs the rebuild just
+# deleted (pages silently lose their JS). Watch the manifest and bounce the
+# server when it changes; CI never rebuilds mid-run, so this only fires in
+# interactive sessions.
+manifest="src/ludamus/static/vite/manifest.json"
+mtime() { stat -c %Y "$manifest" 2>/dev/null || echo missing; }
+while true; do
+  seen=$(mtime)
+  coverage run --source=src -m django runserver --insecure --noreload localhost:8000 &
+  server=$!
+  trap 'kill "$server" 2>/dev/null; exit 0' INT TERM
+  while kill -0 "$server" 2>/dev/null && [ "$(mtime)" = "$seen" ]; do
+    sleep 2
+  done
+  if ! kill -0 "$server" 2>/dev/null; then
+    wait "$server"
+    exit $?
+  fi
+  echo "Vite manifest changed — restarting the e2e server with fresh assets"
+  kill "$server" 2>/dev/null
+  wait "$server" 2>/dev/null || true
+done
+'''
 env = { _.file = '.env.e2e', COVERAGE_FILE = "{{ config_root }}/.coverage.e2e" }
 
 [tasks."test:e2e:boot"]

--- a/src/ludamus/adapters/web/django/urls.py
+++ b/src/ludamus/adapters/web/django/urls.py
@@ -6,6 +6,7 @@ from ludamus.gates.web.django.chronology import offers
 from ludamus.gates.web.django.chronology import views as chronology_views
 from ludamus.gates.web.django.chronology.urls import urlpatterns as chronology_gate_urls
 from ludamus.gates.web.django.crowd.urls import urlpatterns as crowd_gate_urls
+from ludamus.gates.web.django.event.print import PublicEventPrintView
 from ludamus.gates.web.django.notice_board.urls import (
     authenticated_urlpatterns as encounter_authenticated,
 )
@@ -14,7 +15,6 @@ from ludamus.gates.web.django.notice_board.urls import (
 )
 
 from . import views
-from .print_views import PublicEventPrintView
 
 app_name = "web"  # pylint: disable=invalid-name
 

--- a/src/ludamus/client/src/print-controls.ts
+++ b/src/ludamus/client/src/print-controls.ts
@@ -1,0 +1,25 @@
+// The print page sidebar is not a form — there is nothing to submit or
+// apply. Each control in `#print-controls` owns one query param (its `name`):
+// changing it rewrites that param and reloads, so untouched params keep their
+// defaults and an unticked box or cleared field drops its param entirely.
+const controls = document.getElementById("print-controls");
+
+controls?.addEventListener("change", (event) => {
+  const control = event.target;
+  if (!(control instanceof HTMLInputElement || control instanceof HTMLSelectElement)) return;
+  if (!control.name) return;
+
+  const params = new URLSearchParams(globalThis.location.search);
+  const value =
+    control instanceof HTMLInputElement && control.type === "checkbox"
+      ? control.checked
+        ? control.value
+        : ""
+      : control.value;
+  if (value) {
+    params.set(control.name, value);
+  } else {
+    params.delete(control.name);
+  }
+  globalThis.location.search = params.toString();
+});

--- a/src/ludamus/client/src/print-controls.ts
+++ b/src/ludamus/client/src/print-controls.ts
@@ -4,22 +4,48 @@
 // defaults and an unticked box or cleared field drops its param entirely.
 const controls = document.getElementById("print-controls");
 
-controls?.addEventListener("change", (event) => {
-  const control = event.target;
-  if (!(control instanceof HTMLInputElement || control instanceof HTMLSelectElement)) return;
-  if (!control.name) return;
+type Control = HTMLInputElement | HTMLSelectElement;
 
+const controlValue = (control: Control): string =>
+  control instanceof HTMLInputElement && control.type === "checkbox"
+    ? control.checked
+      ? control.value
+      : ""
+    : control.value;
+
+const apply = (control: Control): void => {
   const params = new URLSearchParams(globalThis.location.search);
-  const value =
-    control instanceof HTMLInputElement && control.type === "checkbox"
-      ? control.checked
-        ? control.value
-        : ""
-      : control.value;
+  const value = controlValue(control);
   if (value) {
     params.set(control.name, value);
   } else {
     params.delete(control.name);
   }
   globalThis.location.search = params.toString();
+};
+
+// Was the control edited relative to the server-rendered state? True only
+// when a change fired before this module loaded (see the healing pass below).
+const editedBeforeLoad = (control: Control): boolean =>
+  control instanceof HTMLSelectElement
+    ? [...control.options].some((option) => option.selected !== option.defaultSelected)
+    : control.type === "checkbox"
+      ? control.checked !== control.defaultChecked
+      : control.value !== control.defaultValue;
+
+controls?.addEventListener("change", (event) => {
+  const control = event.target;
+  if (!(control instanceof HTMLInputElement || control instanceof HTMLSelectElement)) return;
+  if (!control.name) return;
+  apply(control);
 });
+
+// Heal the startup race: a control changed before this module executed fired
+// its change event into the void. Apply the first such edit now (applying one
+// navigates, which re-renders everything anyway).
+for (const control of controls?.querySelectorAll<Control>("select[name], input[name]") ?? []) {
+  if (editedBeforeLoad(control)) {
+    apply(control);
+    break;
+  }
+}

--- a/src/ludamus/client/vite.config.ts
+++ b/src/ludamus/client/vite.config.ts
@@ -54,6 +54,7 @@ export default defineConfig({
         "info-popover": resolve(rootDir, "src/info-popover.ts"),
         menu: resolve(rootDir, "src/menu.ts"),
         modal: resolve(rootDir, "src/modal.ts"),
+        "print-controls": resolve(rootDir, "src/print-controls.ts"),
         "proposal-category-settings": resolve(rootDir, "src/proposal-category-settings.ts"),
         "room-lanes": resolve(rootDir, "src/room-lanes.ts"),
         "session-bookmarks": resolve(rootDir, "src/session-bookmarks.ts"),

--- a/src/ludamus/gates/web/django/chronology/panel/views/print.py
+++ b/src/ludamus/gates/web/django/chronology/panel/views/print.py
@@ -92,8 +92,9 @@ class TimetablePrintView(PanelAccessMixin, EventContextMixin, View):
         )
 
     def _time_range(self, tz: tzinfo) -> tuple[datetime, datetime] | None:
-        # No (or unparsable) start means the whole event, matching the public
-        # print page's convention of ``?start=…&hours=…`` query params.
+        # No (or unparsable) start means the whole event. The public print page
+        # reads the same ``?start=…&hours=…`` params but defaults differently:
+        # there, hours alone can clip, and missing hours means until event end.
         if not (raw_start := self.request.GET.get("start")):
             return None
         if (parsed := parse_datetime(raw_start)) is None:

--- a/src/ludamus/gates/web/django/event/print.py
+++ b/src/ludamus/gates/web/django/event/print.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from contextlib import suppress
 from dataclasses import dataclass
 from datetime import datetime, timedelta, tzinfo
-from typing import TYPE_CHECKING, Literal
+from typing import TYPE_CHECKING, Literal, NamedTuple
 
 from django.http import Http404, HttpResponse
 from django.template.response import TemplateResponse
@@ -26,11 +26,12 @@ if TYPE_CHECKING:
     from ludamus.gates.web.django.entities import RootRequest
     from ludamus.pacts import EventDTO
     from ludamus.pacts.printing import PrintOptionDTO
+    from ludamus.pacts.venues import PrintScopeDTO
 
     type _LazyStr = str | _StrPromise
 
 
-DocumentKind = Literal["session_list", "timetable"]
+DocumentKind = Literal["area_schedule", "session_list", "timetable"]
 ScopeKind = Literal["event", "scope", "track"]
 
 
@@ -55,17 +56,16 @@ class MaterialSpec:
     # Timetables take a time range and a "with descriptions" toggle (which
     # swaps the grid for a per-space list); the session list takes neither.
     @property
-    def show_range_controls(self) -> bool:
-        return self.document_kind == "timetable"
-
-    @property
-    def show_descriptions_control(self) -> bool:
+    def show_timetable_controls(self) -> bool:
         return self.document_kind == "timetable"
 
 
 TIMETABLE = "timetable"
 TRACK_TIMETABLE = "track-timetable"
 SESSION_LIST = "session-list"
+# Retired material value still reachable from old bookmarks; maps to the
+# timetable material with the descriptions checkbox ticked.
+LEGACY_DESCRIPTIONS_MATERIAL = "timetable-descriptions"
 # One timetable material, scopable to any space-tree node (a single room, a
 # whole floor, a building) or left unscoped for the whole event — the Scope
 # picker covers every level, so there is no separate venue/area/space material.
@@ -92,12 +92,6 @@ def _available_materials(
     )
 
 
-def _track_pk(material: MaterialSpec, track: PrintOptionDTO | None) -> int | None:
-    if material.scope_kind != "track" or track is None:
-        return None
-    return track.pk
-
-
 def _scope_pk(raw: str | None) -> int | None:
     if not raw:
         return None
@@ -107,22 +101,33 @@ def _scope_pk(raw: str | None) -> int | None:
         return None
 
 
-def _timetable_scope_pks(
-    material: MaterialSpec, scope_space_pks: frozenset[int] | None
-) -> frozenset[int] | None:
-    if material.scope_kind != "scope":
-        return None
-    return scope_space_pks
+class _PrintScope(NamedTuple):
+    space_pks: frozenset[int] | None
+    track_pk: int | None
+    name: str | None
 
 
-def _timetable_scope_name(
-    material: MaterialSpec, scope_name: str | None, track: PrintOptionDTO | None
-) -> str | None:
-    if material.scope_kind == "track":
-        return track.name if track else None
+def _resolve_print_scope(
+    *, material: MaterialSpec, scope: PrintScopeDTO, track: PrintOptionDTO | None
+) -> _PrintScope:
+    # A material is scoped by a space subtree, by a track, or not at all —
+    # the one place that turns scope_kind into query facts.
     if material.scope_kind == "scope":
-        return scope_name
-    return None
+        return _PrintScope(scope.space_pks, None, scope.scope_name)
+    if material.scope_kind == "track":
+        return _PrintScope(
+            None, track.pk if track else None, track.name if track else None
+        )
+    return _PrintScope(None, None, None)
+
+
+@dataclass(frozen=True)
+class _ResolvedRange:
+    start: datetime  # display value for the start input
+    hours: int | None  # display value for the hours input
+    # The user-requested window, or None when both params were untouched —
+    # an untouched range must not clip the timetable.
+    window: tuple[datetime, datetime] | None
 
 
 class PublicEventPrintView(View):
@@ -150,17 +155,11 @@ class PublicEventPrintView(View):
             raise Http404 from exc
 
         tz = get_current_timezone()
-        range_start, range_hours, range_explicit = self._resolve_range(event, tz)
-        # No explicit hours means "until the event ends"; the fallback keeps
-        # the window non-empty when a start past the event end is requested.
-        range_end = (
-            range_start + timedelta(hours=range_hours)
-            if range_hours is not None
-            else max(
-                event.end_time, range_start + timedelta(hours=self.DEFAULT_RANGE_HOURS)
-            )
+        resolved_range = self._resolve_range(event, tz)
+        descriptions = (
+            request.GET.get("descriptions") == "1"
+            or request.GET.get("material") == LEGACY_DESCRIPTIONS_MATERIAL
         )
-        descriptions = request.GET.get("descriptions") == "1"
 
         service = request.services.print_materials
         tracks = service.list_tracks(event.pk)
@@ -173,24 +172,30 @@ class PublicEventPrintView(View):
             tracks_available=bool(tracks),
         )
         material_spec = self._resolve_material(material_options)
+        print_scope = _resolve_print_scope(
+            material=material_spec, scope=scope, track=selected_track
+        )
+        # The descriptions toggle swaps the timetable grid for the per-space
+        # descriptions list; the material still names what is scoped.
+        document_kind: DocumentKind = (
+            "area_schedule"
+            if descriptions and material_spec.document_kind == "timetable"
+            else material_spec.document_kind
+        )
 
         timetable = None
         area_schedule = None
         session_list = None
-        if material_spec.document_kind == "session_list":
+        if document_kind == "session_list":
             session_list = session_list_candidate
-        elif descriptions:
+        elif document_kind == "area_schedule":
             area_schedule = service.build_area_schedule(
                 AreaScheduleQueryDTO(
                     event_pk=event.pk,
-                    time_range=(range_start, range_end),
-                    scope_space_pks=_timetable_scope_pks(
-                        material_spec, scope.space_pks
-                    ),
-                    track_pk=_track_pk(material_spec, selected_track),
-                    scope_name=_timetable_scope_name(
-                        material_spec, scope.scope_name, selected_track
-                    ),
+                    time_range=resolved_range.window,
+                    scope_space_pks=print_scope.space_pks,
+                    track_pk=print_scope.track_pk,
+                    scope_name=print_scope.name,
                     confirmed_only=True,
                 )
             )
@@ -199,15 +204,11 @@ class PublicEventPrintView(View):
                 PrintTimetableQueryDTO(
                     event_pk=event.pk,
                     tz=tz,
-                    scope_space_pks=_timetable_scope_pks(
-                        material_spec, scope.space_pks
-                    ),
-                    track_pk=_track_pk(material_spec, selected_track),
-                    scope_name=_timetable_scope_name(
-                        material_spec, scope.scope_name, selected_track
-                    ),
+                    scope_space_pks=print_scope.space_pks,
+                    track_pk=print_scope.track_pk,
+                    scope_name=print_scope.name,
                     confirmed_only=True,
-                    time_range=((range_start, range_end) if range_explicit else None),
+                    time_range=resolved_range.window,
                 )
             )
 
@@ -232,15 +233,14 @@ class PublicEventPrintView(View):
                 "material": material_spec.value,
                 "show_scope_control": material_spec.show_scope_control,
                 "show_track_control": material_spec.show_track_control,
-                "show_range_controls": material_spec.show_range_controls,
-                "show_descriptions_control": material_spec.show_descriptions_control,
+                "show_timetable_controls": material_spec.show_timetable_controls,
                 "descriptions": descriptions,
                 "selected_scope": str(scope_pk) if scope_pk is not None else "",
                 "selected_track": selected_track.slug if selected_track else "",
                 "range_start_value": (
-                    localtime(range_start, tz).strftime("%Y-%m-%dT%H:%M")
+                    localtime(resolved_range.start, tz).strftime("%Y-%m-%dT%H:%M")
                 ),
-                "range_hours": range_hours,
+                "range_hours": resolved_range.hours,
             },
         )
         if published:
@@ -260,25 +260,32 @@ class PublicEventPrintView(View):
             return material
         return MATERIAL_SPECS_BY_VALUE[TIMETABLE]
 
-    def _resolve_range(
-        self, event: EventDTO, tz: tzinfo
-    ) -> tuple[datetime, int | None, bool]:
+    def _resolve_range(self, event: EventDTO, tz: tzinfo) -> _ResolvedRange:
         # Both params are optional: no start means the event start, no hours
-        # means until the event ends. The bool says whether the user narrowed
-        # the range at all — an untouched range must not clip the timetable.
+        # means until the event ends.
         hours: int | None = None
         if raw_hours := self.request.GET.get("hours"):
             with suppress(ValueError):
                 hours = max(1, min(int(raw_hours), self.MAX_RANGE_HOURS))
-        explicit = hours is not None
 
         start = localtime(event.start_time, tz)
+        explicit_start = False
         if raw_start := self.request.GET.get("start"):
             with suppress(ValueError):
                 if (parsed := parse_datetime(raw_start)) is not None:
                     start = parsed if parsed.tzinfo else make_aware(parsed, tz)
-                    explicit = True
-        return start, hours, explicit
+                    explicit_start = True
+
+        if hours is None and not explicit_start:
+            return _ResolvedRange(start=start, hours=None, window=None)
+        # No explicit hours means "until the event ends"; the fallback keeps
+        # the window non-empty when the start lies past the event end.
+        end = (
+            start + timedelta(hours=hours)
+            if hours is not None
+            else max(event.end_time, start + timedelta(hours=self.DEFAULT_RANGE_HOURS))
+        )
+        return _ResolvedRange(start=start, hours=hours, window=(start, end))
 
     def _selected_track(self, tracks: list[PrintOptionDTO]) -> PrintOptionDTO | None:
         if slug := self.request.GET.get("track") or "":

--- a/src/ludamus/gates/web/django/event/print.py
+++ b/src/ludamus/gates/web/django/event/print.py
@@ -30,7 +30,7 @@ if TYPE_CHECKING:
     type _LazyStr = str | _StrPromise
 
 
-DocumentKind = Literal["area_schedule", "session_list", "timetable"]
+DocumentKind = Literal["session_list", "timetable"]
 ScopeKind = Literal["event", "scope", "track"]
 
 
@@ -52,13 +52,18 @@ class MaterialSpec:
     def show_track_control(self) -> bool:
         return self.scope_kind == "track"
 
+    # Timetables take a time range and a "with descriptions" toggle (which
+    # swaps the grid for a per-space list); the session list takes neither.
     @property
     def show_range_controls(self) -> bool:
-        return self.document_kind == "area_schedule"
+        return self.document_kind == "timetable"
+
+    @property
+    def show_descriptions_control(self) -> bool:
+        return self.document_kind == "timetable"
 
 
 TIMETABLE = "timetable"
-TIMETABLE_DESCRIPTIONS = "timetable-descriptions"
 TRACK_TIMETABLE = "track-timetable"
 SESSION_LIST = "session-list"
 # One timetable material, scopable to any space-tree node (a single room, a
@@ -66,12 +71,6 @@ SESSION_LIST = "session-list"
 # picker covers every level, so there is no separate venue/area/space material.
 MATERIAL_SPECS = (
     MaterialSpec(TIMETABLE, _("Timetable"), "timetable", scope_kind="scope"),
-    MaterialSpec(
-        TIMETABLE_DESCRIPTIONS,
-        _("Timetable with descriptions"),
-        "area_schedule",
-        scope_kind="scope",
-    ),
     MaterialSpec(
         TRACK_TIMETABLE, _("Track timetable"), "timetable", scope_kind="track"
     ),
@@ -151,8 +150,17 @@ class PublicEventPrintView(View):
             raise Http404 from exc
 
         tz = get_current_timezone()
-        range_start, range_hours = self._resolve_range(event, tz)
-        range_end = range_start + timedelta(hours=range_hours)
+        range_start, range_hours, range_explicit = self._resolve_range(event, tz)
+        # No explicit hours means "until the event ends"; the fallback keeps
+        # the window non-empty when a start past the event end is requested.
+        range_end = (
+            range_start + timedelta(hours=range_hours)
+            if range_hours is not None
+            else max(
+                event.end_time, range_start + timedelta(hours=self.DEFAULT_RANGE_HOURS)
+            )
+        )
+        descriptions = request.GET.get("descriptions") == "1"
 
         service = request.services.print_materials
         tracks = service.list_tracks(event.pk)
@@ -169,18 +177,23 @@ class PublicEventPrintView(View):
         timetable = None
         area_schedule = None
         session_list = None
-        if material_spec.document_kind == "area_schedule":
+        if material_spec.document_kind == "session_list":
+            session_list = session_list_candidate
+        elif descriptions:
             area_schedule = service.build_area_schedule(
                 AreaScheduleQueryDTO(
                     event_pk=event.pk,
                     time_range=(range_start, range_end),
-                    scope_space_pks=scope.space_pks,
-                    scope_name=scope.scope_name,
+                    scope_space_pks=_timetable_scope_pks(
+                        material_spec, scope.space_pks
+                    ),
+                    track_pk=_track_pk(material_spec, selected_track),
+                    scope_name=_timetable_scope_name(
+                        material_spec, scope.scope_name, selected_track
+                    ),
                     confirmed_only=True,
                 )
             )
-        elif material_spec.document_kind == "session_list":
-            session_list = session_list_candidate
         else:
             timetable = service.build_timetable(
                 PrintTimetableQueryDTO(
@@ -194,6 +207,7 @@ class PublicEventPrintView(View):
                         material_spec, scope.scope_name, selected_track
                     ),
                     confirmed_only=True,
+                    time_range=((range_start, range_end) if range_explicit else None),
                 )
             )
 
@@ -219,6 +233,8 @@ class PublicEventPrintView(View):
                 "show_scope_control": material_spec.show_scope_control,
                 "show_track_control": material_spec.show_track_control,
                 "show_range_controls": material_spec.show_range_controls,
+                "show_descriptions_control": material_spec.show_descriptions_control,
+                "descriptions": descriptions,
                 "selected_scope": str(scope_pk) if scope_pk is not None else "",
                 "selected_track": selected_track.slug if selected_track else "",
                 "range_start_value": (
@@ -244,18 +260,25 @@ class PublicEventPrintView(View):
             return material
         return MATERIAL_SPECS_BY_VALUE[TIMETABLE]
 
-    def _resolve_range(self, event: EventDTO, tz: tzinfo) -> tuple[datetime, int]:
-        hours = self.DEFAULT_RANGE_HOURS
-        with suppress(ValueError, TypeError):
-            hours = int(self.request.GET.get("hours", self.DEFAULT_RANGE_HOURS))
-        hours = max(1, min(hours, self.MAX_RANGE_HOURS))
+    def _resolve_range(
+        self, event: EventDTO, tz: tzinfo
+    ) -> tuple[datetime, int | None, bool]:
+        # Both params are optional: no start means the event start, no hours
+        # means until the event ends. The bool says whether the user narrowed
+        # the range at all — an untouched range must not clip the timetable.
+        hours: int | None = None
+        if raw_hours := self.request.GET.get("hours"):
+            with suppress(ValueError):
+                hours = max(1, min(int(raw_hours), self.MAX_RANGE_HOURS))
+        explicit = hours is not None
 
         start = localtime(event.start_time, tz)
         if raw_start := self.request.GET.get("start"):
             with suppress(ValueError):
                 if (parsed := parse_datetime(raw_start)) is not None:
                     start = parsed if parsed.tzinfo else make_aware(parsed, tz)
-        return start, hours
+                    explicit = True
+        return start, hours, explicit
 
     def _selected_track(self, tracks: list[PrintOptionDTO]) -> PrintOptionDTO | None:
         if slug := self.request.GET.get("track") or "":

--- a/src/ludamus/locale/pl/LC_MESSAGES/django.po
+++ b/src/ludamus/locale/pl/LC_MESSAGES/django.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-07-29 21:18+0200\n"
+"POT-Creation-Date: 2026-07-29 21:47+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -889,8 +889,6 @@ msgstr "Wybierz przestrzeń, gdzie odbędzie się ten punkt programu"
 
 #: src/ludamus/gates/web/django/chronology/forms.py
 #: src/ludamus/templates/chronology/accept_proposal.html
-#: src/ludamus/templates/chronology/print.html
-#: src/ludamus/templates/panel/print/timetable.html
 msgid "Time slot"
 msgstr "Przedział czasowy"
 
@@ -3558,8 +3556,10 @@ msgstr "Zachowaj ten kod, aby później zarządzać swoim zapisem"
 
 #: src/ludamus/templates/chronology/anonymous_enroll.html
 #: src/ludamus/templates/chronology/parts/session-modal.html
+#: src/ludamus/templates/chronology/print.html
 #: src/ludamus/templates/panel/content-log.html
 #: src/ludamus/templates/panel/parts/timetable-grid.html
+#: src/ludamus/templates/panel/print/timetable.html
 #: src/ludamus/templates/panel/timetable-log.html
 msgid "Time"
 msgstr "Czas"

--- a/src/ludamus/locale/pl/LC_MESSAGES/django.po
+++ b/src/ludamus/locale/pl/LC_MESSAGES/django.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-07-29 21:47+0200\n"
+"POT-Creation-Date: 2026-07-29 22:37+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -536,23 +536,6 @@ msgstr "Goście bez konta"
 #: src/ludamus/adapters/web/django/middlewares.py
 msgid "Sphere not found"
 msgstr "Sfera nie została znaleziona."
-
-#: src/ludamus/adapters/web/django/print_views.py
-#: src/ludamus/templates/chronology/print.html
-msgid "Timetable"
-msgstr "Harmonogram"
-
-#: src/ludamus/adapters/web/django/print_views.py
-msgid "Timetable with descriptions"
-msgstr "Harmonogram z opisami"
-
-#: src/ludamus/adapters/web/django/print_views.py
-msgid "Track timetable"
-msgstr "Harmonogram bloku"
-
-#: src/ludamus/adapters/web/django/print_views.py
-msgid "Session list"
-msgstr "Lista punktów programu"
 
 #: src/ludamus/adapters/web/django/templatetags/enroll_tags.py
 msgid "Already enrolled"
@@ -2167,6 +2150,19 @@ msgstr "Usunięto okno zapisów."
 #: src/ludamus/gates/web/django/event/panel/views/proposal_category_settings.py
 msgid "Category updated successfully."
 msgstr "Kategoria została zaktualizowana."
+
+#: src/ludamus/gates/web/django/event/print.py
+#: src/ludamus/templates/chronology/print.html
+msgid "Timetable"
+msgstr "Harmonogram"
+
+#: src/ludamus/gates/web/django/event/print.py
+msgid "Track timetable"
+msgstr "Harmonogram bloku"
+
+#: src/ludamus/gates/web/django/event/print.py
+msgid "Session list"
+msgstr "Lista punktów programu"
 
 #: src/ludamus/gates/web/django/forms.py
 msgid "Max 8 MB. JPG, PNG, WebP, or AVIF."
@@ -4324,10 +4320,18 @@ msgid "Whole event"
 msgstr "Całe wydarzenie"
 
 #: src/ludamus/templates/chronology/print.html
+msgid "With descriptions"
+msgstr "Z opisami"
+
+#: src/ludamus/templates/chronology/print.html
 #: src/ludamus/templates/panel/parts/import-recipe-row.html
 #: src/ludamus/templates/panel/parts/print-controls.html
 msgid "Start"
 msgstr "Początek"
+
+#: src/ludamus/templates/chronology/print.html
+msgid "until event end"
+msgstr "do końca wydarzenia"
 
 #: src/ludamus/templates/chronology/print.html
 msgid "Table of contents"

--- a/src/ludamus/locale/pl/LC_MESSAGES/django.po
+++ b/src/ludamus/locale/pl/LC_MESSAGES/django.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-07-29 07:25+0200\n"
+"POT-Creation-Date: 2026-07-29 21:18+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -4330,10 +4330,6 @@ msgid "Start"
 msgstr "Początek"
 
 #: src/ludamus/templates/chronology/print.html
-msgid "Apply"
-msgstr "Zastosuj"
-
-#: src/ludamus/templates/chronology/print.html
 msgid "Table of contents"
 msgstr "Spis treści"
 
@@ -8474,6 +8470,9 @@ msgstr "Temat"
 #: src/ludamus/templates/staging_email_inbox.html
 msgid "No emails captured yet."
 msgstr "Brak przechwyconych e-maili."
+
+#~ msgid "Apply"
+#~ msgstr "Zastosuj"
 
 #~ msgid "comma separated"
 #~ msgstr "oddzielone przecinkami"

--- a/src/ludamus/mills/printing.py
+++ b/src/ludamus/mills/printing.py
@@ -193,6 +193,10 @@ class PrintMaterialsService:
             if query.track_pk is not None
             else self._agenda_items.list_by_event(query.event_pk)
         )
+        if query.time_range is not None:
+            all_items = [
+                item for item in all_items if _overlaps(item, *query.time_range)
+            ]
         grouped = self._group_by_space(all_items, confirmed_only=query.confirmed_only)
         items_by_space = {space.pk: grouped.get(space.pk, []) for space in spaces}
 
@@ -245,11 +249,13 @@ class PrintMaterialsService:
             event_start=event.start_time,
             event_end=event.end_time,
             scope_name=query.scope_name,
-            # A scoped print (one space subtree) is a subset by construction, so
-            # it is never "the whole program"; completeness only applies unscoped.
+            # A scoped print (space subtree, track, or time range) is a subset
+            # by construction, so it is never "the whole program"; completeness
+            # only applies unscoped.
             is_complete=(
                 query.scope_space_pks is None
                 and query.track_pk is None
+                and query.time_range is None
                 and _is_complete(all_items)
             ),
             pages=pages,
@@ -260,11 +266,15 @@ class PrintMaterialsService:
     ) -> AreaScheduleDocumentDTO:
         range_start, range_end = query.time_range
         event = self._events.read(query.event_pk)
-        spaces = self._scoped_spaces(query.event_pk, query.scope_space_pks, None)
-        grouped = self._group_by_space(
-            self._agenda_items.list_by_event(query.event_pk),
-            confirmed_only=query.confirmed_only,
+        spaces = self._scoped_spaces(
+            query.event_pk, query.scope_space_pks, query.track_pk
         )
+        items = (
+            self._agenda_items.list_by_track(query.track_pk)
+            if query.track_pk is not None
+            else self._agenda_items.list_by_event(query.event_pk)
+        )
+        grouped = self._group_by_space(items, confirmed_only=query.confirmed_only)
 
         space_dtos: list[AreaScheduleSpaceDTO] = []
         for space in spaces:

--- a/src/ludamus/mills/printing.py
+++ b/src/ludamus/mills/printing.py
@@ -38,6 +38,7 @@ from ludamus.pacts.printing import (
 )
 
 if TYPE_CHECKING:
+    from collections.abc import Iterable
     from datetime import date, datetime, tzinfo
 
     from ludamus.pacts import (
@@ -99,17 +100,16 @@ def _space_range_name(spaces: list[SpaceDTO]) -> str | None:
 
 
 def _timetable_rows_by_date(
-    items_by_space: dict[int, list[AgendaItemDTO]], tz: tzinfo
+    items: Iterable[AgendaItemDTO], tz: tzinfo
 ) -> dict[date, list[tuple[datetime, datetime]]]:
     # Rows are the distinct (start, end) times of the scheduled sessions, so
     # the grid prints real session times. Time slots are proposer availability
     # windows, not display units (see mills/timeslots.py), so they play no
     # part here.
     rows: dict[date, set[tuple[datetime, datetime]]] = defaultdict(set)
-    for items in items_by_space.values():
-        for item in items:
-            day = item.start_time.astimezone(tz).date()
-            rows[day].add((item.start_time, item.end_time))
+    for item in items:
+        day = item.start_time.astimezone(tz).date()
+        rows[day].add((item.start_time, item.end_time))
     return {day: sorted(intervals) for day, intervals in rows.items()}
 
 
@@ -207,7 +207,8 @@ class PrintMaterialsService:
             (
                 space_chunk,
                 _timetable_rows_by_date(
-                    {s.pk: items_by_space.get(s.pk, []) for s in space_chunk}, query.tz
+                    [item for s in space_chunk for item in items_by_space[s.pk]],
+                    query.tz,
                 ),
             )
             for space_chunk in _space_chunks(spaces)
@@ -264,8 +265,8 @@ class PrintMaterialsService:
     def build_area_schedule(
         self, query: AreaScheduleQueryDTO
     ) -> AreaScheduleDocumentDTO:
-        range_start, range_end = query.time_range
         event = self._events.read(query.event_pk)
+        range_start, range_end = query.time_range or (event.start_time, event.end_time)
         spaces = self._scoped_spaces(
             query.event_pk, query.scope_space_pks, query.track_pk
         )

--- a/src/ludamus/mills/printing.py
+++ b/src/ludamus/mills/printing.py
@@ -14,7 +14,6 @@ from collections import defaultdict
 from datetime import timedelta
 from typing import TYPE_CHECKING
 
-from ludamus.mills.timeslots import slot_windows_by_local_date
 from ludamus.pacts.printing import (
     AreaScheduleDocumentDTO,
     AreaScheduleQueryDTO,
@@ -100,25 +99,17 @@ def _space_range_name(spaces: list[SpaceDTO]) -> str | None:
 
 
 def _timetable_rows_by_date(
-    windows_by_date: dict[date, list[tuple[datetime, datetime]]],
-    items_by_space: dict[int, list[AgendaItemDTO]],
-    tz: tzinfo,
+    items_by_space: dict[int, list[AgendaItemDTO]], tz: tzinfo
 ) -> dict[date, list[tuple[datetime, datetime]]]:
-    # Rows are the event's time slots, plus a fallback row for any scheduled
-    # session that overlaps no slot — so a session placed outside the defined
-    # slots (or an event with no slots at all) never silently drops off the
-    # grid the way it would if rows came from slots alone.
+    # Rows are the distinct (start, end) times of the scheduled sessions, so
+    # the grid prints real session times. Time slots are proposer availability
+    # windows, not display units (see mills/timeslots.py), so they play no
+    # part here.
     rows: dict[date, set[tuple[datetime, datetime]]] = defaultdict(set)
-    for day, windows in windows_by_date.items():
-        rows[day].update(windows)
-
-    all_windows = [w for windows in windows_by_date.values() for w in windows]
     for items in items_by_space.values():
         for item in items:
-            if not any(_overlaps(item, ws, we) for ws, we in all_windows):
-                day = item.start_time.astimezone(tz).date()
-                rows[day].add((item.start_time, item.end_time))
-
+            day = item.start_time.astimezone(tz).date()
+            rows[day].add((item.start_time, item.end_time))
     return {day: sorted(intervals) for day, intervals in rows.items()}
 
 
@@ -204,29 +195,39 @@ class PrintMaterialsService:
         )
         grouped = self._group_by_space(all_items, confirmed_only=query.confirmed_only)
         items_by_space = {space.pk: grouped.get(space.pk, []) for space in spaces}
-        windows_by_date = slot_windows_by_local_date(
-            self._time_slots.list_by_event(query.event_pk), query.tz
-        )
-        rows_by_date = _timetable_rows_by_date(
-            windows_by_date, items_by_space, query.tz
-        )
+
+        # Rows are computed per page chunk so a page only lists the times of
+        # its own spaces' sessions; a chunk with nothing scheduled on a day
+        # produces no page for it.
+        chunked_rows = [
+            (
+                space_chunk,
+                _timetable_rows_by_date(
+                    {s.pk: items_by_space.get(s.pk, []) for s in space_chunk}, query.tz
+                ),
+            )
+            for space_chunk in _space_chunks(spaces)
+        ]
 
         pages: list[PrintTimetablePageDTO] = []
-        for day in sorted(rows_by_date):
-            for space_chunk in _space_chunks(spaces):
+        all_days = sorted({day for _, by_date in chunked_rows for day in by_date})
+        for day in all_days:
+            for space_chunk, rows_by_date in chunked_rows:
+                if not (intervals := rows_by_date.get(day)):
+                    continue
                 rows: list[PrintTimetableRowDTO] = []
-                for window_start, window_end in rows_by_date[day]:
+                for row_start, row_end in intervals:
                     cells: list[PrintTimetableCellDTO] = []
                     for space in space_chunk:
                         sessions = [
                             _to_session(item)
                             for item in items_by_space.get(space.pk, [])
-                            if _overlaps(item, window_start, window_end)
+                            if item.start_time == row_start and item.end_time == row_end
                         ]
                         cells.append(PrintTimetableCellDTO(sessions=sessions))
                     rows.append(
                         PrintTimetableRowDTO(
-                            start_time=window_start, end_time=window_end, cells=cells
+                            start_time=row_start, end_time=row_end, cells=cells
                         )
                     )
                 pages.append(

--- a/src/ludamus/mills/timeslots.py
+++ b/src/ludamus/mills/timeslots.py
@@ -1,4 +1,9 @@
-"""Shared time-slot helpers for the chronology and printing mills."""
+"""Shared time-slot helpers for the chronology and printing mills.
+
+Time slots are proposer availability windows ("when could you run your
+session?"), not schedule display units — rendered timetables show the real
+session start and end times instead.
+"""
 
 from __future__ import annotations
 

--- a/src/ludamus/pacts/printing.py
+++ b/src/ludamus/pacts/printing.py
@@ -49,7 +49,8 @@ class DoorCardsQueryDTO:
 @dataclass(frozen=True)
 class AreaScheduleQueryDTO:
     event_pk: int
-    time_range: tuple[datetime, datetime]
+    # None means the whole event; the mill defaults to the event bounds.
+    time_range: tuple[datetime, datetime] | None = None
     scope_space_pks: frozenset[int] | None = None
     track_pk: int | None = None
     scope_name: str | None = None

--- a/src/ludamus/pacts/printing.py
+++ b/src/ludamus/pacts/printing.py
@@ -33,6 +33,7 @@ class PrintTimetableQueryDTO:
     track_pk: int | None = None
     scope_name: str | None = None
     confirmed_only: bool = False
+    time_range: tuple[datetime, datetime] | None = None
 
 
 @dataclass(frozen=True)
@@ -50,6 +51,7 @@ class AreaScheduleQueryDTO:
     event_pk: int
     time_range: tuple[datetime, datetime]
     scope_space_pks: frozenset[int] | None = None
+    track_pk: int | None = None
     scope_name: str | None = None
     confirmed_only: bool = False
 

--- a/src/ludamus/templates/chronology/print.html
+++ b/src/ludamus/templates/chronology/print.html
@@ -73,7 +73,7 @@
                             <div class="flex flex-col gap-1">
                                 <label class="text-sm font-semibold text-foreground-secondary"
                                        for="id_track">{% translate "Track" %}</label>
-                                {% select id="id_track" name="track" %}
+                                {% select id="id_track" name="track" onchange="this.form.submit()" %}
                                     {% for track in tracks %}
                                         <option value="{{ track.slug }}"
                                                 {% if selected_track == track.slug %}selected{% endif %}>
@@ -91,6 +91,7 @@
                                        id="id_start"
                                        name="start"
                                        value="{{ range_start_value }}"
+                                       onchange="this.form.submit()"
                                        class="w-full rounded-lg border border-border bg-bg-secondary px-3 py-2 text-sm text-foreground">
                             </div>
                             <div class="flex flex-col gap-1">
@@ -102,13 +103,12 @@
                                        min="1"
                                        max="72"
                                        value="{{ range_hours }}"
+                                       onchange="this.form.submit()"
                                        class="w-full rounded-lg border border-border bg-bg-secondary px-3 py-2 text-sm text-foreground">
                             </div>
                         {% endif %}
                         <div class="grid gap-2">
-                            {% translate "Apply" as t_apply %}
                             {% translate "Print" as t_print %}
-                            {% tessera_button t_apply variant="secondary" icon="arrow-path" %}
                             {% tessera_button t_print button_type="button" icon="printer" onclick="window.print()" %}
                         </div>
                     </form>

--- a/src/ludamus/templates/chronology/print.html
+++ b/src/ludamus/templates/chronology/print.html
@@ -167,7 +167,7 @@
                                     <table class="w-full table-fixed border-collapse text-[7pt]">
                                         <thead>
                                             <tr>
-                                                <th class="w-[20mm] border border-neutral-900 border-b-2 p-[1mm] text-left">{% translate "Time slot" %}</th>
+                                                <th class="w-[20mm] border border-neutral-900 border-b-2 p-[1mm] text-left">{% translate "Time" %}</th>
                                                 {% for name in page.space_names %}
                                                     <th class="border border-neutral-900 border-b-2 p-[1mm] text-left">{{ name }}</th>
                                                 {% endfor %}

--- a/src/ludamus/templates/chronology/print.html
+++ b/src/ludamus/templates/chronology/print.html
@@ -80,11 +80,9 @@
                                 {% end_select %}
                             </div>
                         {% endif %}
-                        {% if show_descriptions_control %}
+                        {% if show_timetable_controls %}
                             {% translate "With descriptions" as t_descriptions %}
                             {% include "components/checkbox-field.html" with name="descriptions" id="id_descriptions" label=t_descriptions value="1" checked=descriptions %}
-                        {% endif %}
-                        {% if show_range_controls %}
                             <div class="flex flex-col gap-1">
                                 <label class="text-sm font-semibold text-foreground-secondary"
                                        for="id_start">{% translate "Start" %}</label>

--- a/src/ludamus/templates/chronology/print.html
+++ b/src/ludamus/templates/chronology/print.html
@@ -1,5 +1,5 @@
 {% extends "base.html" %}
-{% load i18n tessera %}
+{% load django_vite i18n tessera %}
 {% block title %}
     {{ event.name }} — {% translate "Print" %}
 {% endblock title %}
@@ -35,11 +35,14 @@
         <div class="grid w-full grid-cols-[minmax(260px,320px)_minmax(0,1fr)] max-[900px]:grid-cols-1 print:block">
             <aside class="sticky top-4 max-h-[calc(100vh-32px)] self-start overflow-auto border-r border-border bg-bg-secondary p-4 shadow-sm max-[900px]:static max-[900px]:max-h-none max-[900px]:border-r-0 max-[900px]:border-b print:hidden">
                 <div>
-                    <form method="get" class="flex flex-col gap-4">
+                    {# Not a form: each control rewrites its own query param and #}
+                    {# reloads (src/print-controls.ts), so there is nothing to #}
+                    {# submit or apply. #}
+                    <div id="print-controls" class="flex flex-col gap-4">
                         <div class="flex flex-col gap-1">
                             <label class="text-sm font-semibold text-foreground-secondary"
                                    for="id_material">{% translate "Printable" %}</label>
-                            {% select id="id_material" name="material" onchange="this.form.submit()" %}
+                            {% select id="id_material" name="material" %}
                                 {% for option in material_options %}
                                     <option value="{{ option.value }}"
                                             {% if material == option.value %}selected{% endif %}>
@@ -48,32 +51,26 @@
                                 {% endfor %}
                             {% end_select %}
                         </div>
-                        {% if print_scopes %}
-                            {% if show_scope_control %}
-                                <div class="flex flex-col gap-1">
-                                    <label class="text-sm font-semibold text-foreground-secondary"
-                                           for="scope-select">{% translate "Scope" %}</label>
-                                    {% select id="scope-select" aria_label=aria_scope onchange="if(this.value!==null){window.location.search=this.value;}" %}
-                                        <option value="?material={{ material|urlencode }}&start={{ range_start_value|urlencode }}&hours={{ range_hours }}"
-                                                {% if not selected_scope %}selected{% endif %}>
-                                            {% translate "Whole event" %}
+                        {% if print_scopes and show_scope_control %}
+                            <div class="flex flex-col gap-1">
+                                <label class="text-sm font-semibold text-foreground-secondary"
+                                       for="scope-select">{% translate "Scope" %}</label>
+                                {% select id="scope-select" name="scope" aria_label=aria_scope %}
+                                    <option value="" {% if not selected_scope %}selected{% endif %}>{% translate "Whole event" %}</option>
+                                    {% for scope in print_scopes %}
+                                        <option value="{{ scope.pk }}"
+                                                {% if selected_scope == scope.pk|stringformat:'s' %}selected{% endif %}>
+                                            {{ scope.name }}
                                         </option>
-                                        {% for scope in print_scopes %}
-                                            <option value="?material={{ material|urlencode }}&scope={{ scope.pk }}&start={{ range_start_value|urlencode }}&hours={{ range_hours }}"
-                                                    {% if selected_scope == scope.pk|stringformat:'s' %}selected{% endif %}>
-                                                {{ scope.name }}
-                                            </option>
-                                        {% endfor %}
-                                    {% end_select %}
-                                </div>
-                            {% endif %}
+                                    {% endfor %}
+                                {% end_select %}
+                            </div>
                         {% endif %}
-                        <input type="hidden" name="scope" value="{{ selected_scope }}">
                         {% if tracks and show_track_control %}
                             <div class="flex flex-col gap-1">
                                 <label class="text-sm font-semibold text-foreground-secondary"
                                        for="id_track">{% translate "Track" %}</label>
-                                {% select id="id_track" name="track" onchange="this.form.submit()" %}
+                                {% select id="id_track" name="track" %}
                                     {% for track in tracks %}
                                         <option value="{{ track.slug }}"
                                                 {% if selected_track == track.slug %}selected{% endif %}>
@@ -83,6 +80,10 @@
                                 {% end_select %}
                             </div>
                         {% endif %}
+                        {% if show_descriptions_control %}
+                            {% translate "With descriptions" as t_descriptions %}
+                            {% include "components/checkbox-field.html" with name="descriptions" id="id_descriptions" label=t_descriptions value="1" checked=descriptions %}
+                        {% endif %}
                         {% if show_range_controls %}
                             <div class="flex flex-col gap-1">
                                 <label class="text-sm font-semibold text-foreground-secondary"
@@ -91,7 +92,6 @@
                                        id="id_start"
                                        name="start"
                                        value="{{ range_start_value }}"
-                                       onchange="this.form.submit()"
                                        class="w-full rounded-lg border border-border bg-bg-secondary px-3 py-2 text-sm text-foreground">
                             </div>
                             <div class="flex flex-col gap-1">
@@ -102,8 +102,8 @@
                                        name="hours"
                                        min="1"
                                        max="72"
-                                       value="{{ range_hours }}"
-                                       onchange="this.form.submit()"
+                                       value="{{ range_hours|default_if_none:'' }}"
+                                       placeholder="{% translate "until event end" %}"
                                        class="w-full rounded-lg border border-border bg-bg-secondary px-3 py-2 text-sm text-foreground">
                             </div>
                         {% endif %}
@@ -111,7 +111,7 @@
                             {% translate "Print" as t_print %}
                             {% tessera_button t_print button_type="button" icon="printer" onclick="window.print()" %}
                         </div>
-                    </form>
+                    </div>
                     <nav class="mt-4" aria-label="{% translate "Table of contents" %}">
                         <div class="text-sm font-semibold text-foreground-secondary">{% translate "Table of contents" %}</div>
                         <div class="mt-2 grid gap-1 text-sm max-[900px]:max-h-56 max-[900px]:overflow-auto">
@@ -210,7 +210,11 @@
                                         {% include "chronology/parts/print_header.html" with scope_name=area_schedule.scope_name show_full_schedule_label=True %}
                                         <h2 class="m-0 mb-[3mm] text-[14pt]">{% translate "Program details" %}</h2>
                                         <p class="mb-[4mm] text-[9pt] text-neutral-500">
-                                            {{ area_schedule.range_start|date:"l, j E Y H:i" }}–{{ area_schedule.range_end|date:"H:i" }}
+                                            {% if area_schedule.range_start|date:"Y-m-d" == area_schedule.range_end|date:"Y-m-d" %}
+                                                {{ area_schedule.range_start|date:"l, j E Y H:i" }}–{{ area_schedule.range_end|date:"H:i" }}
+                                            {% else %}
+                                                {{ area_schedule.range_start|date:"j E Y H:i" }}–{{ area_schedule.range_end|date:"j E Y H:i" }}
+                                            {% endif %}
                                         </p>
                                         <div>
                                             <h3 class="m-0 mb-[2mm] border-b border-neutral-300 text-[13pt]">
@@ -262,3 +266,6 @@
         </div>
     </main>
 {% endblock main_region %}
+{% block extra_scripts %}
+    {% vite_asset 'src/print-controls.ts' %}
+{% endblock extra_scripts %}

--- a/src/ludamus/templates/panel/print/timetable.html
+++ b/src/ludamus/templates/panel/print/timetable.html
@@ -31,7 +31,7 @@
                                    border: 0.5pt solid #111827;
                                    border-bottom-width: 1.5pt;
                                    padding: 1.5mm;
-                                   text-align: left">{% translate "Time slot" %}</th>
+                                   text-align: left">{% translate "Time" %}</th>
                         {% for name in page.space_names %}
                             <th style="border: 0.5pt solid #111827;
                                        border-bottom-width: 1.5pt;

--- a/tests/e2e/playwright.config.ts
+++ b/tests/e2e/playwright.config.ts
@@ -89,6 +89,10 @@ export default defineConfig({
         /anonymous-proposal\.spec\.ts/,
         /proposal-delete-restore\.spec\.ts/,
         /write-in-fields\.spec\.ts/,
+        // Read-only but chains several full navigations of the heavy print
+        // preview; Firefox's slow loads make it time out where Chromium fits
+        // comfortably. print-page.spec.ts keeps Firefox coverage of the page.
+        /print-flow\.spec\.ts/,
       ],
       use: { ...devices["Desktop Firefox"] },
     },

--- a/tests/e2e/tests/print-flow.spec.ts
+++ b/tests/e2e/tests/print-flow.spec.ts
@@ -1,0 +1,109 @@
+import { expect, test } from "./helpers/fixtures";
+
+const printUrl = "/event/kapitularz-2025-anonymized/print/";
+const eventName = "Kapitularz 2025 Anonymized";
+
+// The sidebar is not a form: every control rewrites its own query param and
+// reloads (src/print-controls.ts). These tests drive the controls the way a
+// user would and assert the URL and the rendered preview stay in sync.
+test.describe("Print page controls", () => {
+  test("track timetable material reveals the track select and scopes the grid", async ({
+    page,
+  }) => {
+    await page.goto(printUrl);
+
+    await page.getByLabel("Printable").selectOption("track-timetable");
+    await expect(page).toHaveURL(/material=track-timetable/);
+
+    // No load-state wait: even if this fires before print-controls.ts runs,
+    // the module's healing pass applies the missed edit on init. The long
+    // timeout absorbs dev-server contention — the track page renders 200 KB
+    // of grid and can take >10 s with parallel workers on the shared server.
+    const trackSelect = page.getByLabel("Track");
+    await expect(trackSelect).toBeVisible();
+    await trackSelect.selectOption("rpg");
+    await expect(page).toHaveURL(/track=rpg/, { timeout: 30_000 });
+    // Untouched params survive a change to another control.
+    await expect(page).toHaveURL(/material=track-timetable/);
+
+    const preview = page.getByRole("region", { name: "Print preview" });
+    await expect(preview.getByRole("group").first()).toContainText("RPG Table");
+  });
+
+  test("scope select narrows the preview to the chosen node", async ({ page }) => {
+    await page.goto(`${printUrl}?material=timetable`);
+
+    const scopeSelect = page.getByLabel("Scope");
+    const option = scopeSelect.locator("option").nth(1);
+    const value = (await option.getAttribute("value"))!;
+    const label = (await option.textContent())!.trim();
+    await scopeSelect.selectOption(value);
+
+    await expect(page).toHaveURL(new RegExp(`scope=${value}`));
+    const preview = page.getByRole("region", { name: "Print preview" });
+    await expect(preview.getByRole("group").first()).toBeVisible();
+    await expect(preview.getByText(label).first()).toBeVisible();
+  });
+
+  test("hours window clips the preview to fewer pages", async ({ page }) => {
+    await page.goto(`${printUrl}?material=timetable`);
+    const preview = page.getByRole("region", { name: "Print preview" });
+    const fullCount = await preview.getByRole("group").count();
+    expect(fullCount).toBeGreaterThan(1);
+
+    await page.getByLabel("Hours").fill("4");
+    await page.getByLabel("Hours").press("Tab");
+
+    await expect(page).toHaveURL(/hours=4/);
+    await expect.poll(async () => preview.getByRole("group").count()).toBeLessThan(fullCount);
+    expect(await preview.getByRole("group").count()).toBeGreaterThan(0);
+  });
+
+  test("legacy timetable-descriptions URLs map to the checkbox", async ({ page }) => {
+    await page.goto(`${printUrl}?material=timetable-descriptions`);
+
+    await expect(page.getByLabel("With descriptions")).toBeChecked();
+    await expect(page.getByRole("heading", { name: "Program details" }).first()).toBeVisible();
+  });
+});
+
+test.describe("Panel print pages", () => {
+  test.beforeEach(async ({ page }) => {
+    // Log in via Django admin as the manager user (same flow as panel.spec.ts;
+    // domcontentloaded because Firefox occasionally never fires `load` here).
+    await page.goto("/admin/login/", { waitUntil: "domcontentloaded" });
+    await page.getByLabel("Username:").fill("e2e-manager");
+    await page.getByLabel("Password:").fill("e2e-manager-123");
+    await page.getByRole("button", { name: /Log in/i }).click();
+  });
+
+  test("print materials hub offers timetable and door cards", async ({ page }) => {
+    await page.goto("/panel/event/kapitularz-2025-anonymized/print/");
+
+    await expect(page.getByRole("heading", { name: "Print Materials" })).toBeVisible();
+    await expect(page.getByText("Print timetable").first()).toBeVisible();
+    await expect(page.getByText("Print door cards").first()).toBeVisible();
+  });
+
+  test("panel timetable printout shows session-time rows", async ({ page }) => {
+    await page.goto("/panel/event/kapitularz-2025-anonymized/timetable/print/timetable/");
+
+    await expect(page.getByText(eventName).first()).toBeVisible();
+    await expect(
+      page.getByRole("columnheader", { name: "Time", exact: true }).first(),
+    ).toBeVisible();
+    // Session times, not 4-hour availability slots: an 11:00–13:00 session
+    // renders as its own row.
+    await expect(page.getByRole("cell", { name: /11:00–13:00/ }).first()).toBeVisible();
+  });
+
+  test("door cards render one card per room with its hours", async ({ page }) => {
+    await page.goto("/panel/event/kapitularz-2025-anonymized/timetable/print/door-cards/");
+
+    // Only rooms with sessions get a card; Miniature Painting always has some.
+    await expect(
+      page.getByRole("heading", { name: "Miniature Painting", exact: true }).first(),
+    ).toBeVisible();
+    await expect(page.getByText("Capacity: 18").first()).toBeVisible();
+  });
+});

--- a/tests/e2e/tests/print-page.spec.ts
+++ b/tests/e2e/tests/print-page.spec.ts
@@ -46,7 +46,6 @@ test.describe("Public print page", () => {
   test("offers dense-fixture printable materials", async ({ page }) => {
     const materials = [
       ["timetable", "Timetable"],
-      ["timetable-descriptions", "Timetable with descriptions"],
       ["track-timetable", "Track timetable"],
     ] as const;
 
@@ -57,5 +56,16 @@ test.describe("Public print page", () => {
       await expect(select.getByRole("option", { name: label, exact: true })).toHaveCount(1);
     }
     await expect(select.getByRole("option", { name: "Session list" })).toHaveCount(0);
+    await expect(page.getByLabel("With descriptions")).not.toBeChecked();
+  });
+
+  test("descriptions checkbox swaps the grid for a per-space list", async ({ page }) => {
+    await page.goto(`${densePrintUrl}?material=timetable`);
+
+    await page.getByLabel("With descriptions").check();
+
+    await expect(page).toHaveURL(/descriptions=1/);
+    await expect(page.getByRole("heading", { name: "Program details" }).first()).toBeVisible();
+    await expect(page.getByLabel("With descriptions")).toBeChecked();
   });
 });

--- a/tests/integration/web/chronology/test_event_print_page.py
+++ b/tests/integration/web/chronology/test_event_print_page.py
@@ -95,8 +95,7 @@ def _assert_print_ok(
             "material": material,
             "show_scope_control": show_scope_control,
             "show_track_control": show_track_control,
-            "show_range_controls": is_timetable,
-            "show_descriptions_control": is_timetable,
+            "show_timetable_controls": is_timetable,
             "descriptions": descriptions,
             "selected_scope": selected_scope,
             "selected_track": selected_track,
@@ -146,6 +145,57 @@ class TestPublicEventPrintView:
         assert session.title in content
         assert session.description in content
         assert 'id="area-space-1"' in content
+
+    def test_track_descriptions_list_is_scoped_to_the_selected_track(
+        self, client, event, session, space, active_user
+    ):
+        track = Track.objects.create(
+            event=event, name="Main Track", slug="main-track", is_public=True
+        )
+        session.tracks.add(track)
+        space.tracks.add(track)
+        _confirmed_item(event, session, space)
+        untracked_space = SpaceFactory(event=event, name="Untracked Room")
+        untracked = SessionFactory(
+            presenter=active_user, event=event, participants_limit=10
+        )
+        AgendaItemFactory(
+            session=untracked,
+            space=untracked_space,
+            session_confirmed=True,
+            start_time=event.start_time,
+            end_time=event.start_time + timedelta(hours=1),
+        )
+
+        response = client.get(
+            self._url(event.slug),
+            {"material": "track-timetable", "track": track.slug, "descriptions": "1"},
+        )
+
+        _assert_print_ok(
+            response,
+            material="track-timetable",
+            descriptions=True,
+            tracks_available=True,
+            print_scopes=list(response.context_data["print_scopes"]),
+        )
+        schedule = response.context_data["area_schedule"]
+        assert schedule.scope_name == track.name
+        assert [s.space_name for s in schedule.spaces] == [space.name]
+        assert [x.title for s in schedule.spaces for x in s.sessions] == [session.title]
+
+    def test_legacy_descriptions_material_maps_to_the_checkbox(
+        self, client, event, session, space
+    ):
+        _confirmed_item(event, session, space)
+
+        response = client.get(
+            self._url(event.slug), {"material": "timetable-descriptions"}
+        )
+
+        _assert_print_ok(response, descriptions=True, print_scopes=[_scope(space)])
+        assert response.context_data["area_schedule"] is not None
+        assert response.context_data["timetable"] is None
 
     def test_unconfirmed_session_is_hidden(self, client, event, session, space):
         AgendaItemFactory(
@@ -420,9 +470,8 @@ class TestPublicEventPrintView:
                 "selected_scope": "",
                 "selected_track": "focused-track",
                 "session_list": None,
-                "show_descriptions_control": True,
-                "show_range_controls": True,
                 "show_scope_control": False,
+                "show_timetable_controls": True,
                 "show_track_control": True,
                 "timetable": PrintTimetableDocumentDTO(
                     event_name=event.name,
@@ -465,9 +514,8 @@ class TestPublicEventPrintView:
                 "selected_scope": str(space.pk),
                 "selected_track": "",
                 "session_list": None,
-                "show_descriptions_control": True,
-                "show_range_controls": True,
                 "show_scope_control": True,
+                "show_timetable_controls": True,
                 "show_track_control": False,
                 "timetable": PrintTimetableDocumentDTO(
                     event_name=event.name,
@@ -539,9 +587,8 @@ class TestPublicEventPrintView:
                 "selected_scope": "",
                 "selected_track": "main-track",
                 "session_list": None,
-                "show_descriptions_control": True,
-                "show_range_controls": True,
                 "show_scope_control": False,
+                "show_timetable_controls": True,
                 "show_track_control": True,
                 "timetable": PrintTimetableDocumentDTO(
                     event_name=event.name,

--- a/tests/integration/web/chronology/test_event_print_page.py
+++ b/tests/integration/web/chronology/test_event_print_page.py
@@ -6,7 +6,7 @@ import pytest
 from django.urls import reverse
 from django.utils import timezone
 
-from ludamus.adapters.web.django.print_views import MATERIAL_SPECS
+from ludamus.gates.web.django.event.print import MATERIAL_SPECS
 from ludamus.links.db.django.models import Space, Track
 from ludamus.pacts import EventDTO
 from ludamus.pacts.printing import (
@@ -52,8 +52,9 @@ def _assert_print_ok(
     logo="",
     selected_scope="",
     selected_track=None,
-    range_hours=6,
+    range_hours=None,
     material="timetable",
+    descriptions=False,
     session_list_available=False,
     tracks_available=False,
     print_scopes=None,
@@ -67,16 +68,16 @@ def _assert_print_ok(
     assert ctx["range_start_value"]
     if selected_track is None:
         selected_track = ctx["selected_track"]
-    expected_options = ["timetable", "timetable-descriptions"]
+    expected_options = ["timetable"]
     # The track scope is only offered when the event actually has tracks.
     if tracks_available:
         expected_options.append("track-timetable")
     if session_list_available:
         expected_options.append("session-list")
     assert [option.value for option in ctx["material_options"]] == expected_options
-    show_scope_control = material in {"timetable", "timetable-descriptions"}
+    show_scope_control = material == "timetable"
     show_track_control = material == "track-timetable"
-    show_range_controls = material == "timetable-descriptions"
+    is_timetable = material in {"timetable", "track-timetable"}
     assert_response(
         response,
         HTTPStatus.OK,
@@ -94,7 +95,9 @@ def _assert_print_ok(
             "material": material,
             "show_scope_control": show_scope_control,
             "show_track_control": show_track_control,
-            "show_range_controls": show_range_controls,
+            "show_range_controls": is_timetable,
+            "show_descriptions_control": is_timetable,
+            "descriptions": descriptions,
             "selected_scope": selected_scope,
             "selected_track": selected_track,
             "range_start_value": ctx["range_start_value"],
@@ -135,12 +138,10 @@ class TestPublicEventPrintView:
         _confirmed_item(event, session, space)
 
         response = client.get(
-            self._url(event.slug), {"material": "timetable-descriptions"}
+            self._url(event.slug), {"material": "timetable", "descriptions": "1"}
         )
 
-        _assert_print_ok(
-            response, material="timetable-descriptions", print_scopes=[_scope(space)]
-        )
+        _assert_print_ok(response, descriptions=True, print_scopes=[_scope(space)])
         content = response.content.decode()
         assert session.title in content
         assert session.description in content
@@ -289,6 +290,32 @@ class TestPublicEventPrintView:
 
         _assert_print_ok(response, range_hours=hours, print_scopes=[_scope(space)])
 
+    def test_explicit_range_clips_the_timetable_grid(
+        self, client, event, session, space, active_user
+    ):
+        _confirmed_item(event, session, space)
+        late = SessionFactory(presenter=active_user, event=event, participants_limit=10)
+        AgendaItemFactory(
+            session=late,
+            space=space,
+            session_confirmed=True,
+            start_time=event.start_time + timedelta(hours=10),
+            end_time=event.start_time + timedelta(hours=11),
+        )
+        start = event.start_time.strftime("%Y-%m-%dT%H:%M")
+
+        response = client.get(f"{self._url(event.slug)}?start={start}&hours=3")
+
+        _assert_print_ok(response, range_hours=3, print_scopes=[_scope(space)])
+        titles = [
+            s.title
+            for page in response.context_data["timetable"].pages
+            for row in page.rows
+            for cell in row.cells
+            for s in cell.sessions
+        ]
+        assert titles == [session.title]
+
     def test_unknown_scope_is_not_found(self, client, event):
         response = client.get(f"{self._url(event.slug)}?scope=987654")
 
@@ -383,16 +410,18 @@ class TestPublicEventPrintView:
                 "area_schedule": None,
                 "event": EventDTO.model_validate(event),
                 "logo": "",
+                "descriptions": False,
                 "material": "track-timetable",
-                "material_options": MATERIAL_SPECS[:3],
+                "material_options": MATERIAL_SPECS[:2],
                 "print_scopes": [_scope(space)],
                 "qr_svg": response.context_data["qr_svg"],
-                "range_hours": 6,
+                "range_hours": None,
                 "range_start_value": response.context_data["range_start_value"],
                 "selected_scope": "",
                 "selected_track": "focused-track",
                 "session_list": None,
-                "show_range_controls": False,
+                "show_descriptions_control": True,
+                "show_range_controls": True,
                 "show_scope_control": False,
                 "show_track_control": True,
                 "timetable": PrintTimetableDocumentDTO(
@@ -426,16 +455,18 @@ class TestPublicEventPrintView:
                 "area_schedule": None,
                 "event": EventDTO.model_validate(event),
                 "logo": "",
+                "descriptions": False,
                 "material": "timetable",
-                "material_options": MATERIAL_SPECS[:2],
+                "material_options": MATERIAL_SPECS[:1],
                 "print_scopes": [_scope(space)],
                 "qr_svg": response.context_data["qr_svg"],
-                "range_hours": 6,
+                "range_hours": None,
                 "range_start_value": response.context_data["range_start_value"],
                 "selected_scope": str(space.pk),
                 "selected_track": "",
                 "session_list": None,
-                "show_range_controls": False,
+                "show_descriptions_control": True,
+                "show_range_controls": True,
                 "show_scope_control": True,
                 "show_track_control": False,
                 "timetable": PrintTimetableDocumentDTO(
@@ -498,16 +529,18 @@ class TestPublicEventPrintView:
                 "area_schedule": None,
                 "event": EventDTO.model_validate(event),
                 "logo": "",
+                "descriptions": False,
                 "material": "track-timetable",
-                "material_options": MATERIAL_SPECS[:3],
+                "material_options": MATERIAL_SPECS[:2],
                 "print_scopes": [_scope(space)],
                 "qr_svg": response.context_data["qr_svg"],
-                "range_hours": 6,
+                "range_hours": None,
                 "range_start_value": response.context_data["range_start_value"],
                 "selected_scope": "",
                 "selected_track": "main-track",
                 "session_list": None,
-                "show_range_controls": False,
+                "show_descriptions_control": True,
+                "show_range_controls": True,
                 "show_scope_control": False,
                 "show_track_control": True,
                 "timetable": PrintTimetableDocumentDTO(

--- a/tests/unit/test_printing_mills.py
+++ b/tests/unit/test_printing_mills.py
@@ -50,12 +50,14 @@ def _slot_on_day(pk, day, start_hour, end_hour):
     )
 
 
-def _item(pk, space_id, start_hour, end_hour, *, title, confirmed, description=""):
+def _item(
+    pk, space_id, start_hour, end_hour, *, title, confirmed, description="", day=1
+):
     return AgendaItemDTO(
         pk=pk,
         session_confirmed=confirmed,
-        start_time=datetime(2026, 6, 1, start_hour, 0, tzinfo=UTC),
-        end_time=datetime(2026, 6, 1, end_hour, 0, tzinfo=UTC),
+        start_time=datetime(2026, 6, day, start_hour, 0, tzinfo=UTC),
+        end_time=datetime(2026, 6, day, end_hour, 0, tzinfo=UTC),
         space_id=space_id,
         session_title=title,
         session_description=description,
@@ -172,11 +174,13 @@ class TestBuildDoorCards:
 
 
 class TestBuildTimetable:
-    def test_rows_per_slot_with_empty_cells_for_unused_spaces(self):
+    def test_rows_from_session_times_with_empty_cells_for_unused_spaces(self):
         spaces = [_space(1, "Alfa", 0), _space(2, "Bravo", 1)]
-        slots = [_slot(1, 9, 10), _slot(2, 10, 11)]
-        items = [_item(1, 1, 9, 10, title="RPG", confirmed=True)]
-        service = _service(spaces=spaces, items=items, slots=slots)
+        items = [
+            _item(1, 1, 9, 10, title="RPG", confirmed=True),
+            _item(2, 1, 10, 11, title="Larp", confirmed=True),
+        ]
+        service = _service(spaces=spaces, items=items, slots=[])
 
         document = _timetable(service)
 
@@ -185,26 +189,44 @@ class TestBuildTimetable:
         first_row, second_row = page.rows
         assert [s.title for s in first_row.cells[0].sessions] == ["RPG"]
         assert first_row.cells[1].sessions == []
-        assert second_row.cells[0].sessions == []
+        assert [s.title for s in second_row.cells[0].sessions] == ["Larp"]
         assert second_row.cells[1].sessions == []
 
-    def test_session_outside_every_slot_still_appears(self):
+    def test_rows_show_session_times_not_availability_slots(self):
+        # Time slots are proposer availability windows, not display units; the
+        # grid rows come from the sessions' real times.
         spaces = [_space(1, "Alfa", 0)]
-        slots = [_slot(1, 9, 10), _slot(2, 11, 12)]
-        # 10:00-11:00 falls in the gap between the two slots.
-        items = [_item(1, 1, 10, 11, title="Gap RPG", confirmed=True)]
+        slots = [_slot(1, 9, 13)]
+        items = [_item(1, 1, 10, 11, title="RPG", confirmed=True)]
         service = _service(spaces=spaces, items=items, slots=slots)
 
         document = _timetable(service)
 
         rows = document.pages[0].rows
+        assert [(r.start_time, r.end_time) for r in rows] == [
+            (
+                datetime(2026, 6, 1, 10, 0, tzinfo=UTC),
+                datetime(2026, 6, 1, 11, 0, tzinfo=UTC),
+            )
+        ]
+
+    def test_overlapping_sessions_each_appear_once_in_their_own_row(self):
+        spaces = [_space(1, "Alfa", 0), _space(2, "Bravo", 1)]
+        items = [
+            _item(1, 1, 10, 14, title="Long", confirmed=True),
+            _item(2, 2, 10, 11, title="Short", confirmed=True),
+        ]
+        service = _service(spaces=spaces, items=items, slots=[])
+
+        document = _timetable(service)
+
+        rows = document.pages[0].rows
+        assert [(r.start_time.hour, r.end_time.hour) for r in rows] == [
+            (10, 11),
+            (10, 14),
+        ]
         titles = [s.title for row in rows for cell in row.cells for s in cell.sessions]
-        assert titles == ["Gap RPG"]
-        gap_start = datetime(2026, 6, 1, 10, 0, tzinfo=UTC)
-        gap_end = datetime(2026, 6, 1, 11, 0, tzinfo=UTC)
-        assert any(
-            row.start_time == gap_start and row.end_time == gap_end for row in rows
-        )
+        assert sorted(titles) == ["Long", "Short"]
 
     def test_sessions_render_when_event_has_no_slots(self):
         spaces = [_space(1, "Alfa", 0)]
@@ -222,20 +244,34 @@ class TestBuildTimetable:
         ]
         assert titles == ["Solo"]
 
-    def test_one_day_per_date(self):
+    def test_one_page_per_date_with_sessions(self):
+        spaces = [_space(1, "Alfa", 0)]
+        items = [
+            _item(1, 1, 9, 10, title="Day one", confirmed=True),
+            _item(2, 1, 9, 10, title="Day two", confirmed=True, day=2),
+        ]
+        service = _service(spaces=spaces, items=items, slots=[])
+
+        document = _timetable(service)
+
+        assert [d.day for d in document.pages] == [date(2026, 6, 1), date(2026, 6, 2)]
+
+    def test_slots_without_sessions_produce_no_pages(self):
         spaces = [_space(1, "Alfa", 0)]
         slots = [_slot_on_day(1, 1, 9, 10), _slot_on_day(2, 2, 9, 10)]
         service = _service(spaces=spaces, items=[], slots=slots)
 
         document = _timetable(service)
 
-        assert [d.day for d in document.pages] == [date(2026, 6, 1), date(2026, 6, 2)]
+        assert document.pages == []
 
     def test_large_timetables_are_chunked_by_spaces(self):
         spaces = [_space(pk, f"Space {pk}", pk) for pk in range(1, 8)]
-        slots = [_slot(1, 9, 10)]
-        items = [_item(1, 7, 9, 10, title="Final table", confirmed=True)]
-        service = _service(spaces=spaces, items=items, slots=slots)
+        items = [
+            _item(1, 1, 9, 10, title="Opening", confirmed=True),
+            _item(2, 7, 9, 10, title="Final table", confirmed=True),
+        ]
+        service = _service(spaces=spaces, items=items, slots=[])
 
         document = _timetable(service)
 
@@ -246,6 +282,33 @@ class TestBuildTimetable:
         assert document.pages[0].space_range_name == "Space 1 - Space 4"
         assert document.pages[1].space_range_name == "Space 5 - Space 7"
         assert document.pages[1].rows[0].cells[2].sessions[0].title == "Final table"
+
+    def test_chunk_without_sessions_produces_no_page(self):
+        spaces = [_space(pk, f"Space {pk}", pk) for pk in range(1, 8)]
+        items = [_item(1, 7, 9, 10, title="Final table", confirmed=True)]
+        service = _service(spaces=spaces, items=items, slots=[])
+
+        document = _timetable(service)
+
+        assert [page.space_names for page in document.pages] == [
+            ["Space 5", "Space 6", "Space 7"]
+        ]
+
+    def test_rows_are_chunk_local(self):
+        # A session interval on another page chunk must not spawn an all-empty
+        # row on this one.
+        spaces = [_space(pk, f"Space {pk}", pk) for pk in range(1, 8)]
+        items = [
+            _item(1, 1, 9, 10, title="Opening", confirmed=True),
+            _item(2, 7, 10, 12, title="Final table", confirmed=True),
+        ]
+        service = _service(spaces=spaces, items=items, slots=[])
+
+        document = _timetable(service)
+
+        first, second = document.pages
+        assert [(r.start_time.hour, r.end_time.hour) for r in first.rows] == [(9, 10)]
+        assert [(r.start_time.hour, r.end_time.hour) for r in second.rows] == [(10, 12)]
 
     def test_documents_carry_event_description(self):
         service = _service(spaces=[_space(1, "Alfa", 0)], items=[], slots=[])
@@ -384,7 +447,8 @@ class TestScoping:
     @staticmethod
     def _scoped_service():
         spaces = [_space(1, "Alfa", 0), _space(2, "Bravo", 1), _space(3, "Cesarz", 2)]
-        return _service(spaces=spaces, items=[], slots=[_slot(1, 9, 10)])
+        items = [_item(1, 1, 9, 10, title="RPG", confirmed=True)]
+        return _service(spaces=spaces, items=items, slots=[])
 
     def test_timetable_filtered_to_scope_space_pks(self):
         document = _timetable(
@@ -417,21 +481,13 @@ class TestScoping:
         assert document.scope_name is None
         assert document.pages[0].space_names == ["Alfa", "Bravo", "Cesarz"]
 
-    def test_orphan_session_outside_scope_adds_no_row(self):
-        # An un-slotted session lives in Cesarz (area 30), outside the scoped
-        # area 10 — it must not spawn a fallback row in the scoped grid.
+    def test_session_outside_scope_adds_no_row(self):
+        # The session lives in Cesarz, outside the scoped space set — it must
+        # not spawn a row (nor a page) in the scoped grid.
         spaces = [_space(1, "Alfa", 0), _space(3, "Cesarz", 2)]
         items = [_item(1, 3, 12, 13, title="Out of scope", confirmed=True)]
-        service = _service(spaces=spaces, items=items, slots=[_slot(1, 9, 10)])
+        service = _service(spaces=spaces, items=items, slots=[])
 
         document = _timetable(service, scope_space_pks=frozenset({1}))
 
-        page = document.pages[0]
-        assert page.space_names == ["Alfa"]
-        slot_row = (
-            datetime(2026, 6, 1, 9, 0, tzinfo=UTC),
-            datetime(2026, 6, 1, 10, 0, tzinfo=UTC),
-        )
-        assert [(r.start_time, r.end_time) for r in page.rows] == [slot_row]
-        titles = [s.title for r in page.rows for c in r.cells for s in c.sessions]
-        assert titles == []
+        assert document.pages == []

--- a/tests/unit/test_printing_mills.py
+++ b/tests/unit/test_printing_mills.py
@@ -462,6 +462,17 @@ class TestBuildAreaSchedule:
 
         assert document.spaces[0].sessions == []
 
+    def test_no_range_defaults_to_event_bounds(self):
+        spaces = [_space(1, "Alfa", 0)]
+        items = [_item(1, 1, 10, 11, title="RPG", confirmed=True)]
+        service = _service(spaces=spaces, items=items, slots=[])
+
+        document = service.build_area_schedule(AreaScheduleQueryDTO(event_pk=1))
+
+        assert document.range_start == _event().start_time
+        assert document.range_end == _event().end_time
+        assert [s.title for s in document.spaces[0].sessions] == ["RPG"]
+
     def test_track_scopes_spaces(self):
         spaces = [_space(1, "Alfa", 0), _space(2, "Bravo", 1)]
         items = [_item(1, 1, 10, 11, title="Tracked", confirmed=True)]

--- a/tests/unit/test_printing_mills.py
+++ b/tests/unit/test_printing_mills.py
@@ -80,13 +80,19 @@ class _ListByEvent:
     def list_by_event(self, _event_pk):
         return list(self._rows)
 
+    def list_by_track(self, _track_pk):
+        return list(self._rows)
+
 
 class _Tracks:
+    def __init__(self, space_pks=()):
+        self._space_pks = list(space_pks)
+
     def list_public_by_event(self, _event_pk):
         return []
 
     def list_space_pks(self, _track_pk):
-        return []
+        return list(self._space_pks)
 
 
 def _service(*, spaces, items, slots, tracks=None):
@@ -310,6 +316,33 @@ class TestBuildTimetable:
         assert [(r.start_time.hour, r.end_time.hour) for r in first.rows] == [(9, 10)]
         assert [(r.start_time.hour, r.end_time.hour) for r in second.rows] == [(10, 12)]
 
+    def test_time_range_clips_sessions_and_completeness(self):
+        spaces = [_space(1, "Alfa", 0)]
+        items = [
+            _item(1, 1, 9, 10, title="Morning", confirmed=True),
+            _item(2, 1, 15, 16, title="Afternoon", confirmed=True),
+        ]
+        service = _service(spaces=spaces, items=items, slots=[])
+
+        document = _timetable(
+            service,
+            time_range=(
+                datetime(2026, 6, 1, 8, 0, tzinfo=UTC),
+                datetime(2026, 6, 1, 12, 0, tzinfo=UTC),
+            ),
+        )
+
+        titles = [
+            s.title
+            for page in document.pages
+            for row in page.rows
+            for cell in row.cells
+            for s in cell.sessions
+        ]
+        assert titles == ["Morning"]
+        # A time-clipped print is a subset, never "the whole program".
+        assert document.is_complete is False
+
     def test_documents_carry_event_description(self):
         service = _service(spaces=[_space(1, "Alfa", 0)], items=[], slots=[])
 
@@ -428,6 +461,22 @@ class TestBuildAreaSchedule:
         document = _area_schedule(service, window, confirmed_only=True)
 
         assert document.spaces[0].sessions == []
+
+    def test_track_scopes_spaces(self):
+        spaces = [_space(1, "Alfa", 0), _space(2, "Bravo", 1)]
+        items = [_item(1, 1, 10, 11, title="Tracked", confirmed=True)]
+        service = _service(
+            spaces=spaces, items=items, slots=[], tracks=_Tracks(space_pks=[1])
+        )
+        window = (
+            datetime(2026, 6, 1, 9, 0, tzinfo=UTC),
+            datetime(2026, 6, 1, 15, 0, tzinfo=UTC),
+        )
+
+        document = _area_schedule(service, window, track_pk=7)
+
+        assert [s.space_name for s in document.spaces] == ["Alfa"]
+        assert [s.title for s in document.spaces[0].sessions] == ["Tracked"]
 
     def test_carries_range_bounds(self):
         spaces = [_space(1, "Alfa", 0)]


### PR DESCRIPTION
## Summary

Reworks the public print page (`/event/<slug>/print/`) around three ideas:

1. **Timetable rows show real session times, not availability slots.** Time slots are proposer availability windows ("when could you run your session?"), not schedule display units — a clarifying comment now sits in `mills/timeslots.py`. Grid rows are the distinct (start, end) times of the scheduled sessions, so each session appears exactly once instead of repeating across every slot it overlaps. Rows are computed per printed page chunk, so a page never shows all-dash rows for times used only by rooms on other pages, and a chunk with nothing scheduled produces no page. The column header becomes "Time".

2. **The sidebar is not a form.** There is nothing to submit or apply, so the Apply button and the `<form>` are gone. Each control owns one query param (its `name`) and rewrites it on change (`client/src/print-controls.ts`); untouched params keep their defaults, cleared controls drop their param.

3. **"With descriptions" is a checkbox, not a material.** The `timetable-descriptions` material is folded into a checkbox available on both Timetable and Track timetable — it swaps the grid for the per-space descriptions list (the area schedule builder now supports track scoping). Start/Hours apply to both materials and both variants: blank hours means "until event end" (placeholder says so), and an explicit range clips the grid and marks the print as partial (`is_complete=False`).

## Layering

`PublicEventPrintView` moves from legacy `adapters/web/django/print_views.py` to `gates/web/django/event/print.py` — it is already fully `request.services`-based, so the strangler-fig move was mechanical and pays down the debt this change would otherwise add (`tingle check`: net −269 vs main).

## Behavior changes worth knowing

- An event with time slots but nothing scheduled now renders the "No confirmed sessions scheduled yet" empty state instead of an empty slot grid.
- The descriptions list defaults to the whole event instead of a 6-hour window; the range header shows full dates when it spans days.
- Old `?material=timetable-descriptions` links fall back to the default Timetable material.

## Screenshots

| Default grid (session-time rows) | With descriptions |
| --- | --- |
| ![Default timetable grid](https://raw.githubusercontent.com/zagrajmy/ludamus/d814fa1becc84dc4921a88afc8800635043626e1/pr726-default-grid.png) | ![Descriptions list](https://raw.githubusercontent.com/zagrajmy/ludamus/d814fa1becc84dc4921a88afc8800635043626e1/pr726-descriptions-list.png) |

| Track timetable | Track + descriptions + 4h range |
| --- | --- |
| ![Track timetable grid](https://raw.githubusercontent.com/zagrajmy/ludamus/d814fa1becc84dc4921a88afc8800635043626e1/pr726-track-grid.png) | ![Track descriptions with range](https://raw.githubusercontent.com/zagrajmy/ludamus/d814fa1becc84dc4921a88afc8800635043626e1/pr726-track-descriptions-4h.png) |

(Images hosted on the throwaway `pr-726-assets` orphan branch — delete it after merge.)

## Testing

- Unit: row derivation from session times, no duplication across rows, chunk-local rows, time-range clipping + completeness, track-scoped area schedule, slots-only events produce no pages.
- Integration: descriptions checkbox path, explicit range clipping the grid, new context contract across materials.
- E2e (chromium): dense-fixture preview/PDF page parity unchanged (21 pages), material options, descriptions checkbox swaps grid → list and syncs the URL.
- Full suite 3335 passed; `mise run lint` and `lint-client` green.

https://claude.ai/code/session_01VgBxsug4NtwFR2EDvrWB1e