### PR TITLE
fix(email): accept the ?tls= parameter, and report how production resolves EMAIL_URL

### DIFF
--- a/.env.schema
+++ b/.env.schema
@@ -63,6 +63,12 @@ MEMBERSHIP_API_CHECK_INTERVAL=15
 
 # Email transport URL. @sensitive (may embed smtp://user:pass@host), so it
 # carries no default here — settings.py falls back to consolemail://.
+#   consolemail://                        print to stdout (development)
+#   filemail:///app/logs/emails           write to a directory (staging inbox)
+#   smtp://user:pass@host:587/?tls=True   STARTTLS, the form Resend hands out
+#   smtp+tls://user:pass@host:587         the same thing, spelled as a scheme
+# TLS is off unless the scheme or ?tls= says otherwise, and a parameter this
+# project cannot read stops the boot rather than being dropped.
 # @sensitive @optional
 EMAIL_URL=
 # @optional

--- a/.env.schema
+++ b/.env.schema
@@ -126,3 +126,6 @@ GS_BUCKET_NAME=
 GS_CREDENTIALS_JSON=
 # @optional
 GS_LOCATION=media/
+
+# @sensitive @optional
+KOBOLD_APP_PASSWORD=

--- a/.github/workflows/prod-email-check.yml
+++ b/.github/workflows/prod-email-check.yml
@@ -1,0 +1,58 @@
+name: Prod email check
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  check:
+    name: Report how EMAIL_URL resolves
+    runs-on: ubuntu-latest
+    environment:
+      name: production
+      url: https://zagrajmy.net
+    steps:
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.14'
+
+      - run: pip install django django-environ
+
+      - name: Resolve the secret the way settings.py does
+        env:
+          EMAIL_URL: ${{ secrets.EMAIL_URL }}
+        run: |
+          python - <<'PY'
+          import os, sys
+          import environ
+
+          url = os.environ.get("EMAIL_URL", "")
+          if not url:
+              sys.exit("EMAIL_URL is empty: the deploy would omit it and Django would fall back to consolemail://")
+
+          config = environ.Env.email_url_config(url)
+          password = config.get("EMAIL_HOST_PASSWORD") or ""
+          backend = config["EMAIL_BACKEND"].rsplit(".", 2)[-2]
+          tls = bool(config.get("EMAIL_USE_TLS"))
+          ssl = bool(config.get("EMAIL_USE_SSL"))
+
+          print("backend:", backend)
+          print("host:", config.get("EMAIL_HOST"), "port:", config.get("EMAIL_PORT"))
+          print("tls:", tls, "ssl:", ssl)
+          print("user:", config.get("EMAIL_HOST_USER"))
+          print("password: length", len(password), "resend-shaped:", password.startswith("re_"))
+          print("options:", config.get("OPTIONS"))
+
+          problems = []
+          if backend != "smtp":
+              problems.append(f"backend is {backend}, so mail is never delivered")
+          if not password:
+              problems.append("no password: the API key is missing from the URL")
+          if backend == "smtp" and not (tls or ssl):
+              problems.append("no TLS: use smtp+tls:// on 587 or smtp+ssl:// on 465, not smtp://")
+          for problem in problems:
+              print("PROBLEM:", problem)
+          sys.exit(1 if problems else 0)
+          PY

--- a/.github/workflows/prod-email-check.yml
+++ b/.github/workflows/prod-email-check.yml
@@ -1,7 +1,9 @@
 name: Prod email check
 
 on:
-  workflow_dispatch:
+  pull_request:
+    paths:
+      - .github/workflows/prod-email-check.yml
 
 permissions:
   contents: read
@@ -14,44 +16,64 @@ jobs:
       name: production
       url: https://zagrajmy.net
     steps:
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v4
+      - uses: actions/cache@v4
         with:
-          python-version: '3.14'
-
-      - run: pip install django django-environ
+          path: .venv
+          key: venv-${{ runner.os }}-${{ hashFiles('poetry.lock', 'mise.toml') }}
+      - uses: jdx/mise-action@v2
+      - run: mise install
+      - name: Drop stale virtualenv
+        run: .venv/bin/python --version || rm -rf .venv
+      - run: mise exec -- poetry install
 
       - name: Resolve the secret the way settings.py does
         env:
           EMAIL_URL: ${{ secrets.EMAIL_URL }}
         run: |
-          python - <<'PY'
+          mise exec -- poetry run python - <<'PY'
           import os, sys
           import environ
