### PR TITLE
Refine session modal view-transition animations

### DIFF
--- a/PAPERCUTS.md
+++ b/PAPERCUTS.md
@@ -234,3 +234,16 @@ If you fix a papercut, remove it.
   django_vite's cached manifest kept serving deleted hashed JS, pages silently
   lost their scripts until a manual server restart. Fixed test:e2e:serve to
   watch manifest.json and bounce itself.
+- 2026-07-31: sandbox: 'mise install' wedges on pipx:shellcheck-py@0.11.0 /
+  hadolint-py@2.14.0 (PyPI only ships .0.1 wrapper revs) and session-start.sh's
+  trim-retry did not self-heal, so every 'mise run' aborted until I exported
+  MISE_DISABLE_TOOLS=shellcheck,hadolint.
+- 2026-07-31: sandbox: /opt/pw-browsers lags the pinned @playwright/test 1.58.2
+  (has chromium-1194, needs 1208 / webkit-2248), and session-start.sh reported
+  'Playwright install failed'. The whole e2e suite fails with "Executable
+  doesn't exist" until you run npx playwright install --with-deps chromium
+  firefox webkit by hand.
+- 2026-07-31: 'mise run test:py' resolves pytest from PATH, so a uv-installed
+  ~/.local/bin/pytest shadows .venv/bin/pytest and the run dies with
+  ModuleNotFoundError: No module named 'django'. Took a while to spot because
+  the traceback points at tests/conftest.py, not at the wrong interpreter.

--- a/src/ludamus/client/src/modal.css
+++ b/src/ludamus/client/src/modal.css
@@ -130,12 +130,18 @@
   animation-timing-function: var(--vt-morph-ease);
 }
 
-/* The title flies through the tab bar on its way to the header. Hold the bar
-   back until the title has cleared, so the two never render on top of one
-   another. */
+/* Static labels the title flies through on its way to the header. Hold each
+   back until the title has cleared it, so the two never render on top of one
+   another, and stagger them so the modal's chrome settles before its body
+   copy does. */
 ::view-transition-new(morph-tabs) {
   animation: vt-chrome-in calc(var(--vt-morph-duration) * 0.5) var(--vt-morph-ease)
     calc(var(--vt-morph-duration) * 0.35) both;
+}
+
+::view-transition-new(morph-desc-label) {
+  animation: vt-chrome-in calc(var(--vt-morph-duration) * 0.4) var(--vt-morph-ease)
+    calc(var(--vt-morph-duration) * 0.5) both;
 }
 
 @keyframes vt-chrome-in {
@@ -266,6 +272,7 @@
   ::view-transition-old(morph-avatar),
   ::view-transition-new(morph-avatar),
   ::view-transition-new(morph-tabs),
+  ::view-transition-new(morph-desc-label),
   ::view-transition-new(morph-footer) {
     animation: none;
   }

--- a/src/ludamus/client/src/modal.css
+++ b/src/ludamus/client/src/modal.css
@@ -108,11 +108,40 @@
   mix-blend-mode: normal;
 }
 
+/* Card content that the modal re-renders elsewhere (or drops) is cut the moment
+   the morph starts. Without this the card's tag pills and its meta row keep
+   painting under the description as it grows past them — the container snapshot
+   they belong to fades over 55% of the morph, which is long enough to read. */
 ::view-transition-old(morph-title),
 ::view-transition-old(morph-host),
