### PR TITLE
Smooth multi-layer shadows: shadow-plugin, elevated-surface sweep, lint rule

### DIFF
--- a/.claude/skills/product-design/references/patterns.md
+++ b/.claude/skills/product-design/references/patterns.md
@@ -58,4 +58,12 @@ visibility badges, …). Prefer including those over re-creating their markup.
   `var(--theme-…)` is blocked by `rules/no-inline-color-var.yml` /
   `rules/no-inline-theme-var.yml`.
 - Spacing/sizing comes from the Tailwind scale; don't invent magic pixel values.
+- **Elevated surfaces: `smooth-shadow-ring-{size}`, never `border` + `shadow`.**
+  Pairing them draws a double edge (hard 1px stroke, then the shadow next to
+  it). The [shadow-plugin](https://shadow.floriankiem.com) utilities bake a
+  hairline ring into the shadow's final layer instead: `border shadow-md` →
+  `smooth-shadow-ring-md`; no edge wanted → plain `smooth-shadow-{size}`.
+  Don't add a `border`/`ring` on top — the ring is already in there. Tint via
+  `shadow-{color}` (shadow) and `smooth-ring-{color}` (ring); dark mode is
+  handled automatically.
 - One brand font (Outfit) by design — don't add a second.

--- a/.claude/skills/product-design/references/patterns.md
+++ b/.claude/skills/product-design/references/patterns.md
@@ -65,6 +65,7 @@ visibility badges, …). Prefer including those over re-creating their markup.
   `smooth-shadow-ring-md`; no edge wanted → plain `smooth-shadow-{size}`.
   Don't add a `border`/`ring` on top — the ring is already in there. Tint via
   `shadow-{color}` (shadow) and `smooth-ring-{color}` (ring). Globally the
-  ring reads `var(--color-border)` (index.css) so hairlines stay warm and flip
-  with the theme — don't re-tint per element without a reason.
+  ring is a translucent warm tone derived to composite to `--color-border`
+  (see the `--smooth-ring-color` block in index.css) and flips with the
+  theme — don't re-tint per element without a reason.
 - One brand font (Outfit) by design — don't add a second.

--- a/.claude/skills/product-design/references/patterns.md
+++ b/.claude/skills/product-design/references/patterns.md
@@ -64,6 +64,7 @@ visibility badges, …). Prefer including those over re-creating their markup.
   hairline ring into the shadow's final layer instead: `border shadow-md` →
   `smooth-shadow-ring-md`; no edge wanted → plain `smooth-shadow-{size}`.
   Don't add a `border`/`ring` on top — the ring is already in there. Tint via
-  `shadow-{color}` (shadow) and `smooth-ring-{color}` (ring); dark mode is
-  handled automatically.
+  `shadow-{color}` (shadow) and `smooth-ring-{color}` (ring). Globally the
+  ring reads `var(--color-border)` (index.css) so hairlines stay warm and flip
+  with the theme — don't re-tint per element without a reason.
 - One brand font (Outfit) by design — don't add a second.

--- a/aube-lock.yaml
+++ b/aube-lock.yaml
@@ -84,6 +84,9 @@ importers:
       postcss-nested:
         specifier: 7.0.2
         version: 7.0.2(postcss@8.5.15)
+      shadow-plugin:
+        specifier: 1.2.4
+        version: 1.2.4
       tailwindcss:
         specifier: 4.1.16
         version: 4.1.16
@@ -1694,6 +1697,9 @@ packages:
 
   setprototypeof@1.2.0:
     resolution: {integrity: sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==}
+
+  shadow-plugin@1.2.4:
+    resolution: {integrity: sha512-A+Xuns08CYWNAfrAEEKok53Jy+emqo/6FdvGWfk6X4AF6vEJ9NAJ7EAlvPdfNNnabP/DC4Q4kofrdehvgY5Mug==}
 
   shebang-command@2.0.0:
     resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
@@ -3431,6 +3437,8 @@ snapshots:
       send: 1.2.1(supports-color@9.4.0)
 
   setprototypeof@1.2.0: {}
