### PR TITLE
fix(notifications): mail an absolute link, not a bare path

### DIFF
--- a/docs/plans/email-and-seat-claim-test-plan.md
+++ b/docs/plans/email-and-seat-claim-test-plan.md
@@ -23,19 +23,17 @@ Use these status values: `Not started`, `In progress`, `Passed`, `Failed`, or
 
 ## Known risks from source review
 
-1. Offer emails appear to contain only a relative path such as
-   `/offer/<token>/claim/`. `DjangoUserNotifier._deliver` sends
-   `notification.url` without adding the sphere's scheme and host. An email
-   without a directly usable
-   `https://skytower.zagrajmy.net/offer/<token>/claim/` link fails this test.
+1. Emails carry an absolute link: `DjangoUserNotifier._deliver` resolves the
+   sphere host from the notification and mails
+   `https://skytower.zagrajmy.net/offer/<token>/claim/`. Verify the host in the
+   received mail — a relative or wrong-sphere link fails this test.
 2. Email delivery uses `fail_silently=True`. Application logs alone cannot prove
    delivery; the message must reach Gmail.
 3. Existing browser coverage tests automatic wait-list promotion, not the
    `OFFER_CLAIM` path.
 4. The backoffice panel cannot create the sphere's first event. Create the event
-   through Django admin or a production shell. The organizer's category form
-   also omits `promotion_mode` and `offer_claim_window`; configure both through
-   Django admin or the shell.
+   through Django admin or a production shell. `promotion_mode` and
+   `offer_claim_window` are on the panel's category settings page.
 
 ## Safety rules
 

--- a/src/ludamus/links/db/django/notifications.py
+++ b/src/ludamus/links/db/django/notifications.py
@@ -7,6 +7,7 @@ send time and links each notification to the relevant page.
 
 from __future__ import annotations
 
+import logging
 from datetime import UTC, datetime
 from typing import TYPE_CHECKING
 
@@ -33,32 +34,43 @@ if TYPE_CHECKING:
     from ludamus.pacts.safety import ShadowbanSignupNotification
 
 
-def _email_link(notification: Notification) -> str:
-    domain = _sphere_domain(notification) or settings.ROOT_DOMAIN
-    return f"https://{domain}{notification.url}"
+logger = logging.getLogger(__name__)
 
 
-def _sphere_domain(notification: Notification) -> str | None:
-    if domain := notification.payload.get("sphere_domain"):
-        return str(domain)
-    if session_id := notification.payload.get("session_id"):
-        return (
-            Session.objects.filter(pk=session_id)
-            .values_list("event__sphere__site__domain", flat=True)
-            .first()
+def _absolute(path: str, *, domain: str) -> str:
+    scheme = "http" if settings.ENV == "development" else "https"
+    return f"{scheme}://{domain}{path}"
+
+
+def _session_enrollment_url(event_slug: str, session_id: int) -> str:
+    return _absolute(
+        reverse(
+            "web:chronology:session-enrollment",
+            kwargs={"event_slug": event_slug, "session_id": session_id},
+        ),
+        domain=_session_host(session_id),
+    )
+
+
+def _session_host(session_id: int) -> str:
+    domain = (
+        Session.objects.filter(pk=session_id)
+        .values_list("event__sphere__site__domain", flat=True)
+        .first()
+    )
+    if not domain:
+        logger.warning(
+            "No sphere host for session %s; linking to %s",
+            session_id,
+            settings.ROOT_DOMAIN,
         )
-    return None
+        return str(settings.ROOT_DOMAIN)
+    return domain
 
 
 class DjangoUserNotifier:
     def notify_promoted(self, notification: PromotionNotification) -> None:
-        url = reverse(
-            "web:chronology:session-enrollment",
-            kwargs={
-                "event_slug": notification.event_slug,
-                "session_id": notification.session_id,
-            },
-        )
+        url = _session_enrollment_url(notification.event_slug, notification.session_id)
         title = _("You're in: a spot opened in %(session)s") % {
             "session": notification.session_title
         }
@@ -76,8 +88,11 @@ class DjangoUserNotifier:
         )
 
     def notify_offered(self, notification: OfferNotification) -> None:
-        url = reverse(
-            "web:chronology:offer-claim", kwargs={"token": notification.claim_token}
+        url = _absolute(
+            reverse(
+                "web:chronology:offer-claim", kwargs={"token": notification.claim_token}
+            ),
+            domain=_session_host(notification.session_id),
         )
         deadline = date_format(
             localtime(notification.offer_expires_at), "DATETIME_FORMAT"
@@ -122,12 +137,8 @@ class DjangoUserNotifier:
                 kind=NotificationKind.OFFER_EXPIRED.value,
                 title=title,
                 body=body,
-                url=reverse(
-                    "web:chronology:session-enrollment",
-                    kwargs={
-                        "event_slug": notification.event_slug,
-                        "session_id": notification.session_id,
-                    },
+                url=_session_enrollment_url(
+                    notification.event_slug, notification.session_id
                 ),
                 payload={"session_id": notification.session_id},
             ),
@@ -151,20 +162,16 @@ class DjangoUserNotifier:
                 kind=NotificationKind.PARTY_INVITE.value,
                 title=title,
                 body=body,
-                url=reverse("web:crowd:profile-parties"),
+                url=_absolute(
+                    reverse("web:crowd:profile-parties"), domain=settings.ROOT_DOMAIN
+                ),
                 payload={},
             ),
             notification.recipient_email,
         )
 
     def notify_party_enrolled(self, notification: PartyEnrolledNotification) -> None:
-        url = reverse(
-            "web:chronology:session-enrollment",
-            kwargs={
-                "event_slug": notification.event_slug,
-                "session_id": notification.session_id,
-            },
-        )
+        url = _session_enrollment_url(notification.event_slug, notification.session_id)
         title = _("%(leader)s enrolled you in %(session)s") % {
             "leader": notification.actor_name,
             "session": notification.session_title,
@@ -186,8 +193,11 @@ class DjangoUserNotifier:
         )
 
     def notify_seat_held(self, notification: HeldSeatNotification) -> None:
-        url = reverse(
-            "web:chronology:offer-claim", kwargs={"token": notification.claim_token}
+        url = _absolute(
+            reverse(
+                "web:chronology:offer-claim", kwargs={"token": notification.claim_token}
+            ),
+            domain=_session_host(notification.session_id),
         )
         deadline = date_format(
             localtime(notification.offer_expires_at), "DATETIME_FORMAT"
@@ -219,8 +229,9 @@ class DjangoUserNotifier:
     def notify_printables_ready(
         self, notification: PrintablesReadyNotification
     ) -> None:
-        path = reverse(
-            "panel:print-materials", kwargs={"slug": notification.event_slug}
+        url = _absolute(
+            reverse("panel:print-materials", kwargs={"slug": notification.event_slug}),
+            domain=notification.sphere_domain,
         )
         title = _("Print your materials for %(event)s") % {
             "event": notification.event_name
@@ -235,11 +246,8 @@ class DjangoUserNotifier:
                 kind=NotificationKind.PRINTABLES_READY.value,
                 title=title,
                 body=body,
-                url=path,
-                payload={
-                    "event_slug": notification.event_slug,
-                    "sphere_domain": notification.sphere_domain,
-                },
+                url=url,
+                payload={"event_slug": notification.event_slug},
             ),
             notification.recipient_email,
         )
@@ -282,13 +290,13 @@ class DjangoUserNotifier:
                 kind=NotificationKind.SHADOWBANNED_SIGNUP.value,
                 title=title,
                 body=body,
-                url=reverse(
-                    "web:chronology:event", kwargs={"slug": notification.event_slug}
+                url=_absolute(
+                    reverse(
+                        "web:chronology:event", kwargs={"slug": notification.event_slug}
+                    ),
+                    domain=notification.sphere_domain,
                 ),
-                payload={
-                    "event_slug": notification.event_slug,
-                    "sphere_domain": notification.sphere_domain,
-                },
+                payload={"event_slug": notification.event_slug},
             ),
             notification.recipient_email,
         )
@@ -307,7 +315,7 @@ class DjangoUserNotifier:
         def _send_email() -> None:
             send_mail(
                 subject=notification.title,
-                message=f"{notification.body}\n\n{_email_link(notification)}",
+                message=f"{notification.body}\n\n{notification.url}",
                 from_email=None,
                 recipient_list=[email],
                 fail_silently=True,

--- a/src/ludamus/links/db/django/notifications.py
+++ b/src/ludamus/links/db/django/notifications.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 from datetime import UTC, datetime
 from typing import TYPE_CHECKING
 
+from django.conf import settings
 from django.core.mail import send_mail
 from django.db import transaction
 from django.urls import reverse
@@ -17,7 +18,7 @@ from django.utils.formats import date_format
 from django.utils.timezone import localtime
 from django.utils.translation import gettext as _
 
-from ludamus.links.db.django.models import Notification
+from ludamus.links.db.django.models import Event, Notification, Session
 from ludamus.pacts.enrollment import NotificationDTO
 from ludamus.pacts.legacy import NotificationKind
 
@@ -30,6 +31,29 @@ if TYPE_CHECKING:
     )
     from ludamus.pacts.printing import PrintablesReadyNotification
     from ludamus.pacts.safety import ShadowbanSignupNotification
+
+
+def _email_link(notification: Notification) -> str:
+    if notification.url.startswith("http"):
+        return notification.url
+    domain = _sphere_domain(notification) or settings.ROOT_DOMAIN
+    return f"https://{domain}{notification.url}"
+
+
+def _sphere_domain(notification: Notification) -> str | None:
+    if session_id := notification.payload.get("session_id"):
+        return (
+            Session.objects.filter(pk=session_id)
+            .values_list("event__sphere__site__domain", flat=True)
+            .first()
+        )
+    if event_slug := notification.payload.get("event_slug"):
+        return (
+            Event.objects.filter(slug=event_slug)
+            .values_list("sphere__site__domain", flat=True)
+            .first()
+        )
+    return None
 
 
 class DjangoUserNotifier:
@@ -282,10 +306,12 @@ class DjangoUserNotifier:
         if not email:
             return
 
+        link = _email_link(notification)
+
         def _send_email() -> None:
             send_mail(
                 subject=notification.title,
-                message=f"{notification.body}\n\n{notification.url}",
+                message=f"{notification.body}\n\n{link}",
                 from_email=None,
                 recipient_list=[email],
                 fail_silently=True,

--- a/src/ludamus/links/db/django/notifications.py
+++ b/src/ludamus/links/db/django/notifications.py
@@ -18,7 +18,7 @@ from django.utils.formats import date_format
 from django.utils.timezone import localtime
 from django.utils.translation import gettext as _
 
-from ludamus.links.db.django.models import Event, Notification, Session
+from ludamus.links.db.django.models import Notification, Session
 from ludamus.pacts.enrollment import NotificationDTO
 from ludamus.pacts.legacy import NotificationKind
 
@@ -34,23 +34,17 @@ if TYPE_CHECKING:
 
 
 def _email_link(notification: Notification) -> str:
-    if notification.url.startswith("http"):
-        return notification.url
     domain = _sphere_domain(notification) or settings.ROOT_DOMAIN
     return f"https://{domain}{notification.url}"
 
 
 def _sphere_domain(notification: Notification) -> str | None:
+    if domain := notification.payload.get("sphere_domain"):
+        return str(domain)
     if session_id := notification.payload.get("session_id"):
         return (
             Session.objects.filter(pk=session_id)
             .values_list("event__sphere__site__domain", flat=True)
-            .first()
-        )
-    if event_slug := notification.payload.get("event_slug"):
-        return (
-            Event.objects.filter(slug=event_slug)
-            .values_list("sphere__site__domain", flat=True)
             .first()
         )
     return None
@@ -241,10 +235,11 @@ class DjangoUserNotifier:
                 kind=NotificationKind.PRINTABLES_READY.value,
                 title=title,
                 body=body,
-                # Absolute, unlike sibling notifications: reminders go out by
-                # email and each sphere's site lives on its own domain.
-                url=f"https://{notification.sphere_domain}{path}",
-                payload={"event_slug": notification.event_slug},
+                url=path,
+                payload={
+                    "event_slug": notification.event_slug,
+                    "sphere_domain": notification.sphere_domain,
+                },
             ),
             notification.recipient_email,
         )
@@ -290,7 +285,10 @@ class DjangoUserNotifier:
                 url=reverse(
                     "web:chronology:event", kwargs={"slug": notification.event_slug}
                 ),
-                payload={"event_slug": notification.event_slug},
+                payload={
+                    "event_slug": notification.event_slug,
+                    "sphere_domain": notification.sphere_domain,
+                },
             ),
             notification.recipient_email,
         )
@@ -306,12 +304,10 @@ class DjangoUserNotifier:
         if not email:
             return
 
