### PR TITLE
fix(email): stop documenting the URL form that drops TLS

### DIFF
--- a/.env.schema
+++ b/.env.schema
@@ -62,8 +62,10 @@ MEMBERSHIP_API_TIMEOUT=30
 MEMBERSHIP_API_CHECK_INTERVAL=15
 
 # Email transport URL. @sensitive (may embed smtp://user:pass@host), so it
-# carries no default here — settings.py falls back to consolemail://.
-# @sensitive @optional
+# carries no default here — settings.py falls back to consolemail://. TLS comes
+# from the scheme (smtp+tls://…:587), never from a query parameter:
+# django-environ files those under OPTIONS, which nothing reads.
+# @sensitive @optional @type=string(matches=/^[^?]*$/)
 EMAIL_URL=
 # @optional
 DEFAULT_FROM_EMAIL="Zagrajmy <noreply@zagrajmy.net>"

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Outgoing email is configured by the `EMAIL_URL` env var (django-environ):
   end-to-end testing of enrollment/offer notifications: point the server at a
   directory and assert on the written `.log` files.
 
-Production sets `EMAIL_URL=smtp://user:pass@host:587/?tls=True`.
+Production sets `EMAIL_URL=smtp+tls://user:pass@host:587`.
 
 ### Deployment
 

--- a/src/ludamus/edges/settings.py
+++ b/src/ludamus/edges/settings.py
@@ -53,7 +53,7 @@ env = environ.Env(
     DEBUG=(bool, False),
     # Email transport: consolemail:// (default), smtp://mailpit:1025 for the
     # local Mailpit inbox, filemail:///path for file capture, or
-    # smtp://user:pass@host:587/?tls=True in production.
+    # smtp+tls://user:pass@host:587 in production.
     EMAIL_URL=(str, "consolemail://"),
     DEFAULT_FROM_EMAIL=(str, "Zagrajmy <noreply@zagrajmy.net>"),
     # Scheduler mode: "dbos" (default; durable offer timers plus the
@@ -428,8 +428,8 @@ else:
     }
 
 # Email — transport selected by EMAIL_URL (consolemail:// in dev, smtp://mailpit
-# for the local inbox UI, smtp://… in production). Wired the same way in every
-# environment so prod only needs the env var set.
+# for the local inbox UI, smtp+tls://… in production). Wired the same way in
+# every environment so prod only needs the env var set.
 _EMAIL_CONFIG = env.email_url("EMAIL_URL")
 EMAIL_BACKEND = _EMAIL_CONFIG["EMAIL_BACKEND"]
 EMAIL_HOST = _EMAIL_CONFIG.get("EMAIL_HOST", "")


### PR DESCRIPTION
## What happened

Production has never delivered an email. `EMAIL_URL` was
`smtp://resend:<key>@smtp.resend.com:587/?tls=True`, which resolves to
`EMAIL_USE_TLS = False`: `django-environ` takes TLS from the *scheme*
(`smtp+tls://`, `smtps://`) and files every other query parameter under
`OPTIONS`, which `settings.py` never reads. Django then connected in the clear
to port 587, Resend rejected it, and `send_mail(fail_silently=True)` swallowed
the error.

That URL was not a mistake by whoever set the secret. **We documented it**:

```python
# settings.py:56-58
# Email transport: consolemail:// (default), smtp://mailpit:1025 for the
# local Mailpit inbox, filemail:///path for file capture, or
# smtp://user:pass@host:587/?tls=True in production.
```

Someone followed the comment and got a silently dead transport.

## The change

Both comments now name `smtp+tls://user:pass@host:587`, and `.env.schema`
refuses a query string:

```
# @sensitive @optional @type=string(matches=/^[^?]*$/)
```

`deploy-production.yml` already validates with `varlock load` before shipping,
so the bad URL now fails the deploy rather than reaching a container:

```
❌ EMAIL_URL  🔐sensitive
   - Value must match regex "/^[^?]*$/"
💥 Resolved config/env did not pass validation 💥
```

Verified both ways: the old value is rejected, `smtp+tls://…:587` passes.

## Not in scope

An earlier attempt (#734, now a draft) made the app read `?tls=` so Resend's
URL would work verbatim — 197 lines of parser, tests and CI to accept a form we
should not be recommending. Rejecting it at the schema costs three lines and
fails earlier. The secret itself is being changed to `smtp+tls://` by hand.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated email configuration guidance to use the `smtp+tls://` format.
  * Clarified `EMAIL_URL` configuration requirements and examples.
  * Added validation guidance indicating that query parameters are not supported in the email URL.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->