-::view-transition-old(morph-desc) {
+::view-transition-old(morph-desc),
+::view-transition-old(morph-tags),
+::view-transition-old(morph-meta),
+::view-transition-old(morph-time) {
   animation: none;
   opacity: 0;
+}
+
+/* Modal chrome with no card counterpart is captured as a new-only group, which
+   the spec appends after every paired group — so these paint above the morphing
+   description and, being opaque, finally occlude it. */
+::view-transition-new(morph-footer) {
+  animation-duration: var(--vt-morph-duration);
+  animation-timing-function: var(--vt-morph-ease);
+}
+
+/* The title flies through the tab bar on its way to the header. Hold the bar
+   back until the title has cleared, so the two never render on top of one
+   another. */
+::view-transition-new(morph-tabs) {
+  animation: vt-chrome-in calc(var(--vt-morph-duration) * 0.5) var(--vt-morph-ease)
+    calc(var(--vt-morph-duration) * 0.35) both;
+}
+
+@keyframes vt-chrome-in {
+  from {
+    opacity: 0;
+  }
 }
 
 ::view-transition-old(session-morph) {
@@ -231,8 +260,13 @@
   ::view-transition-old(morph-title),
   ::view-transition-old(morph-host),
   ::view-transition-old(morph-desc),
+  ::view-transition-old(morph-tags),
+  ::view-transition-old(morph-meta),
+  ::view-transition-old(morph-time),
   ::view-transition-old(morph-avatar),
-  ::view-transition-new(morph-avatar) {
+  ::view-transition-new(morph-avatar),
+  ::view-transition-new(morph-tabs),
+  ::view-transition-new(morph-footer) {
     animation: none;
   }
 }

--- a/src/ludamus/templates/chronology/_room_lane_tile.html
+++ b/src/ludamus/templates/chronology/_room_lane_tile.html
@@ -16,7 +16,9 @@
            aria-controls="session-{{ data.session.pk }}">
             <span class="sr-only">{% blocktranslate with title=data.session.title %}Open details for {{ title }}{% endblocktranslate %}</span>
         </a>
-        <h4 class="text-sm font-semibold leading-snug text-foreground"
+        {# w-fit keeps the morph group's box on the title text rather than the #}
+        {# tile column — see _session_card.html. #}
+        <h4 class="w-fit text-sm font-semibold leading-snug text-foreground"
             data-morph="title">{{ data.session.title }}</h4>
         <div class="flex min-w-0 items-center gap-0.75 text-xs text-foreground-muted">
             <span class="shrink-0" data-morph="avatar">
@@ -31,7 +33,8 @@
                 · <span class="font-medium text-coral-600 dark:text-coral-400">{{ data.session.min_age }}+</span>
             {% endif %}
         </span>
-        <div class="mt-auto flex items-center justify-between gap-2 pt-0.5 text-xs">
+        <div class="mt-auto flex items-center justify-between gap-2 pt-0.5 text-xs"
+             data-morph="meta">
             <span class="min-w-0 truncate text-foreground-muted">{% include "chronology/_session_availability.html" %}</span>
             {% include "chronology/_bookmark_toggle.html" with wrapper_class="shrink-0" %}
         </div>

--- a/src/ludamus/templates/chronology/_session_card.html
+++ b/src/ludamus/templates/chronology/_session_card.html
@@ -23,7 +23,10 @@
         {% endif %}
         <div class="relative z-10 flex min-h-0 flex-1 flex-col px-5 pb-5 pointer-events-none **:pointer-events-none pt-4">
             <header>
-                <h3 class="text-3xl font-bold leading-tight tracking-tight text-foreground-primary"
+                {# w-fit keeps the morph group's box on the title text rather than #}
+                {# the card column, so the modal title snapshot is not scaled up on #}
+                {# the transition's first frame. #}
+                <h3 class="w-fit text-3xl font-bold leading-tight tracking-tight text-foreground-primary"
                     data-morph="title">{{ data.session.title }}</h3>
                 <div class="flex items-center gap-2.5 my-3.5 min-w-0 flex-nowrap overflow-hidden">
                     <span class="shrink-0" data-morph="avatar">
@@ -50,9 +53,10 @@
                    data-morph="desc"
                    data-session-description>{{ data.session.description }}</p>
             {% endif %}
-            <div class="relative">{% include "chronology/session_tags.html" %}</div>
+            <div class="relative" data-morph="tags">{% include "chronology/session_tags.html" %}</div>
             <div class="flex-1"></div>
-            <div class="mt-auto pt-4 flex items-center justify-between gap-3 min-w-0">
+            <div class="mt-auto pt-4 flex items-center justify-between gap-3 min-w-0"
+                 data-morph="meta">
                 <div class="flex items-center gap-1.5 text-sm text-foreground-secondary min-w-0 overflow-hidden">
                     {% if data.location_label %}
                         {% icon "map-pin" class="size-4 shrink-0 text-foreground-muted/80" variant="mini" %}

--- a/src/ludamus/templates/chronology/parts/session-modal.html
+++ b/src/ludamus/templates/chronology/parts/session-modal.html
@@ -19,7 +19,12 @@
     <div class="flex-auto min-h-0 flex flex-col overflow-hidden"
          data-session-tabs="{{ data.session.pk }}">
         <!-- Tabs -->
-        <div class="tab-list shrink-0" role="tablist">
+        {# data-morph makes the bar its own view-transition group so it can fade #}
+        {# in after the card title has flown past it; bg-bg-secondary (the modal #}
+        {# surface colour, so no static change) keeps that group opaque. #}
+        <div class="tab-list shrink-0 bg-bg-secondary"
+             role="tablist"
+             data-morph="tabs">
             <button role="tab"
                     aria-selected="true"
                     aria-controls="info-{{ data.session.pk }}"
@@ -72,7 +77,9 @@
                     <!-- Description -->
                     <div class="mb-6">
                         <h3 class="font-semibold mb-2 text-foreground-secondary">{% translate "About this session" %}</h3>
-                        <div class="prose prose-sm dark:prose-invert max-w-none text-foreground prose-p:text-foreground"
+                        {# leading-5 matches the card excerpt's text-sm leading, so #}
+                        {# the description keeps its rhythm across the morph. #}
+                        <div class="prose prose-sm dark:prose-invert max-w-none text-foreground prose-p:text-foreground prose-p:leading-5 prose-li:leading-5"
                              data-morph="desc">{{ data.session.description|render_markdown }}</div>
                     </div>
                 {% endif %}
@@ -227,7 +234,11 @@
     {% endif %}
     {% if data.is_enrollment_available or data.can_edit %}
         <!-- Footer -->
-        <div class="px-6 py-4 flex items-center justify-between gap-2 border-t border-border shrink-0"
+        {# data-morph + the modal surface colour give the footer its own opaque #}
+        {# view-transition group, so the description no longer paints over the #}
+        {# enroll button while it grows into place. #}
+        <div class="px-6 py-4 flex items-center justify-between gap-2 border-t border-border shrink-0 bg-bg-secondary"
+             data-morph="footer"
              data-session-footer="{{ data.session.pk }}">
             <div>
                 {% if data.can_edit %}

--- a/src/ludamus/templates/chronology/parts/session-modal.html
+++ b/src/ludamus/templates/chronology/parts/session-modal.html
@@ -79,7 +79,8 @@
                 {% if data.session.description %}
                     <!-- Description -->
                     <div class="mb-6">
-                        <h3 class="font-semibold mb-2 text-foreground-secondary">{% translate "About this session" %}</h3>
+                        <h3 class="font-semibold mb-2 text-foreground-secondary"
+                            data-morph="desc-label">{% translate "About this session" %}</h3>
                         {# leading-5 matches the card excerpt's text-sm leading, so #}
                         {# the description keeps its rhythm across the morph. #}
                         <div class="prose prose-sm dark:prose-invert max-w-none text-foreground prose-p:text-foreground prose-p:leading-5 prose-li:leading-5"

--- a/src/ludamus/templates/chronology/parts/session-modal.html
+++ b/src/ludamus/templates/chronology/parts/session-modal.html
@@ -55,7 +55,10 @@
                     <span class="shrink-0" data-morph="avatar">
                         {% include "components/avatar.html" with user=data.presenter size="size-10" %}
                     </span>
-                    <div class="flex items-center gap-3 flex-wrap min-w-0">
+                    {# flex-1 zeroes this group's flex basis so the outer row never #}
+                    {# wraps it whole — a long room path breaks inside the group, #}
+                    {# under the name, instead of orphaning the avatar on its own row. #}
+                    <div class="flex flex-1 items-center gap-3 flex-wrap min-w-0">
                         <div class="font-medium text-foreground" data-morph="host">{{ data.presenter.full_name }}</div>
                         {% if data.location_label %}
                             <span class="flex items-center gap-1.5 text-sm min-w-0 text-foreground-muted">

--- a/tests/e2e/tests/event-details.spec.ts
+++ b/tests/e2e/tests/event-details.spec.ts
@@ -86,6 +86,48 @@ test.describe("Event detail page", () => {
     await expect(card).not.toHaveClass(/session-suppressed/);
   });
 
+  // Whether the morph *feels* right is not assertable; that the modal's chrome
+  // still animates on its own delayed groups is. Losing those groups is what
+  // put the enroll footer under the growing description and crossed the tab bar
+  // with the flying title.
+  test("modal chrome morphs on its own groups, staggered behind the title", async ({ page }) => {
+    const supportsViewTransitions = await page.evaluate(() => "startViewTransition" in document);
+    test.skip(!supportsViewTransitions, "Browser does not implement the View Transition API");
+
+    // Stretch the morph so its animations are readable while it runs.
+    await page.addStyleTag({
+      content: ":root { --vt-morph-duration: 5s; --vt-morph-exit-duration: 5s; }",
+    });
+    await page.getByRole("link", { name: "Open details for Mega Strategy Lab" }).click();
+
+    const pseudoOf = (name: string) => `::view-transition-new(morph-${name})`;
+    await page.waitForFunction(
+      (pseudo) =>
+        document
+          .getAnimations()
+          .some((a) => (a.effect as KeyframeEffect | null)?.pseudoElement === pseudo),
+      pseudoOf("tabs"),
+    );
+
+    const delays = await page.evaluate(() => {
+      const entries: [string, number][] = [];
+      for (const animation of document.getAnimations()) {
+        const effect = animation.effect as KeyframeEffect | null;
+        const pseudo = effect?.pseudoElement;
+        if (effect && pseudo?.startsWith("::view-transition-new(morph-")) {
+          entries.push([pseudo, Number(effect.getComputedTiming().delay)]);
+        }
+      }
+      return Object.fromEntries(entries);
+    });
+
+    // The footer has to be opaque from the first frame to occlude the
+    // description; the labels the title flies past must not be.
+    expect(delays[pseudoOf("footer")]).toBe(0);
+    expect(delays[pseudoOf("tabs")]).toBeGreaterThan(0);
+    expect(delays[pseudoOf("desc-label")]).toBeGreaterThan(delays[pseudoOf("tabs")]);
+  });
+
   test("mobile session modal closes on iOS tap (touchmove not cancelled)", async ({
     browser,
     browserName,


### PR DESCRIPTION
Improves the View Transition API animations when morphing from session cards to the modal, ensuring chrome elements (tabs, labels, footer) don't paint over the expanding description and that the visual hierarchy settles smoothly.

<img width="1824" height="440" alt="morphchromestagger" src="https://github.com/user-attachments/assets/73abe2f4-1476-4af1-beda-dd834247e6d7" />

.mp4 upload doesn't work so I'm attaching it on Discord

## Changes

- **Card snapshot groups**: Added `data-morph` markers to tags, meta row, and time elements in the card so they fade out immediately when the morph starts, preventing them from painting under the growing description.

- **Modal chrome layering**: Wrapped the footer in its own opaque view-transition group (`data-morph="footer"`) with the modal's surface color, so it occludes the description as it expands. Added the tabs bar and description label as separate groups that fade in on staggered delays, keeping them from rendering on top of the flying title.

- **New keyframe**: Added `vt-chrome-in` to fade in chrome elements without moving them, paired with calculated animation delays so tabs settle before the description label.

- **Layout fixes**: 
  - Added `w-fit` to card and tile titles so their morph groups box only the text, not the full column width (prevents scaling artifacts on the first frame).
  - Added `flex-1` to the host info wrapper so long room paths break inside the group instead of orphaning the avatar.
  - Added `leading-5` to description prose so text rhythm is preserved across the morph.
  - Added `bg-bg-secondary` to tabs and footer to keep those groups opaque during the transition.

- **Reduced motion**: Updated the prefers-reduced-motion query to disable animations on all new groups.

- **Documentation**: Added inline comments explaining the morph group strategy and layout constraints.

## Implementation notes

The staggered fade-in timing (tabs at 35% of morph duration, description label at 50%) ensures the modal's structural chrome settles before body copy, creating a sense of hierarchy. The `w-fit` constraint on titles is subtle but critical — without it, the snapshot's bounding box includes the full card column, which gets scaled up on the transition's first frame, creating a jarring jump.

https://claude.ai/code/session_019NzmawjqyFCsQp8RkcgpB9

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Improved session and room tile transitions for smoother modal opening and navigation.
  * Added staggered animations for modal tabs, descriptions, and footer content.
  * Improved modal layout for long host or location details.
  * Refined tab and footer styling, along with description text spacing.
  * Improved sizing and transition behavior for session titles, tags, and metadata.

* **Documentation**
  * Added troubleshooting notes for common mise, Playwright, and pytest setup issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->