+
+  shadow-plugin@1.2.4: {}
 
   shebang-command@2.0.0:
     dependencies:

--- a/rules/no-border-plus-shadow.yml
+++ b/rules/no-border-plus-shadow.yml
@@ -1,0 +1,16 @@
+id: no-border-plus-shadow
+language: html
+severity: warning
+rule:
+  kind: attribute
+  regex: 'class="(?:[^"]*[\s"])?(?:(?:border(?:-2)?|ring(?:-\d)?)[\s"](?:[^"]*[\s"])?(?:smooth-)?shadow(?:-ring)?(?:-(?:xs|sm|md|lg|xl|2xl)|-\(--[a-z-]+\))?[\s"]|(?:smooth-)?shadow(?:-ring)?(?:-(?:xs|sm|md|lg|xl|2xl)|-\(--[a-z-]+\))?[\s"](?:[^"]*[\s"])?(?:border(?:-2)?|ring(?:-\d)?)[\s"])'
+message: |
+  Border + shadow on one element draws a double edge: a hard 1px stroke with
+  the shadow starting just outside it. Elevated surfaces (cards, menus,
+  popovers, dialogs) use smooth-shadow-ring-{size} instead — the hairline is
+  baked into the shadow's last layer, so the edge dissolves into it:
+    border border-border shadow-lg  → smooth-shadow-ring-lg
+    border shadow-(--shadow-card)   → smooth-shadow-ring-xs
+  Never stack a border/ring on top of smooth-shadow-ring-* either; the ring
+  is already in there. Directional dividers (border-b, border-r) are fine.
+  See .claude/skills/product-design/references/patterns.md.

--- a/src/ludamus/client/package.json
+++ b/src/ludamus/client/package.json
@@ -23,6 +23,7 @@
     "oxfmt": "0.56.0",
     "oxlint": "1.70.0",
     "postcss-nested": "7.0.2",
+    "shadow-plugin": "1.2.4",
     "tailwindcss": "4.1.16",
     "typescript": "5.9.3",
     "vite": "8.0.16"