-        link = _email_link(notification)
-
         def _send_email() -> None:
             send_mail(
                 subject=notification.title,
-                message=f"{notification.body}\n\n{link}",
+                message=f"{notification.body}\n\n{_email_link(notification)}",
                 from_email=None,
                 recipient_list=[email],
                 fail_silently=True,

--- a/src/ludamus/links/db/django/notifications.py
+++ b/src/ludamus/links/db/django/notifications.py
@@ -38,7 +38,7 @@ logger = logging.getLogger(__name__)
 
 
 def _absolute(path: str, *, domain: str) -> str:
-    scheme = "http" if settings.ENV == "development" else "https"
+    scheme = "http" if "localhost" in domain else "https"
     return f"{scheme}://{domain}{path}"
 
 

--- a/src/ludamus/links/db/django/safety.py
+++ b/src/ludamus/links/db/django/safety.py
@@ -207,7 +207,7 @@ class ShadowbanRepository(ShadowbanRepositoryProtocol):
         if not signed_up_ids:
             return None
         agenda_item = (
-            AgendaItem.objects.select_related("session__event")
+            AgendaItem.objects.select_related("session__event__sphere__site")
             .filter(session_id=session_id)
             .order_by("pk")
             .first()
@@ -254,6 +254,7 @@ class ShadowbanRepository(ShadowbanRepositoryProtocol):
             event_slug=event.slug,
             event_name=event.name,
             session_title=agenda_item.session.title,
+            sphere_domain=event.sphere.site.domain,
             hits=list(hits.values()),
         )
 

--- a/src/ludamus/mills/safety.py
+++ b/src/ludamus/mills/safety.py
@@ -100,6 +100,7 @@ class ShadowbanService:
                     event_slug=data.event_slug,
                     event_name=data.event_name,
                     session_title=data.session_title,
+                    sphere_domain=data.sphere_domain,
                     player_names=event_names,
                     session_player_names=session_names,
                 )

--- a/src/ludamus/pacts/safety.py
+++ b/src/ludamus/pacts/safety.py
@@ -65,6 +65,7 @@ class ShadowbanEventSignupDTO(BaseModel):
     event_slug: str
     event_name: str
     session_title: str
+    sphere_domain: str
     hits: list[ShadowbanHitDTO]
 
 
@@ -74,6 +75,7 @@ class ShadowbanSignupNotification(BaseModel):
     event_slug: str
     event_name: str
     session_title: str
+    sphere_domain: str
     player_names: list[str]
     session_player_names: list[str]
 

--- a/tests/integration/links/test_notification_email_links.py
+++ b/tests/integration/links/test_notification_email_links.py
@@ -4,6 +4,7 @@ from django.core import mail
 from django.test import override_settings
 from django.urls import reverse
 
+from ludamus.links.db.django.models import Notification
 from ludamus.links.db.django.notifications import DjangoUserNotifier
 from ludamus.pacts.enrollment import OfferNotification
 from ludamus.pacts.party import PartyInviteNotification
@@ -36,7 +37,9 @@ class TestEmailLink:
             )
 
         path = reverse("web:chronology:offer-claim", kwargs={"token": "tok-123"})
