### PR TITLE
feat(enrollment): say why a session promoted nobody

### DIFF
--- a/src/ludamus/links/db/django/enrollment.py
+++ b/src/ludamus/links/db/django/enrollment.py
@@ -10,6 +10,7 @@ reads and participation mutations.
 
 from __future__ import annotations
 
+import logging
 from datetime import UTC, datetime, timedelta
 from typing import TYPE_CHECKING
 
@@ -115,6 +116,9 @@ class EnrollmentParticipationRepository(EnrollmentParticipationRepositoryProtoco
         )
 
 
+logger = logging.getLogger(__name__)
+
+
 class ParticipationPromotionRepository:
     def lock_and_read_state(self, session_id: int) -> PromotionStateDTO | None:
         try:
@@ -127,13 +131,18 @@ class ParticipationPromotionRepository:
                 .get(id=session_id)
             )
         except Session.DoesNotExist:
+            logger.info("Session %s is gone, so nobody can be promoted", session_id)
             return None
         # Promotion only applies to scheduled sessions (those with an agenda item).
         if not hasattr(session, "agenda_item"):
+            logger.info("Session %s is not on the timetable yet", session_id)
             return None
         event = session.event
 
         if (config := event.get_most_liberal_config(session)) is None:
+            logger.info(
+                "Session %s sits outside every active enrollment window", session_id
+            )
             return None
 
         category = session.category

--- a/src/ludamus/mills/enrollment.py
+++ b/src/ludamus/mills/enrollment.py
@@ -9,6 +9,7 @@ the ticket API.
 
 from __future__ import annotations
 
+import logging
 import math
 import secrets
 import sys
@@ -216,6 +217,9 @@ class EnrollmentSettingsService(EnrollmentSettingsServiceProtocol):
             raise InvalidEnrollmentWindowError
 
 