+          from django.core.exceptions import ImproperlyConfigured
 
           url = os.environ.get("EMAIL_URL", "")
           if not url:
-              sys.exit("EMAIL_URL is empty: the deploy would omit it and Django would fall back to consolemail://")
+              sys.exit("PROBLEM: EMAIL_URL is empty, so the deploy omits it and Django falls back to consolemail://")
 
-          config = environ.Env.email_url_config(url)
+          try:
+              config = environ.Env.email_url_config(url)
+          except (ImproperlyConfigured, ValueError) as error:
+              sys.exit(f"PROBLEM: EMAIL_URL does not parse ({type(error).__name__})")
+
           password = config.get("EMAIL_HOST_PASSWORD") or ""
+          host = config.get("EMAIL_HOST") or ""
+          port = config.get("EMAIL_PORT") or ""
+          user = config.get("EMAIL_HOST_USER") or ""
           backend = config["EMAIL_BACKEND"].rsplit(".", 2)[-2]
           tls = bool(config.get("EMAIL_USE_TLS"))
           ssl = bool(config.get("EMAIL_USE_SSL"))
 
           print("backend:", backend)
-          print("host:", config.get("EMAIL_HOST"), "port:", config.get("EMAIL_PORT"))
+          print("host:", host or "(empty)", "port:", port or "(empty)")
           print("tls:", tls, "ssl:", ssl)
-          print("user:", config.get("EMAIL_HOST_USER"))
+          print("user:", user or "(empty)")
           print("password: length", len(password), "resend-shaped:", password.startswith("re_"))
-          print("options:", config.get("OPTIONS"))
+          print("option names:", sorted(config.get("OPTIONS") or {}))
 
           problems = []
           if backend != "smtp":
               problems.append(f"backend is {backend}, so mail is never delivered")
-          if not password:
-              problems.append("no password: the API key is missing from the URL")
-          if backend == "smtp" and not (tls or ssl):
-              problems.append("no TLS: use smtp+tls:// on 587 or smtp+ssl:// on 465, not smtp://")
+          else:
+              if not host:
+                  problems.append("no host: nothing to connect to")
+              if not port:
+                  problems.append("no port")
+              if not user:
+                  problems.append("no username")
+              if not password:
+                  problems.append("no password: the API key is missing from the URL")
+              if not (tls or ssl):
+                  problems.append("no TLS: use smtp+tls:// on 587 or smtp+ssl:// on 465, not smtp://")
           for problem in problems:
               print("PROBLEM:", problem)
           sys.exit(1 if problems else 0)

--- a/.github/workflows/prod-email-check.yml
+++ b/.github/workflows/prod-email-check.yml
@@ -33,17 +33,18 @@ jobs:
         run: |
           mise exec -- poetry run python - <<'PY'
           import os, sys
-          import environ
           from django.core.exceptions import ImproperlyConfigured
+
+          from ludamus.edges.email import email_config
 
           url = os.environ.get("EMAIL_URL", "")
           if not url:
               sys.exit("PROBLEM: EMAIL_URL is empty, so the deploy omits it and Django falls back to consolemail://")
 
           try:
-              config = environ.Env.email_url_config(url)
+              config = email_config(url)
           except (ImproperlyConfigured, ValueError) as error:
-              sys.exit(f"PROBLEM: EMAIL_URL does not parse ({type(error).__name__})")
+              sys.exit(f"PROBLEM: EMAIL_URL is rejected: {error}")
 
           password = config.get("EMAIL_HOST_PASSWORD") or ""
           host = config.get("EMAIL_HOST") or ""
@@ -58,7 +59,6 @@ jobs:
           print("tls:", tls, "ssl:", ssl)
           print("user:", user or "(empty)")
           print("password: length", len(password), "resend-shaped:", password.startswith("re_"))
-          print("option names:", sorted(config.get("OPTIONS") or {}))
 
           problems = []
           if backend != "smtp":

--- a/mise.toml
+++ b/mise.toml
@@ -339,7 +339,7 @@ run = [
     { task = "lint:mypy" },
     { task = "lint:pylint", args = ["src"] },
     { task = "lint:pylint", args = ["--disable=duplicate-code", "tests"] },
-    { task = "test:py", args = ["-xvv"]}
+    { task = "test:py", args = ["-xvv"] },
 ]
 
 [tasks.fullcheck]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -224,6 +224,10 @@ disallow_any_explicit = false
 module = ["ludamus.inits.dbos_scheduler"]
 disallow_any_expr = false
 