-        assert _mailed_link() == f"https://skytower.example.net{path}"
+        link = f"https://skytower.example.net{path}"
+        assert _mailed_link() == link
+        assert Notification.objects.get().url == link
 
     def test_link_prefers_the_domain_the_notification_carries(
         self, django_capture_on_commit_callbacks, active_user

--- a/tests/integration/links/test_notification_email_links.py
+++ b/tests/integration/links/test_notification_email_links.py
@@ -2,27 +2,21 @@ from datetime import UTC, datetime, timedelta
 
 from django.core import mail
 from django.test import override_settings
+from django.urls import reverse
 
 from ludamus.links.db.django.notifications import DjangoUserNotifier
 from ludamus.pacts.enrollment import OfferNotification
 from ludamus.pacts.party import PartyInviteNotification
+from ludamus.pacts.safety import ShadowbanSignupNotification
 from tests.integration.conftest import EventFactory, SessionFactory, SphereFactory
 
 
-def _offer(session, *, email):
-    return OfferNotification(
-        recipient_user_id=session.presenter_id,
-        recipient_email=email,
-        session_id=session.pk,
-        session_title=session.title,
-        event_slug=session.event.slug,
-        claim_token="tok-123",
-        offer_expires_at=datetime.now(UTC) + timedelta(minutes=5),
-    )
+def _mailed_link():
+    return mail.outbox[0].body.rsplit("\n\n", 1)[1]
 
 
-class TestOfferEmailLink:
-    def test_link_uses_the_session_sphere_domain(
+class TestEmailLink:
+    def test_offer_link_uses_the_session_sphere_domain(
         self, django_capture_on_commit_callbacks
     ):
         sphere = SphereFactory(site__domain="skytower.example.net")
@@ -30,12 +24,39 @@ class TestOfferEmailLink:
 
         with django_capture_on_commit_callbacks(execute=True):
             DjangoUserNotifier().notify_offered(
-                _offer(session, email="waiter@example.com")
+                OfferNotification(
+                    recipient_user_id=session.presenter_id,
+                    recipient_email="waiter@example.com",
+                    session_id=session.pk,
+                    session_title=session.title,
+                    event_slug=session.event.slug,
+                    claim_token="tok-123",
+                    offer_expires_at=datetime.now(UTC) + timedelta(minutes=5),
+                )
             )
 
-        assert (
-            "https://skytower.example.net/offer/tok-123/claim/" in mail.outbox[0].body
-        )
+        path = reverse("web:chronology:offer-claim", kwargs={"token": "tok-123"})
+        assert _mailed_link() == f"https://skytower.example.net{path}"
+
+    def test_link_prefers_the_domain_the_notification_carries(
+        self, django_capture_on_commit_callbacks, active_user
+    ):
+        with django_capture_on_commit_callbacks(execute=True):
+            DjangoUserNotifier().notify_shadowbanned_signup(
+                ShadowbanSignupNotification(
+                    recipient_user_id=active_user.pk,
+                    recipient_email="organizer@example.com",
+                    event_slug="con-2026",
+                    event_name="Con 2026",
+                    session_title="Deniable Game",
+                    sphere_domain="con.example.net",
+                    player_names=["Banned Bob"],
+                    session_player_names=[],
+                )
+            )
+
+        path = reverse("web:chronology:event", kwargs={"slug": "con-2026"})
+        assert _mailed_link() == f"https://con.example.net{path}"
 
     @override_settings(ROOT_DOMAIN="zagrajmy.example.net")
     def test_link_falls_back_to_the_root_domain(
@@ -51,4 +72,5 @@ class TestOfferEmailLink:
                 )
             )
 
-        assert "https://zagrajmy.example.net/" in mail.outbox[0].body
+        path = reverse("web:crowd:profile-parties")
+        assert _mailed_link() == f"https://zagrajmy.example.net{path}"

--- a/tests/integration/links/test_notification_email_links.py
+++ b/tests/integration/links/test_notification_email_links.py
@@ -1,24 +1,25 @@
+import logging
 from datetime import UTC, datetime, timedelta
 
-from django.core import mail
 from django.test import override_settings
 from django.urls import reverse
 
 from ludamus.links.db.django.models import Notification
 from ludamus.links.db.django.notifications import DjangoUserNotifier
-from ludamus.pacts.enrollment import OfferNotification
+from ludamus.pacts.enrollment import OfferNotification, PromotionNotification
 from ludamus.pacts.party import PartyInviteNotification
 from ludamus.pacts.safety import ShadowbanSignupNotification
 from tests.integration.conftest import EventFactory, SessionFactory, SphereFactory
 
 
-def _mailed_link():
-    return mail.outbox[0].body.rsplit("\n\n", 1)[1]
+def _mailed_link(mailoutbox):
+    assert len(mailoutbox) == 1
+    return mailoutbox[0].body.rsplit("\n\n", 1)[1]
 
 
 class TestEmailLink:
     def test_offer_link_uses_the_session_sphere_domain(
-        self, django_capture_on_commit_callbacks
+        self, mailoutbox, django_capture_on_commit_callbacks
     ):
         sphere = SphereFactory(site__domain="skytower.example.net")
         session = SessionFactory(event=EventFactory(sphere=sphere))
@@ -38,11 +39,11 @@ class TestEmailLink:
 
         path = reverse("web:chronology:offer-claim", kwargs={"token": "tok-123"})
         link = f"https://skytower.example.net{path}"
-        assert _mailed_link() == link
+        assert _mailed_link(mailoutbox) == link
         assert Notification.objects.get().url == link
 
     def test_link_prefers_the_domain_the_notification_carries(
-        self, django_capture_on_commit_callbacks, active_user
+        self, mailoutbox, django_capture_on_commit_callbacks, active_user
     ):
         with django_capture_on_commit_callbacks(execute=True):
             DjangoUserNotifier().notify_shadowbanned_signup(
@@ -59,11 +60,11 @@ class TestEmailLink:
             )
 
         path = reverse("web:chronology:event", kwargs={"slug": "con-2026"})
-        assert _mailed_link() == f"https://con.example.net{path}"
+        assert _mailed_link(mailoutbox) == f"https://con.example.net{path}"
 
     @override_settings(ROOT_DOMAIN="zagrajmy.example.net")
-    def test_link_falls_back_to_the_root_domain(
-        self, django_capture_on_commit_callbacks, active_user
+    def test_party_invite_links_to_the_root_domain(
+        self, mailoutbox, django_capture_on_commit_callbacks, active_user
     ):
         with django_capture_on_commit_callbacks(execute=True):
             DjangoUserNotifier().notify_party_invited(
@@ -76,4 +77,46 @@ class TestEmailLink:
             )
 
         path = reverse("web:crowd:profile-parties")
-        assert _mailed_link() == f"https://zagrajmy.example.net{path}"
+        assert _mailed_link(mailoutbox) == f"https://zagrajmy.example.net{path}"
+
+    @override_settings(ROOT_DOMAIN="zagrajmy.example.net")
+    def test_vanished_session_falls_back_to_the_root_domain(
+        self, mailoutbox, django_capture_on_commit_callbacks, active_user, caplog
+    ):
+        with (
+            caplog.at_level(logging.WARNING),
+            django_capture_on_commit_callbacks(execute=True),
+        ):
+            DjangoUserNotifier().notify_promoted(
+                PromotionNotification(
+                    recipient_user_id=active_user.pk,
+                    recipient_email="waiter@example.com",
+                    session_id=404_404,
+                    session_title="Gone Game",
+                    event_slug="con-2026",
+                )
+            )
+
+        path = reverse(
+            "web:chronology:session-enrollment",
+            kwargs={"event_slug": "con-2026", "session_id": 404_404},
+        )
+        assert _mailed_link(mailoutbox) == f"https://zagrajmy.example.net{path}"
+        assert "No sphere host for session 404404" in caplog.text
+
+    @override_settings(ROOT_DOMAIN="localhost:8000")
+    def test_local_hosts_keep_http(
+        self, mailoutbox, django_capture_on_commit_callbacks, active_user
+    ):
+        with django_capture_on_commit_callbacks(execute=True):
+            DjangoUserNotifier().notify_party_invited(
+                PartyInviteNotification(
+                    recipient_user_id=active_user.pk,
+                    recipient_email="invitee@example.com",
+                    actor_name="Kobold",
+                    party_name="Drużyna",
+                )
+            )
+
+        path = reverse("web:crowd:profile-parties")
+        assert _mailed_link(mailoutbox) == f"http://localhost:8000{path}"

--- a/tests/integration/links/test_notification_email_links.py
+++ b/tests/integration/links/test_notification_email_links.py
@@ -1,0 +1,54 @@
+from datetime import UTC, datetime, timedelta
+
+from django.core import mail
+from django.test import override_settings
+
+from ludamus.links.db.django.notifications import DjangoUserNotifier
+from ludamus.pacts.enrollment import OfferNotification
+from ludamus.pacts.party import PartyInviteNotification
+from tests.integration.conftest import EventFactory, SessionFactory, SphereFactory
+
+
+def _offer(session, *, email):
+    return OfferNotification(
+        recipient_user_id=session.presenter_id,
+        recipient_email=email,
+        session_id=session.pk,
+        session_title=session.title,
+        event_slug=session.event.slug,
+        claim_token="tok-123",
+        offer_expires_at=datetime.now(UTC) + timedelta(minutes=5),
+    )
+
+
+class TestOfferEmailLink:
+    def test_link_uses_the_session_sphere_domain(
+        self, django_capture_on_commit_callbacks
+    ):
+        sphere = SphereFactory(site__domain="skytower.example.net")
+        session = SessionFactory(event=EventFactory(sphere=sphere))
+
+        with django_capture_on_commit_callbacks(execute=True):
+            DjangoUserNotifier().notify_offered(
+                _offer(session, email="waiter@example.com")
+            )
+
+        assert (
+            "https://skytower.example.net/offer/tok-123/claim/" in mail.outbox[0].body
+        )
+
+    @override_settings(ROOT_DOMAIN="zagrajmy.example.net")
+    def test_link_falls_back_to_the_root_domain(
+        self, django_capture_on_commit_callbacks, active_user
+    ):
+        with django_capture_on_commit_callbacks(execute=True):
+            DjangoUserNotifier().notify_party_invited(
+                PartyInviteNotification(
+                    recipient_user_id=active_user.pk,
+                    recipient_email="invitee@example.com",
+                    actor_name="Kobold",
+                    party_name="Drużyna",
+                )
+            )
+
+        assert "https://zagrajmy.example.net/" in mail.outbox[0].body

--- a/tests/unit/test_shadowban_service.py
+++ b/tests/unit/test_shadowban_service.py
@@ -50,6 +50,7 @@ class FakeRepo:
             event_slug=self._signup.event_slug,
             event_name=self._signup.event_name,
             session_title=self._signup.session_title,
+            sphere_domain=self._signup.sphere_domain,
             hits=[h for h in self._signup.hits if h.banned_user_id in signed_up_ids],
         )
 
@@ -83,6 +84,7 @@ def _signup(*hits):
         event_slug="con-2026",
         event_name="Con 2026",
         session_title="Deniable Game",
+        sphere_domain="con.example.net",
         hits=list(hits),
     )
 