+logger = logging.getLogger(__name__)
+
+
 class WaitlistPromotionService:
     def __init__(
         self,
@@ -241,8 +245,20 @@ class WaitlistPromotionService:
 
         with self._transaction.atomic():
             if (state := self._participations.lock_and_read_state(session_id)) is None:
+                logger.info(
+                    "Session %s promotes nobody: it is gone, unscheduled, or "
+                    "outside every enrollment window",
+                    session_id,
+                )
                 return result
             if not (parties := select_promotable_parties(state)):
+                logger.info(
+                    "Session %s promotes nobody: %s seats free, %s waiting, mode %s",
+                    session_id,
+                    state.available_seats,
+                    len(state.waiting),
+                    state.promotion_mode.value,
+                )
                 return result
             if state.promotion_mode == PromotionMode.AUTO:
                 self._confirm(parties, state, result, promotions)

--- a/tests/integration/web/chronology/test_promotion_diagnostics.py
+++ b/tests/integration/web/chronology/test_promotion_diagnostics.py
@@ -1,0 +1,68 @@
+import logging
+
+import pytest
+
+from ludamus.inits.services import Services
+from ludamus.links.db.django.models import (
+    SessionParticipation,
+    SessionParticipationStatus,
+)
+from ludamus.pacts.legacy import PromotionMode
+from tests.integration.conftest import ProposalCategoryFactory
+
+
+def _service():
+    return Services().waitlist_promotion
+
+
+@pytest.mark.usefixtures("enrollment_config", "agenda_item")
+class TestPresenterlessSession:
+    def test_offer_reaches_a_waiter(
+        self, session, event, waiter, django_capture_on_commit_callbacks
+    ):
+        session.participants_limit = 2
+        session.presenter = None
+        session.category = ProposalCategoryFactory(
+            event=event, promotion_mode=PromotionMode.OFFER_CLAIM.value
+        )
+        session.save()
+        participation = SessionParticipation.objects.create(
+            session=session, user=waiter, status=SessionParticipationStatus.WAITING
+        )
+
+        with django_capture_on_commit_callbacks(execute=True):
+            result = _service().fill_freed_seats(session_id=session.pk)
+
+        participation.refresh_from_db()
+        assert result.offered == [participation.pk]
+        assert participation.status == SessionParticipationStatus.OFFERED.value
+
+
+class TestSilentSkipsAreLogged:
+    def test_unscheduled_session_says_so(self, session, caplog):
+        with caplog.at_level(logging.INFO):
+            result = _service().fill_freed_seats(session_id=session.pk)
+
+        assert not result.offered
+        assert "not on the timetable yet" in caplog.text
+
+    @pytest.mark.usefixtures("agenda_item")
+    def test_session_outside_every_window_says_so(self, session, caplog):
+        with caplog.at_level(logging.INFO):
+            result = _service().fill_freed_seats(session_id=session.pk)
+
+        assert not result.promoted
+        assert "outside every active enrollment window" in caplog.text
+
+    @pytest.mark.usefixtures("enrollment_config", "agenda_item")
+    def test_full_session_reports_seats_and_waiters(self, session, waiter, caplog):
+        session.participants_limit = 1
+        session.save()
+        SessionParticipation.objects.create(
+            session=session, user=waiter, status=SessionParticipationStatus.CONFIRMED
+        )
+
+        with caplog.at_level(logging.INFO):
+            _service().fill_freed_seats(session_id=session.pk)
+
+        assert "0 seats free, 0 waiting" in caplog.text


### PR DESCRIPTION
## Why

On production, `[PROD TEST] Claim` sits at **0/3 capacity with one person on the
waiting list**. Raising the capacity calls `fill_freed_seats`
(`proposals.py:1006-1010`), the call runs, and nothing happens: no offer, no
notification row, no email, no log line. Two separate triggers (a freed seat and
two capacity raises) produced the same silence.

`fill_freed_seats` gives up in five places without saying anything:

| where | condition |
| --- | --- |
| `enrollment.py:134` | session row is gone |
| `enrollment.py:139` | session is not on the timetable |
| `enrollment.py:145` | no active enrollment window covers it |
| `mills/enrollment.py:247` | `lock_and_read_state` returned `None` |
| `mills/enrollment.py:254` | `select_promotable_parties` selected nobody |

From outside, all five look identical: an empty seat and somebody waiting for
it. Telling them apart currently requires a database shell.

## What this changes

Each branch logs its reason, and the last one logs the numbers it decided on:

```
Session 2827 promotes nobody: 3 seats free, 1 waiting, mode offer_claim
Session 2827 is not on the timetable yet
Session 2827 sits outside every active enrollment window
```

That is the difference between "the trigger never ran", "the window lapsed" and
"the waiter was ruled ineligible" — the question I could not answer today
without shell access to the box.

## What this does not change

**It does not fix the production symptom**, because I cannot yet name the
defect. Reproduced locally with the same shape — presenterless session,
party-leading waiter, `OFFER_CLAIM` category, active window, free seats — and
promotion works (`test_offer_reaches_a_waiter`, plus the pre-existing
`test_offer_mode_holds_seat_and_notifies`). Ruled out by reading the code
against what production shows: presenter, shadowban, `available_seats`,
membership allowances, event-scoped conflicts, and the trigger's own condition
(it compares against the pre-update value, so it did fire).

The next step needs one command on the box, which I could not run today:

```
docker compose --env-file .env.local -p ludamus -f docker/compose/prod.yaml exec -T web \
  run dj shell -c "from ludamus.links.db.django.models import Session; s = Session.objects.get(pk=2827); print(s.participants_limit, s.presenter_id, s.enrolled_count); [print(p.pk, p.user_id, p.status, p.party_id) for p in s.session_participations.all()]"
```

With this merged, the log line answers most of that on its own.

## Tests

`tests/integration/web/chronology/test_promotion_diagnostics.py` — each skip
reports its reason, plus coverage for a presenterless session, the shape the
panel creates (`proposals.py:895`) and one the factories never build.