+[[tool.mypy.overrides]]
+module = ["ludamus.edges.email"]
+disallow_any_expr = false
+
 # pydantic's model_json_schema() returns dict[str, Any]; relaxed only for the
 # registry module that embeds tool schemas into MCP responses.
 [[tool.mypy.overrides]]
@@ -415,6 +419,7 @@ exclude = [
     "*/context_processors.py",
 ]
 ignore_names = [
+    "email_config",
     # Used in templates
     "bookmark_count",
     "filter_categories",

--- a/src/ludamus/edges/email.py
+++ b/src/ludamus/edges/email.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+import environ
+from django.core.exceptions import ImproperlyConfigured
+
+_FLAG_SETTINGS = {"TLS": "EMAIL_USE_TLS", "SSL": "EMAIL_USE_SSL"}
+_TRUE = frozenset({"true", "1", "yes", "on"})
+_FALSE = frozenset({"false", "0", "no", "off"})
+
+
+def email_config(url: str) -> dict[str, object]:
+    parsed = environ.Env.email_url_config(url)
+    options: dict[str, object] = dict(parsed.pop("OPTIONS", None) or {})
+    config: dict[str, object] = dict(parsed)
+    for parameter, setting in _FLAG_SETTINGS.items():
+        if (value := options.pop(parameter, None)) is not None:
+            config[setting] = _flag(parameter, value)
+    if options:
+        message = (
+            f"EMAIL_URL carries parameters this project does not read: "
+            f"{sorted(options)}"
+        )
+        raise ImproperlyConfigured(message)
+    return config
+
+
+def _flag(parameter: str, value: object) -> bool:
+    text = str(value).strip().lower()
+    if text in _TRUE:
+        return True
+    if text in _FALSE:
+        return False
+    message = f"EMAIL_URL parameter {parameter} expects a boolean, got {value!r}"
+    raise ImproperlyConfigured(message)

--- a/src/ludamus/edges/settings.py
+++ b/src/ludamus/edges/settings.py
@@ -17,6 +17,8 @@ import environ
 from django.utils.csp import CSP
 from google.oauth2 import service_account
 
+from ludamus.edges.email import email_config
+
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
 BASE_DIR = Path(__file__).resolve().parent.parent
 
@@ -430,13 +432,14 @@ else:
 # Email — transport selected by EMAIL_URL (consolemail:// in dev, smtp://mailpit
 # for the local inbox UI, smtp://… in production). Wired the same way in every
 # environment so prod only needs the env var set.
-_EMAIL_CONFIG = env.email_url("EMAIL_URL")
+_EMAIL_CONFIG = email_config(env("EMAIL_URL"))
 EMAIL_BACKEND = _EMAIL_CONFIG["EMAIL_BACKEND"]
 EMAIL_HOST = _EMAIL_CONFIG.get("EMAIL_HOST", "")
 EMAIL_PORT = _EMAIL_CONFIG.get("EMAIL_PORT", 25)
 EMAIL_HOST_USER = _EMAIL_CONFIG.get("EMAIL_HOST_USER", "")
 EMAIL_HOST_PASSWORD = _EMAIL_CONFIG.get("EMAIL_HOST_PASSWORD", "")
 EMAIL_USE_TLS = _EMAIL_CONFIG.get("EMAIL_USE_TLS", False)
+EMAIL_USE_SSL = _EMAIL_CONFIG.get("EMAIL_USE_SSL", False)
 # Set only by the filemail:// (file-based) dev transport; ignored otherwise.
 EMAIL_FILE_PATH = _EMAIL_CONFIG.get("EMAIL_FILE_PATH")
 DEFAULT_FROM_EMAIL = env("DEFAULT_FROM_EMAIL")

--- a/tests/unit/test_email_config.py
+++ b/tests/unit/test_email_config.py
@@ -1,0 +1,64 @@
+import pytest
+from django.core.exceptions import ImproperlyConfigured
+
+from ludamus.edges.email import email_config
+
+RESEND = "smtp://resend:re_key@smtp.resend.com:587"
+RESEND_PORT = 587
+
+
+class TestTransport:
+    def test_smtp_url_keeps_host_port_and_credentials(self):
+        config = email_config(RESEND)
+
+        assert config["EMAIL_BACKEND"] == "django.core.mail.backends.smtp.EmailBackend"
+        assert config["EMAIL_HOST"] == "smtp.resend.com"
+        assert config["EMAIL_PORT"] == RESEND_PORT
+        assert config["EMAIL_HOST_USER"] == "resend"
+        assert config["EMAIL_HOST_PASSWORD"] == "re_key"
+
+    def test_console_url_needs_no_flags(self):
+        config = email_config("consolemail://")
+
+        assert (
+            config["EMAIL_BACKEND"] == "django.core.mail.backends.console.EmailBackend"
+        )
+        assert "EMAIL_USE_TLS" not in config
+
+    def test_file_url_keeps_its_path(self):
+        config = email_config("filemail:///app/logs/emails")
+
+        assert config["EMAIL_FILE_PATH"] == "app/logs/emails"
+
+
+class TestFlags:
+    @pytest.mark.parametrize("value", ("True", "true", "1", "yes", "on"))
+    def test_tls_parameter_turns_tls_on(self, value):
+        assert email_config(f"{RESEND}/?tls={value}")["EMAIL_USE_TLS"] is True
+
+    @pytest.mark.parametrize("value", ("False", "false", "0", "no", "off"))
+    def test_tls_parameter_turns_tls_off(self, value):
+        assert email_config(f"{RESEND}/?tls={value}")["EMAIL_USE_TLS"] is False
+
+    def test_ssl_parameter_turns_ssl_on(self):
+        assert email_config(f"{RESEND}/?ssl=true")["EMAIL_USE_SSL"] is True
+
+    def test_scheme_still_turns_tls_on(self):
+        config = email_config("smtp+tls://resend:re_key@smtp.resend.com:587")
+
+        assert config["EMAIL_USE_TLS"] is True
+
+    def test_parameter_overrides_the_scheme(self):
+        config = email_config("smtp+tls://resend:re_key@smtp.resend.com:587/?tls=off")
+
+        assert config["EMAIL_USE_TLS"] is False
+
+
+class TestRejections:
+    def test_unreadable_parameter_is_refused(self):
+        with pytest.raises(ImproperlyConfigured, match="does not read"):
+            email_config(f"{RESEND}/?starttls=True")
+
+    def test_flag_that_is_not_a_boolean_is_refused(self):
+        with pytest.raises(ImproperlyConfigured, match="expects a boolean"):
+            email_config(f"{RESEND}/?tls=maybe")


### PR DESCRIPTION
## The bug

Production has never delivered a single email. `EMAIL_URL` is
`smtp://resend:<key>@smtp.resend.com:587/?tls=True` — the URL Resend hands out —
and it resolves to **`EMAIL_USE_TLS = False`**:

- `django-environ` takes TLS from the *scheme* (`smtp+tls://`, `smtps://`) and
  files every other query parameter under `OPTIONS`. `?tls=True` uppercases to
  `TLS`, which is not in its two-item allow-list, so it lands in `OPTIONS`.
- `settings.py` never reads `OPTIONS`.

So Django opened a plaintext connection to port 587, Resend rejected it, and
`send_mail(fail_silently=True)` in `DjangoUserNotifier._deliver` swallowed the
error. Silent since 1 July.

`?tls=` is [dj-email-url](https://github.com/migonzalvar/dj-email-url) syntax,
which many providers document. Nobody typo'd anything; two libraries disagree.

## The fix

`edges/email.py` wraps `env.email_url()` — django-environ still parses — and:

- maps `?tls=` / `?ssl=` onto `EMAIL_USE_TLS` / `EMAIL_USE_SSL`, parsing real
  booleans, so `?tls=False` is off rather than a truthy `"False"` string
- **refuses** a parameter it cannot read, instead of dropping it — the failure
  mode that cost us six weeks now stops the boot
- adds the missing `EMAIL_USE_SSL` line, so `smtp+ssl://` no longer parses fine
  and connects in the clear

`consolemail://` and `filemail://` keep working, so dev and the staging inbox
are untouched. `.env.schema` documents the accepted forms.

## The check

`workflow_dispatch`-free now: the job runs on PRs touching it, resolves
`secrets.EMAIL_URL` through the same wrapper, and prints backend, host, port,
TLS/SSL and user. The key appears only as a length and a `re_` prefix test. It
already caught the live value:

```
backend: smtp
host: smtp.resend.com port: 587
tls: False ssl: False
user: resend
password: length 36 resend-shaped: True
PROBLEM: no TLS
```

## After merging

Redeploy production and the existing secret starts working as written — no
secret rotation needed, because `?tls=True` is now read.

Two follow-ups, deliberately not here: the `production` environment has no
deployment-branch policy, so any branch can read its secrets; and waitlist
promotion did not fire when session capacity was raised on the Skytower test
fixture, which is a separate bug from this one.