### PR DESCRIPTION
## Problem

`DjangoUserNotifier._deliver` mailed `f"{body}\n\n{notification.url}"`, and every
`url` was a bare `reverse()` path. So the offer and held-seat emails — the ones
whose entire purpose is a clickable claim link — arrived as:

```
A spot opened up — claim it before 30 July 2026 21:00 …

/offer/<token>/claim/
```

Nothing to click, no host. Per `docs/plans/email-and-seat-claim-test-plan.md`
(risk 1, failure policy) that alone fails the production claim run, so the
claim / decline / expiry phases were pre-failed before anyone started them.

## Fix

Each notification now builds one absolute url at construction, from a host it
names explicitly:

- the session's sphere, looked up once (promoted, offered, offer-expired,
  party-enrolled, seat-held — both claim links included)
- the `sphere_domain` the DTO carries (printables reminder, shadowbanned signup)
- `settings.ROOT_DOMAIN` for a party invite, which belongs to no sphere

`_deliver` mails `notification.url` unchanged, exactly as before. The scheme
follows the link's own host — `http` for `localhost`, `https` otherwise — so
development and e2e links stay reachable without either environment knowing
about the other.

`ShadowbanSignupNotification` gained `sphere_domain` (as
`PrintablesReadyNotification` already had) because guessing the host from an
event slug picks the wrong sphere when two spheres reuse a slug — event slugs
are unique per sphere, not globally.