--- a/src/ludamus/client/src/index.css
+++ b/src/ludamus/client/src/index.css
@@ -662,9 +662,8 @@ button:active {
 
   .card {
     border-radius: 1rem;
-    border: 1px solid var(--color-border);
     background-color: var(--color-bg-secondary);
-    box-shadow: var(--shadow-card);
+    @apply smooth-shadow-ring-xs;
   }
 
   .card-header {

--- a/src/ludamus/client/src/index.css
+++ b/src/ludamus/client/src/index.css
@@ -350,24 +350,27 @@ button {
   --shadow-dropdown: 0 4px 6px rgba(0, 0, 0, 0.4), 0 2px 4px rgba(0, 0, 0, 0.3);
 }
 
-/* smooth-shadow-ring hairlines read the house border token — our neutrals are
-   warm, and the plugin's default semi-transparent black renders cool grey
-   against them. Mirrors all three plugin selectors (:root, the
-   prefers-color-scheme media rule, .dark) so this wins each cascade branch;
-   var() resolves per-theme, so one value covers light and dark. */
+/* smooth-shadow-ring hairlines: translucent warm, tuned to the border token.
+   The plugin's default semi-transparent black renders cool grey against our
+   warm neutrals, and the opaque token itself would kill the dissolve — so
+   these composite to the border color instead. Derivation per channel:
+   α·C + (1−α)·bg = target. Light: --color-border (warm-300 #e4ddd6) on white
+   at α = 20% → rgb(120 85 50). Dark: neutral-700 #404040 on the #0a0a0a page
+   at α = 22% → white. Re-derive if the border token retunes. Mirrors all
+   three plugin selectors so this wins each cascade branch. */
 :root {
-  --smooth-ring-color: var(--color-border);
+  --smooth-ring-color: rgb(120 85 50 / 20%);
 }
 
 @media (prefers-color-scheme: dark) {
   :root:not(.light):not([data-theme="light"]) {
-    --smooth-ring-color: var(--color-border);
+    --smooth-ring-color: rgb(255 255 255 / 22%);
   }
 }
 
 .dark,
 [data-theme="dark"] {
-  --smooth-ring-color: var(--color-border);
+  --smooth-ring-color: rgb(255 255 255 / 22%);
 }
 
 :focus-visible {

--- a/src/ludamus/client/src/index.css
+++ b/src/ludamus/client/src/index.css
@@ -12,6 +12,8 @@
 @plugin "@tailwindcss/typography";
 @plugin "@hasparus/tailwind/scrollview-fade";
 
+@import "shadow-plugin";
+
 @source "../../**/*.{html,py,js}";
 
 @custom-variant dark (&:where(.dark, .dark *));

--- a/src/ludamus/client/src/index.css
+++ b/src/ludamus/client/src/index.css
@@ -74,7 +74,7 @@
   --color-stone-*: initial;
 
   --color-background: #f0f1f3;
-  --color-border: #e4ddd6;
+  --color-border: var(--color-warm-300);
 
   --ease-spring-a-bit: linear(
     0 0%,
@@ -323,7 +323,7 @@ button {
   --color-foreground-secondary: #d4d4d4;
   --color-foreground-muted: #737373;
   --color-foreground-inverse: #0a0a0a;
-  --color-border: #404040;
+  --color-border: var(--color-neutral-700);
   --color-border-focus: #f85a3c;
   --color-primary: #f85a3c;
   --color-primary-hover: #e53e20;

--- a/src/ludamus/client/src/index.css
+++ b/src/ludamus/client/src/index.css
@@ -350,6 +350,26 @@ button {
   --shadow-dropdown: 0 4px 6px rgba(0, 0, 0, 0.4), 0 2px 4px rgba(0, 0, 0, 0.3);
 }
 
+/* smooth-shadow-ring hairlines read the house border token — our neutrals are
+   warm, and the plugin's default semi-transparent black renders cool grey
+   against them. Mirrors all three plugin selectors (:root, the
+   prefers-color-scheme media rule, .dark) so this wins each cascade branch;
+   var() resolves per-theme, so one value covers light and dark. */
+:root {
+  --smooth-ring-color: var(--color-border);
+}
+
+@media (prefers-color-scheme: dark) {
+  :root:not(.light):not([data-theme="light"]) {
+    --smooth-ring-color: var(--color-border);
+  }
+}
+
+.dark,
+[data-theme="dark"] {
+  --smooth-ring-color: var(--color-border);
+}
+
 :focus-visible {
   outline: none;
   box-shadow:

--- a/src/ludamus/templates/chronology/enroll_select.html
+++ b/src/ludamus/templates/chronology/enroll_select.html
@@ -125,7 +125,7 @@
                     {# feed enroll-preview.ts, which projects each ticked row to #}
                     {# "gets a seat" / "joins the waiting list" using the same order #}
                     {# and seat accounting as the server's routing. #}
-                    <div class="rounded-2xl border border-border bg-bg-secondary overflow-hidden shadow-xl"
+                    <div class="rounded-2xl bg-bg-secondary overflow-hidden smooth-shadow-ring-xl"
                          style="box-shadow: var(--shadow-elevated)"
                          data-enroll-preview
                          {% if seats_left is not None %}data-seats-left="{{ seats_left }}"{% endif %}

--- a/src/ludamus/templates/chronology/session_tags.html
+++ b/src/ludamus/templates/chronology/session_tags.html
@@ -8,7 +8,7 @@
             {% endfor %}
             {% if row.overflow_count %}
                 <div class="session-tags-more relative inline-block pointer-events-auto">
-                    <div class="session-tags-popover absolute z-30 min-w-56 max-w-[20rem] rounded-xl border border-border bg-bg-secondary p-2 shadow-(--shadow-elevated) opacity-0 pointer-events-none transition-opacity duration-150 flex flex-wrap gap-1">
+                    <div class="session-tags-popover absolute z-30 min-w-56 max-w-[20rem] rounded-xl bg-bg-secondary p-2 smooth-shadow-ring-lg opacity-0 pointer-events-none transition-opacity duration-150 flex flex-wrap gap-1">
                         {% for val in row.overflow_values %}
                             {% include "components/_field_pill.html" with value=val icon=row.icon title=val size="md" %}
                         {% endfor %}

--- a/src/ludamus/templates/components/navbar.html
+++ b/src/ludamus/templates/components/navbar.html
@@ -53,8 +53,7 @@
                              class="absolute right-0 top-full mt-2 z-50">
                             <span aria-hidden="true"
                                   class="absolute right-0 -top-2 block h-2 w-48 pointer-events-auto [clip-path:polygon(81.25%_0,100%_0,100%_100%,0_100%)]"></span>
-                            <div {% include "components/menu_surface.html" with extra_class="w-48 rounded-lg shadow-lg border bg-bg-secondary border-border" %}
-                                 style="box-shadow: var(--shadow-elevated)">
+                            <div {% include "components/menu_surface.html" with extra_class="w-48 rounded-lg bg-bg-secondary smooth-shadow-ring-lg" %}>
                                 <!-- User info header -->
                                 <div class="px-3.5 py-2.5 border-b rounded-t-lg border-border">
                                     <p class="text-sm font-medium truncate text-foreground-primary">{{ request.user.full_name|default:"User" }}</p>

--- a/src/ludamus/templates/components/notifications.html
+++ b/src/ludamus/templates/components/notifications.html
@@ -16,8 +16,7 @@
          data-menu-panel
          hidden
          class="absolute right-0 top-full mt-2 z-50">
-        <div {% include "components/menu_surface.html" with extra_class="w-72 rounded-lg shadow-lg border bg-bg-secondary border-border" %}
-             style="box-shadow: var(--shadow-elevated)">
+        <div {% include "components/menu_surface.html" with extra_class="w-72 rounded-lg bg-bg-secondary smooth-shadow-ring-lg" %}>
             <div class="px-3.5 py-2.5 border-b rounded-t-lg border-border flex items-center justify-between gap-2">
                 <p class="text-sm font-medium text-foreground-primary mb-0">{% translate "Notifications" %}</p>
                 {% if navbar_notifications.items %}

--- a/src/ludamus/templates/crowd/user/parties.html
+++ b/src/ludamus/templates/crowd/user/parties.html
@@ -130,7 +130,7 @@
                                      data-menu-panel
                                      hidden
                                      class="absolute right-0 top-full mt-1 z-50">
-                                    <div {% include "components/menu_surface.html" with extra_class="w-44 rounded-lg border border-border bg-bg-secondary overflow-hidden shadow-(--shadow-elevated)" %}>
+                                    <div {% include "components/menu_surface.html" with extra_class="w-44 rounded-lg bg-bg-secondary overflow-hidden smooth-shadow-ring-lg" %}>
                                         <a href="?rename={{ entry.party.pk }}"
                                            class="flex w-full items-center gap-2 px-3.5 py-2.5 text-sm text-left text-foreground-secondary hover:bg-bg-tertiary"
                                            aria-controls="rename-modal-{{ entry.party.pk }}"

--- a/src/ludamus/templates/notice_board/_calendar_inline.html
+++ b/src/ludamus/templates/notice_board/_calendar_inline.html
@@ -5,7 +5,7 @@
         {% icon "calendar" class="h-4 w-4" variant="mini" %}
         {% translate "Add to calendar" %}
     </button>
-    <div class="calendar-menu hidden absolute top-full left-0 right-0 mt-1 rounded-lg border border-border bg-bg-secondary shadow-(--shadow-dropdown) z-10">
+    <div class="calendar-menu hidden absolute top-full left-0 right-0 mt-1 rounded-lg bg-bg-secondary smooth-shadow-ring-md z-10">
         <a href="{{ google_calendar_url }}"
            target="_blank"
            rel="noopener noreferrer"

--- a/src/ludamus/templates/notice_board/_organizer_actions.html
+++ b/src/ludamus/templates/notice_board/_organizer_actions.html
@@ -7,7 +7,7 @@
                 {% icon "share" class="h-4 w-4" variant="mini" %}
                 {% translate "Share" %}
             </button>
-            <div class="share-menu hidden absolute top-full left-0 right-0 mt-1 rounded-lg border border-border bg-bg-secondary shadow-(--shadow-dropdown) z-10">
+            <div class="share-menu hidden absolute top-full left-0 right-0 mt-1 rounded-lg bg-bg-secondary smooth-shadow-ring-md z-10">
                 {% tessera_copy share_url variant="menu-item" class="rounded-t-lg" %}
                 {% icon "clipboard-document" variant="solid" class="h-4 w-4 inline" %}
                 {% translate "Copy link" %}

--- a/src/ludamus/templates/notice_board/_rsvp_inline.html
+++ b/src/ludamus/templates/notice_board/_rsvp_inline.html
@@ -30,7 +30,7 @@
                                 {% icon "calendar" class="h-5 w-5" variant="mini" %}
                                 {% translate "Add to calendar" %}
                             </button>
-                            <div class="calendar-menu hidden absolute top-full left-0 right-0 mt-1 rounded-lg border border-border bg-bg-secondary shadow-(--shadow-dropdown) z-10">
+                            <div class="calendar-menu hidden absolute top-full left-0 right-0 mt-1 rounded-lg bg-bg-secondary smooth-shadow-ring-md z-10">
                                 <a href="{{ google_calendar_url }}"
                                    target="_blank"
                                    rel="noopener noreferrer"
@@ -72,7 +72,7 @@
                             {% icon "calendar" class="h-5 w-5" variant="mini" %}
                             {% translate "Add to calendar" %}
                         </button>
-                        <div class="calendar-menu hidden absolute top-full left-0 right-0 mt-1 rounded-lg border border-border bg-bg-secondary shadow-(--shadow-dropdown) z-10">
+                        <div class="calendar-menu hidden absolute top-full left-0 right-0 mt-1 rounded-lg bg-bg-secondary smooth-shadow-ring-md z-10">
                             <a href="{{ google_calendar_url }}"
                                target="_blank"
                                rel="noopener noreferrer"

--- a/src/ludamus/templates/panel/_space_tree_node.html
+++ b/src/ludamus/templates/panel/_space_tree_node.html
@@ -52,7 +52,7 @@
                     {% icon "ellipsis-horizontal" class="w-4 h-4" %}
                 </button>
                 <div data-menu-panel hidden class="absolute right-0 z-10 mt-2">
-                    <div {% include "components/menu_surface.html" with extra_class="w-44 rounded-lg border border-border bg-bg-secondary shadow-lg" %}>
+                    <div {% include "components/menu_surface.html" with extra_class="w-44 rounded-lg bg-bg-secondary smooth-shadow-ring-lg" %}>
                         <form method="post"
                               action="{% url 'panel:space-duplicate' slug=current_event.slug pk=node.pk %}">
                             {% csrf_token %}

--- a/src/ludamus/templates/panel/cfp.html
+++ b/src/ludamus/templates/panel/cfp.html
@@ -89,7 +89,7 @@
             </tbody>
         {% end_tessera_table %}
     {% else %}
-        <div class="bg-bg-secondary rounded-2xl shadow-(--shadow-card) border border-border p-8 text-center">
+        <div class="bg-bg-secondary rounded-2xl smooth-shadow-ring-xs p-8 text-center">
             <p class="text-foreground-muted mb-4">
                 {% translate "No categories yet. Add a category to allow facilitators to submit proposals." %}
             </p>
@@ -101,7 +101,7 @@
 {% end_tab_shell_body %}
 {% end_tab_shell %}
 {% else %}
-<div class="bg-bg-secondary rounded-2xl shadow-(--shadow-card) border border-border p-8 text-center">
+<div class="bg-bg-secondary rounded-2xl smooth-shadow-ring-xs p-8 text-center">
     <p class="text-foreground-muted">{% translate "No events available. Create an event to get started." %}</p>
 </div>
 {% endif %}

--- a/src/ludamus/templates/panel/facilitators.html
+++ b/src/ludamus/templates/panel/facilitators.html
@@ -26,7 +26,7 @@
             {% tab_shell "panel/_facilitator_tabs.html" %}
             {% tab_shell_body %}
             {% if facilitators or filters_active %}
-                <div class="bg-bg-secondary rounded-2xl shadow-sm border border-border p-4 mb-6">
+                <div class="bg-bg-secondary rounded-2xl smooth-shadow-ring-xs p-4 mb-6">
                     <form method="get" class="flex flex-wrap gap-4 items-end">
                         {% if filter_sort and filter_sort != "name" %}
                             <input type="hidden" name="sort" value="{{ filter_sort }}">

--- a/src/ludamus/templates/panel/personal-data-field-create.html
+++ b/src/ludamus/templates/panel/personal-data-field-create.html
@@ -166,7 +166,7 @@
                     </script>
                 </div>
             </div>
-            <div class="bg-bg-secondary rounded-2xl shadow-(--shadow-card) border border-border p-6 mt-6">
+            <div class="bg-bg-secondary rounded-2xl smooth-shadow-ring-xs p-6 mt-6">
                 <h3 class="text-lg font-semibold text-foreground mb-1">{% translate "Categories" %}</h3>
                 <p class="text-sm text-foreground-muted mb-6">{% translate "Select which categories should include this field." %}</p>
                 {% if categories %}

--- a/src/ludamus/templates/panel/personal-data-field-edit.html
+++ b/src/ludamus/templates/panel/personal-data-field-edit.html
@@ -127,7 +127,7 @@
                     </div>
                 </div>
             </div>
-            <div class="bg-bg-secondary rounded-2xl shadow-(--shadow-card) border border-border p-6 mt-6">
+            <div class="bg-bg-secondary rounded-2xl smooth-shadow-ring-xs p-6 mt-6">
                 <h3 class="text-lg font-semibold text-foreground mb-1">{% translate "Categories" %}</h3>
                 <p class="text-sm text-foreground-muted mb-6">{% translate "Select which categories should include this field." %}</p>
                 {% if categories %}

--- a/src/ludamus/templates/panel/personal-data-fields.html
+++ b/src/ludamus/templates/panel/personal-data-fields.html
@@ -124,7 +124,7 @@
 {% end_tab_shell_body %}
 {% end_tab_shell %}
 {% else %}
-<div class="bg-bg-secondary rounded-2xl shadow-(--shadow-card) border border-border p-8 text-center">
+<div class="bg-bg-secondary rounded-2xl smooth-shadow-ring-xs p-8 text-center">
     <p class="text-foreground-muted">{% translate "No events available. Create an event to get started." %}</p>
 </div>
 {% endif %}

--- a/src/ludamus/templates/panel/proposals.html
+++ b/src/ludamus/templates/panel/proposals.html
@@ -64,7 +64,7 @@
 {% block content %}
     <div class="p-4">
         {% if current_event %}
-            <div class="bg-bg-secondary rounded-2xl shadow-sm border border-border p-4 mb-6">
+            <div class="bg-bg-secondary rounded-2xl smooth-shadow-ring-xs p-4 mb-6">
                 <form method="get"
                       id="proposals-filter-form"
                       data-autosubmit
@@ -346,7 +346,7 @@
         {% end_tessera_table %}
     {% endif %}
 {% else %}
-    <div class="bg-bg-secondary rounded-2xl shadow-sm border border-border p-8 text-center">
+    <div class="bg-bg-secondary rounded-2xl smooth-shadow-ring-xs p-8 text-center">
         <p class="text-foreground-muted">{% translate "No events available. Create an event to get started." %}</p>
     </div>
 {% endif %}

--- a/src/ludamus/templates/panel/session-field-create.html
+++ b/src/ludamus/templates/panel/session-field-create.html
@@ -184,7 +184,7 @@
                     </script>
                 </div>
             </div>
-            <div class="bg-bg-secondary rounded-2xl shadow-(--shadow-card) border border-border p-6 mt-6">
+            <div class="bg-bg-secondary rounded-2xl smooth-shadow-ring-xs p-6 mt-6">
                 <h3 class="text-lg font-semibold text-foreground mb-1">{% translate "Categories" %}</h3>
                 <p class="text-sm text-foreground-muted mb-6">{% translate "Select which categories should include this field." %}</p>
                 {% if categories %}

--- a/src/ludamus/templates/panel/session-field-edit.html
+++ b/src/ludamus/templates/panel/session-field-edit.html
@@ -145,7 +145,7 @@
                     </div>
                 </div>
             </div>
-            <div class="bg-bg-secondary rounded-2xl shadow-(--shadow-card) border border-border p-6 mt-6">
+            <div class="bg-bg-secondary rounded-2xl smooth-shadow-ring-xs p-6 mt-6">
                 <h3 class="text-lg font-semibold text-foreground mb-1">{% translate "Categories" %}</h3>
                 <p class="text-sm text-foreground-muted mb-6">{% translate "Select which categories should include this field." %}</p>
                 {% if categories %}

--- a/src/ludamus/templates/panel/session-fields.html
+++ b/src/ludamus/templates/panel/session-fields.html
@@ -128,7 +128,7 @@
 {% end_tab_shell_body %}
 {% end_tab_shell %}
 {% else %}
-<div class="bg-bg-secondary rounded-2xl shadow-(--shadow-card) border border-border p-8 text-center">
+<div class="bg-bg-secondary rounded-2xl smooth-shadow-ring-xs p-8 text-center">
     <p class="text-foreground-muted">{% translate "No events available. Create an event to get started." %}</p>
 </div>
 {% endif %}

--- a/src/ludamus/templates/panel/time-slots.html
+++ b/src/ludamus/templates/panel/time-slots.html
@@ -187,7 +187,7 @@
 {% end_tab_shell %}
 {% include "panel/_time-slot-create-modal.html" with modal_id="time-slot-create-modal" form=create_form current_event=current_event csrf_token=csrf_token only %}
 {% else %}
-<div class="bg-bg-secondary rounded-2xl shadow-(--shadow-card) border border-border p-8 text-center">
+<div class="bg-bg-secondary rounded-2xl smooth-shadow-ring-xs p-8 text-center">
     <p class="text-foreground-muted">{% translate "No events available. Create an event to get started." %}</p>
 </div>
 {% endif %}

--- a/src/ludamus/templates/panel/timetable.html
+++ b/src/ludamus/templates/panel/timetable.html
@@ -73,7 +73,7 @@
                     <span class="hidden sm:inline">{{ t_print }}</span>
                 </button>
                 <div data-menu-panel hidden class="absolute right-0 mt-1 z-40">
-                    <div {% include "components/menu_surface.html" with extra_class="flex flex-col gap-2 rounded-2xl border border-border bg-bg-secondary p-3 shadow-xl" %}>
+                    <div {% include "components/menu_surface.html" with extra_class="flex flex-col gap-2 rounded-2xl bg-bg-secondary p-3 smooth-shadow-ring-xl" %}>
                         {% include "panel/parts/print-controls.html" %}
                     </div>
                 </div>


### PR DESCRIPTION
Adopts [shadow-plugin](https://shadow.floriankiem.com) (flornkm/shadow-plugin) so elevated surfaces get one continuous edge instead of the border-next-to-shadow double stroke.

## What's here

- **Plugin wired in**: `shadow-plugin@1.2.4` (exact pin) imported in `index.css`. Utilities are `@utility`-based, so only the four sizes we use get emitted. Heads-up: aube's supply-chain guard flagged the package (375 weekly downloads — it shipped recently), added with `--allow-low-downloads`.
- **Warm translucent hairlines**: the plugin's default ring is semi-transparent black, which renders cool grey against our warm neutrals — and the opaque border token would kill the dissolve. `--smooth-ring-color` is derived instead: solve α·C + (1−α)·bg = target per channel, so light mode uses `rgb(120 85 50 / 20%)` (composites to exactly `--color-border`/warm-300 `#e4ddd6` on white) and dark uses `rgb(255 255 255 / 22%)` (composites to neutral-700 `#404040` on the near-black page). Rings look like the house border where surfaces meet the page but still blend over shadows and tinted content. `--color-border` itself now references the scale tokens (`warm-300`/`neutral-700`) instead of duplicating them as raw hexes.
- **Sweep**: every surface that paired a full `border` with a shadow now uses `smooth-shadow-ring-{size}` — the `.card` chrome in CSS (via `@apply`), navbar + notification menus (which also stacked an inline `box-shadow` on top of `shadow-lg border`; the inline style is gone too), notice-board calendar/share dropdowns, panel cards and empty states, space-tree/parties menus, enroll and timetable popovers, session-tags popover. Size mapping: `--shadow-card`/`shadow-sm` → `xs`, `--shadow-dropdown` → `md`, `shadow-lg`/`--shadow-elevated` → `lg`, `shadow-xl` → `xl`. Directional dividers (`border-b`, `border-r`) and bordered-but-shadowless surfaces (tab-shell, event cards) are untouched.
- **Lint rule**: `rules/no-border-plus-shadow.yml` (ast-grep) warns when a class attribute pairs `border`/`ring` with a shadow, or stacks an extra edge on a `smooth-shadow-ring-*` surface. It catches the `extra_class="…"` include-argument form too. 23 hits before the sweep, 0 after.
- **Skill note**: one bullet in `product-design/references/patterns.md` (Theming/styling) instead of vendoring the plugin's own agent skill.

## Screenshots

**Interactive:** [before/after slider comparison](https://claude.ai/code/artifact/f3ea7e47-0d54-4cb7-b4aa-be278b2b7405) (Claude artifact — private by default; ask @hasparus to share it).

### Navbar menu (light)
| Before | After |
| --- | --- |
| ![before](https://raw.githubusercontent.com/zagrajmy/ludamus/c2561a1788ee49702bf82692897685f1cb1789be/screenshots/before-navbar-menu.png) | ![after](https://raw.githubusercontent.com/zagrajmy/ludamus/c2561a1788ee49702bf82692897685f1cb1789be/screenshots/after-navbar-menu.png) |

### Navbar menu (dark)
| Before | After |
| --- | --- |
| ![before](https://raw.githubusercontent.com/zagrajmy/ludamus/c2561a1788ee49702bf82692897685f1cb1789be/screenshots/before-navbar-menu-dark.png) | ![after](https://raw.githubusercontent.com/zagrajmy/ludamus/c2561a1788ee49702bf82692897685f1cb1789be/screenshots/after-navbar-menu-dark.png) |

### Panel · Proposals
| Before | After |
| --- | --- |
| ![before](https://raw.githubusercontent.com/zagrajmy/ludamus/c2561a1788ee49702bf82692897685f1cb1789be/screenshots/before-panel-proposals.png) | ![after](https://raw.githubusercontent.com/zagrajmy/ludamus/c2561a1788ee49702bf82692897685f1cb1789be/screenshots/after-panel-proposals.png) |

### Panel · Call for Proposals
| Before | After |
| --- | --- |
| ![before](https://raw.githubusercontent.com/zagrajmy/ludamus/c2561a1788ee49702bf82692897685f1cb1789be/screenshots/before-panel-cfp.png) | ![after](https://raw.githubusercontent.com/zagrajmy/ludamus/c2561a1788ee49702bf82692897685f1cb1789be/screenshots/after-panel-cfp.png) |

Images are hosted on the throwaway branch `claude/zagrajmy-resource-zbsh82-assets` (SHA-pinned) — delete it after this PR closes if you don't want to keep them.

## Checks

djlint, ast-grep (incl. the new rule), and tingle all pass — no new debt, and the sweep pays some off (net −3 lines). No strings changed, so no i18n churn.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AMNSfJRm69jCGWA7thYmb6