Side effect worth having: the printables reminder no longer hand-rolls its own
absolute url, and all eight notification kinds now render the same way in the
navbar. `href="{{ notification.url }}"` previously broke for seven of them when
an organizer opened the dropdown while browsing a different sphere's host.

## Trades taken deliberately

- **Persisted absolute urls are coupled to the current `Site.domain`.** Move a
  sphere to a new domain and historical notification links die. Previously only
  `PRINTABLES_READY` rows carried that risk; now all of them do. Accepted as the
  cost of in-app links that work from any host.
- **One indexed `Session → event → sphere → site` lookup per notification.**
  The cleaner endgame is carrying the host on `PromotionStateDTO` / `OfferDTO`,
  where `links/db/django/enrollment.py:126` and `:364` already join `event` and
  would make it free — and it would make a forgotten host a type error rather
  than a warning. Deferred: it touches the enrollment repos and mill that #708
  just changed, and this branch exists to unblock a production email test.
  Promotions are rare and small-batch.
- **`ROOT_DOMAIN` still defaults to `""`**, so a deploy that omits it would mail
  `https:///profile/parties/`. Deployment marks it required; not guarded here.

## Tests

`tests/integration/links/test_notification_email_links.py` — the offer link lands
on the session's sphere host (asserted on both the mail body and the stored row),
the shadowban link uses the host its DTO carries, a party invite links to the
root domain, a vanished session falls back to the root domain with a logged
warning, and a `localhost` host keeps `http`.

No UI change, so no screenshots. `mise run check` green, full suite green, and
`tingle stat --diff` shows no added debt.