### PR TITLE
fix(print): one door card page per room and day

### DIFF
--- a/PAPERCUTS.md
+++ b/PAPERCUTS.md
@@ -263,3 +263,8 @@ If you fix a papercut, remove it.
   /etc/ssh/ssh_config.d/20-systemd-ssh-proxy.conf' (symlink owned by
   nobody:nogroup); worked around with git -c credential.helper='!gh auth git-
   credential' push <https://github.com/zagrajmy/ludamus.git> HEAD:the-branch
+- 2026-08-01: mise run lint fails locally on lint:hk: oxlint can't build
+  src/ludamus/client/oxlint.config.ts because eslint-plugin-sonarjs isn't
+  installed in the local node_modules (CI is fine). Same failure on a clean
+  tree, so it's env drift, not a code problem — had to stash and re-run to prove
+  my change was innocent.

--- a/src/ludamus/mills/printing.py
+++ b/src/ludamus/mills/printing.py
@@ -19,7 +19,6 @@ from ludamus.pacts.printing import (
     AreaScheduleQueryDTO,
     AreaScheduleSessionDTO,
     AreaScheduleSpaceDTO,
-    DoorCardDayDTO,
     DoorCardDTO,
     DoorCardEntryDTO,
     DoorCardsDocumentDTO,
@@ -148,11 +147,9 @@ class PrintMaterialsService:
         for space in spaces:
             # Cards hang on doors for participants: a room with nothing
             # scheduled gets no card, and empty hours are simply not listed.
-            if not (space_items := items_by_space.get(space.pk)):
-                continue
             entries_by_day: dict[date, list[DoorCardEntryDTO]] = defaultdict(list)
 
-            for item in space_items:
+            for item in items_by_space.get(space.pk, []):
                 day = item.start_time.astimezone(query.tz).date()
                 entries_by_day[day].append(
                     DoorCardEntryDTO(
@@ -162,15 +159,15 @@ class PrintMaterialsService:
                     )
                 )
 
-            days = [
-                DoorCardDayDTO(
-                    day=day, entries=sorted(entries_by_day[day], key=_entry_start)
+            cards += [
+                DoorCardDTO(
+                    space_name=space.name,
+                    capacity=space.capacity,
+                    day=day,
+                    entries=sorted(entries_by_day[day], key=_entry_start),
                 )
                 for day in sorted(entries_by_day)
             ]
-            cards.append(
-                DoorCardDTO(space_name=space.name, capacity=space.capacity, days=days)
-            )
 
         return DoorCardsDocumentDTO(
             event_name=event.name,

--- a/src/ludamus/pacts/printing.py
+++ b/src/ludamus/pacts/printing.py
@@ -63,15 +63,12 @@ class DoorCardEntryDTO(BaseModel):
     session: PrintSessionDTO
 
 
-class DoorCardDayDTO(BaseModel):
-    day: date
-    entries: list[DoorCardEntryDTO]
-
-
+# One card is one sheet of paper: it hangs on a door for a single day.
 class DoorCardDTO(BaseModel):
     space_name: str
     capacity: int | None
-    days: list[DoorCardDayDTO]
+    day: date
+    entries: list[DoorCardEntryDTO]
 
 
 class DoorCardsDocumentDTO(BaseModel):

--- a/src/ludamus/templates/panel/print/base.html
+++ b/src/ludamus/templates/panel/print/base.html
@@ -1,5 +1,5 @@
 {% extends "base.html" %}
-{% load i18n %}
+{% load i18n tessera %}
 {% block title %}
     {{ document.event_name }}
 {% endblock title %}
@@ -16,7 +16,9 @@
         /* Document typography + white paper are scoped to the sheet so they
            never touch the site navbar/footer that now wrap this page, and so
            the sheet prints white regardless of the active light/dark theme.
-           One .sheet is one printed page. */
+           A .sheet starts a printed page; content taller than the paper still
+           spills onto an unheadered continuation page — nothing caps it yet
+           (#767). */
         .sheet {
             font-family: sans-serif;
             color: #111827;
@@ -50,26 +52,6 @@
         .empty {
             color: #9ca3af;
             font-style: italic;
-        }
-
-        .toolbar {
-            margin: 0 0 12px;
-        }
-
-        .print-btn {
-            font: 600 14px sans-serif;
-            padding: 8px 16px;
-            border: 1px solid #111827;
-            border-radius: 8px;
-            background: #111827;
-            color: #fff;
-            cursor: pointer;
-        }
-
-        .print-hint {
-            margin-left: 10px;
-            font: 14px sans-serif;
-            color: #6b7280;
         }
 
         @media screen {
@@ -116,9 +98,11 @@
         <div class="print-doc">
             {# The sheets repeat their header, so the document's one heading is here. #}
             <h1 class="sr-only">{{ document.event_name }}</h1>
-            <div class="toolbar no-print">
-                <button type="button" class="print-btn" data-action="print">{% translate "Print" %}</button>
-                <span class="print-hint">{% translate "or press Ctrl+P (⌘P on Mac)" %}</span>
+            {# Theme-aware tokens: the toolbar sits on the page, not on the white sheet. #}
+            <div class="no-print mb-3 flex flex-wrap items-center gap-3">
+                {% translate "Print" as t_print %}
+                {% tessera_button t_print button_type="button" icon="printer" data_action="print" full_width_mobile=False %}
+                <span class="text-sm text-foreground-secondary">{% translate "or press Ctrl+P (⌘P on Mac)" %}</span>
             </div>
             {% block body %}
             {% endblock body %}

--- a/src/ludamus/templates/panel/print/base.html
+++ b/src/ludamus/templates/panel/print/base.html
@@ -15,7 +15,8 @@
 
         /* Document typography + white paper are scoped to the sheet so they
            never touch the site navbar/footer that now wrap this page, and so
-           the sheet prints white regardless of the active light/dark theme. */
+           the sheet prints white regardless of the active light/dark theme.
+           One .sheet is one printed page. */
         .sheet {
             font-family: sans-serif;
             color: #111827;
@@ -72,11 +73,21 @@
         }
 
         @media screen {
-            .sheet {
+            .print-doc {
                 max-width: 210mm;
                 margin: 16px auto;
+            }
+
+            /* On paper the page break draws the boundary; on screen only this
+               does, so the preview shows where each sheet starts and ends. */
+            .sheet {
+                min-height: 297mm;
                 padding: 14mm;
                 box-shadow: 0 1px 6px rgba(0, 0, 0, 0.18);
+            }
+
+            .sheet+.sheet {
+                margin-top: 16px;
             }
         }
 
@@ -102,7 +113,9 @@
 {% endblock body_class %}
 {% block main_region %}
     <main class="grow w-full">
-        <div class="sheet">
+        <div class="print-doc">
+            {# The sheets repeat their header, so the document's one heading is here. #}
+            <h1 class="sr-only">{{ document.event_name }}</h1>
             <div class="toolbar no-print">
                 <button type="button" class="print-btn" data-action="print">{% translate "Print" %}</button>
                 <span class="print-hint">{% translate "or press Ctrl+P (⌘P on Mac)" %}</span>

--- a/src/ludamus/templates/panel/print/door-cards.html
+++ b/src/ludamus/templates/panel/print/door-cards.html
@@ -3,15 +3,15 @@
 {% block body %}
     {% for card in document.cards %}
         {# one A4 page per card: a card hangs on the door for one day #}
-        <section class="print:break-after-page last:print:break-after-auto">
+        <section class="sheet print:break-after-page last:print:break-after-auto">
             {% include "panel/print/parts/doc-header.html" %}
-            <h1 style="font-size: 26pt; margin: 0 0 1mm 0;">{{ card.space_name }}</h1>
+            <h2 style="font-size: 26pt; margin: 0 0 1mm 0;">{{ card.space_name }}</h2>
             {% if card.capacity %}
                 <p style="margin: 0 0 1mm 0; color: #6b7280;">{% translate "Capacity" %}: {{ card.capacity }}</p>
             {% endif %}
-            <h2 style="font-size: 12pt;
+            <h3 style="font-size: 12pt;
                        margin: 5mm 0 2mm 0;
-                       border-bottom: 0.5pt solid #d1d5db">{{ card.day|date:"l, j E" }}</h2>
+                       border-bottom: 0.5pt solid #d1d5db">{{ card.day|date:"l, j E" }}</h3>
             <table style="width: 100%; border-collapse: collapse;">
                 {% for entry in card.entries %}
                     <tr style="border-bottom: 0.5pt solid #e5e7eb;">
@@ -31,6 +31,9 @@
             </table>
         </section>
     {% empty %}
-        <p class="empty">{% translate "No rooms to print." %}</p>
+        <section class="sheet">
+            {% include "panel/print/parts/doc-header.html" %}
+            <p class="empty">{% translate "No rooms to print." %}</p>
+        </section>
     {% endfor %}
 {% endblock body %}

--- a/src/ludamus/templates/panel/print/door-cards.html
+++ b/src/ludamus/templates/panel/print/door-cards.html
@@ -3,13 +3,18 @@
 {% block body %}
     {% for card in document.cards %}
         {# one A4 page per card: a card hangs on the door for one day #}
-        <section class="sheet print:break-after-page last:print:break-after-auto">
+        <section class="sheet print:break-after-page last:print:break-after-auto"
+                 role="group"
+                 aria-labelledby="card-{{ forloop.counter }}-room card-{{ forloop.counter }}-day">
             {% include "panel/print/parts/doc-header.html" %}
-            <h2 style="font-size: 26pt; margin: 0 0 1mm 0;">{{ card.space_name }}</h2>
+            <h2 id="card-{{ forloop.counter }}-room"
+                style="font-size: 26pt;
+                       margin: 0 0 1mm 0">{{ card.space_name }}</h2>
             {% if card.capacity %}
                 <p style="margin: 0 0 1mm 0; color: #6b7280;">{% translate "Capacity" %}: {{ card.capacity }}</p>
             {% endif %}
-            <h3 style="font-size: 12pt;
+            <h3 id="card-{{ forloop.counter }}-day"
+                style="font-size: 12pt;
                        margin: 5mm 0 2mm 0;
                        border-bottom: 0.5pt solid #d1d5db">{{ card.day|date:"l, j E" }}</h3>
             <table style="width: 100%; border-collapse: collapse;">

--- a/src/ludamus/templates/panel/print/door-cards.html
+++ b/src/ludamus/templates/panel/print/door-cards.html
@@ -2,18 +2,18 @@
 {% load i18n %}
 {% block body %}
     {% for card in document.cards %}
-        {# one A4 page per room #}
-        <section {% if not forloop.last %}style="break-after: page;"{% endif %}>
-            <div class="doc-header">
-                <div class="event-name">{{ document.event_name }}</div>
-                <div class="event-dates">{{ document.event_start|date:"j E Y" }}–{{ document.event_end|date:"j E Y" }}</div>
-                {% if document.scope_name %}<div class="scope-name">{{ document.scope_name }}</div>{% endif %}
-            </div>
-            <h1 style="font-size: 26pt; margin: 0 0 1mm 0;">{{ card.space_name }}</h1>
-            {% if card.capacity %}
-                <p style="margin: 0 0 6mm 0; color: #6b7280;">{% translate "Capacity" %}: {{ card.capacity }}</p>
-            {% endif %}
-            {% for day in card.days %}
+        {# one A4 page per room and day: a card hangs on the door for one day #}
+        {% for day in card.days %}
+            <section {% if not forloop.last or not forloop.parentloop.last %}style="break-after: page;"{% endif %}>
+                <div class="doc-header">
+                    <div class="event-name">{{ document.event_name }}</div>
+                    <div class="event-dates">{{ document.event_start|date:"j E Y" }}–{{ document.event_end|date:"j E Y" }}</div>
+                    {% if document.scope_name %}<div class="scope-name">{{ document.scope_name }}</div>{% endif %}
+                </div>
+                <h1 style="font-size: 26pt; margin: 0 0 1mm 0;">{{ card.space_name }}</h1>
+                {% if card.capacity %}
+                    <p style="margin: 0 0 1mm 0; color: #6b7280;">{% translate "Capacity" %}: {{ card.capacity }}</p>
+                {% endif %}
                 <h2 style="font-size: 12pt;
                            margin: 5mm 0 2mm 0;
                            border-bottom: 0.5pt solid #d1d5db">{{ day.day|date:"l, j E" }}</h2>
@@ -34,8 +34,8 @@
                         </tr>
                     {% endfor %}
                 </table>
-            {% endfor %}
-        </section>
+            </section>
+        {% endfor %}
     {% empty %}
         <p class="empty">{% translate "No rooms to print." %}</p>
     {% endfor %}

--- a/src/ludamus/templates/panel/print/door-cards.html
+++ b/src/ludamus/templates/panel/print/door-cards.html
@@ -2,40 +2,34 @@
 {% load i18n %}
 {% block body %}
     {% for card in document.cards %}
-        {# one A4 page per room and day: a card hangs on the door for one day #}
-        {% for day in card.days %}
-            <section {% if not forloop.last or not forloop.parentloop.last %}style="break-after: page;"{% endif %}>
-                <div class="doc-header">
-                    <div class="event-name">{{ document.event_name }}</div>
-                    <div class="event-dates">{{ document.event_start|date:"j E Y" }}–{{ document.event_end|date:"j E Y" }}</div>
-                    {% if document.scope_name %}<div class="scope-name">{{ document.scope_name }}</div>{% endif %}
-                </div>
-                <h1 style="font-size: 26pt; margin: 0 0 1mm 0;">{{ card.space_name }}</h1>
-                {% if card.capacity %}
-                    <p style="margin: 0 0 1mm 0; color: #6b7280;">{% translate "Capacity" %}: {{ card.capacity }}</p>
-                {% endif %}
-                <h2 style="font-size: 12pt;
-                           margin: 5mm 0 2mm 0;
-                           border-bottom: 0.5pt solid #d1d5db">{{ day.day|date:"l, j E" }}</h2>
-                <table style="width: 100%; border-collapse: collapse;">
-                    {% for entry in day.entries %}
-                        <tr style="border-bottom: 0.5pt solid #e5e7eb;">
-                            <td style="width: 28mm;
-                                       padding: 2mm 3mm 2mm 0;
-                                       vertical-align: top;
-                                       white-space: nowrap;
-                                       font-variant-numeric: tabular-nums">
-                                {{ entry.start_time|time:"H:i" }}–{{ entry.end_time|time:"H:i" }}
-                            </td>
-                            <td style="padding: 2mm 0; vertical-align: top;">
-                                <strong>{{ entry.session.title }}</strong>
-                                {% if entry.session.presenter_name %}<div style="color: #6b7280;">{{ entry.session.presenter_name }}</div>{% endif %}
-                            </td>
-                        </tr>
-                    {% endfor %}
-                </table>
-            </section>
-        {% endfor %}
+        {# one A4 page per card: a card hangs on the door for one day #}
+        <section class="print:break-after-page last:print:break-after-auto">
+            {% include "panel/print/parts/doc-header.html" %}
+            <h1 style="font-size: 26pt; margin: 0 0 1mm 0;">{{ card.space_name }}</h1>
+            {% if card.capacity %}
+                <p style="margin: 0 0 1mm 0; color: #6b7280;">{% translate "Capacity" %}: {{ card.capacity }}</p>
+            {% endif %}
+            <h2 style="font-size: 12pt;
+                       margin: 5mm 0 2mm 0;
+                       border-bottom: 0.5pt solid #d1d5db">{{ card.day|date:"l, j E" }}</h2>
+            <table style="width: 100%; border-collapse: collapse;">
+                {% for entry in card.entries %}
+                    <tr style="border-bottom: 0.5pt solid #e5e7eb;">
+                        <td style="width: 28mm;
+                                   padding: 2mm 3mm 2mm 0;
+                                   vertical-align: top;
+                                   white-space: nowrap;
+                                   font-variant-numeric: tabular-nums">
+                            {{ entry.start_time|time:"H:i" }}–{{ entry.end_time|time:"H:i" }}
+                        </td>
+                        <td style="padding: 2mm 0; vertical-align: top;">
+                            <strong>{{ entry.session.title }}</strong>
+                            {% if entry.session.presenter_name %}<div style="color: #6b7280;">{{ entry.session.presenter_name }}</div>{% endif %}
+                        </td>
+                    </tr>
+                {% endfor %}
+            </table>
+        </section>
     {% empty %}
         <p class="empty">{% translate "No rooms to print." %}</p>
     {% endfor %}

--- a/src/ludamus/templates/panel/print/parts/doc-header.html
+++ b/src/ludamus/templates/panel/print/parts/doc-header.html
@@ -1,0 +1,6 @@
+{# Repeated on every printed sheet: a page torn off the stack still names its event. #}
+<div class="doc-header">
+    <div class="event-name">{{ document.event_name }}</div>
+    <div class="event-dates">{{ document.event_start|date:"j E Y" }}–{{ document.event_end|date:"j E Y" }}</div>
+    {% if document.scope_name %}<div class="scope-name">{{ document.scope_name }}</div>{% endif %}
+</div>

--- a/src/ludamus/templates/panel/print/timetable.html
+++ b/src/ludamus/templates/panel/print/timetable.html
@@ -20,9 +20,13 @@
 {% endblock extra_style %}
 {% block body %}
     {% for page in document.pages %}
-        <section class="sheet print:break-after-page last:print:break-after-auto">
+        <section class="sheet print:break-after-page last:print:break-after-auto"
+                 role="group"
+                 aria-labelledby="timetable-page-{{ forloop.counter }}-heading">
             {% include "panel/print/parts/doc-header.html" %}
-            <h2 style="font-size: 12pt; margin: 0 0 2mm 0;">
+            <h2 id="timetable-page-{{ forloop.counter }}-heading"
+                style="font-size: 12pt;
+                       margin: 0 0 2mm 0">
                 {{ page.day|date:"l, j E Y" }}
                 {% if page.space_range_name %}
                     <span style="display: block; font-size: 9pt; font-weight: 400;">{{ page.space_range_name }}</span>

--- a/src/ludamus/templates/panel/print/timetable.html
+++ b/src/ludamus/templates/panel/print/timetable.html
@@ -5,12 +5,23 @@
         @page {
             size: A4 landscape;
         }
+
+        /* Landscape sheets: keep the screen preview the shape of the paper. */
+        @media screen {
+            .print-doc {
+                max-width: 297mm;
+            }
+
+            .sheet {
+                min-height: 210mm;
+            }
+        }
     </style>
 {% endblock extra_style %}
 {% block body %}
-    {% include "panel/print/parts/doc-header.html" %}
     {% for page in document.pages %}
-        <section class="print:break-after-page last:print:break-after-auto">
+        <section class="sheet print:break-after-page last:print:break-after-auto">
+            {% include "panel/print/parts/doc-header.html" %}
             <h2 style="font-size: 12pt; margin: 0 0 2mm 0;">
                 {{ page.day|date:"l, j E Y" }}
                 {% if page.space_range_name %}
@@ -67,6 +78,9 @@
             </table>
         </section>
     {% empty %}
-        <p class="empty">{% translate "No time slots scheduled." %}</p>
+        <section class="sheet">
+            {% include "panel/print/parts/doc-header.html" %}
+            <p class="empty">{% translate "No time slots scheduled." %}</p>
+        </section>
     {% endfor %}
 {% endblock body %}

--- a/src/ludamus/templates/panel/print/timetable.html
+++ b/src/ludamus/templates/panel/print/timetable.html
@@ -8,13 +8,9 @@
     </style>
 {% endblock extra_style %}
 {% block body %}
-    <div class="doc-header">
-        <div class="event-name">{{ document.event_name }}</div>
-        <div class="event-dates">{{ document.event_start|date:"j E Y" }}–{{ document.event_end|date:"j E Y" }}</div>
-        {% if document.scope_name %}<div class="scope-name">{{ document.scope_name }}</div>{% endif %}
-    </div>
+    {% include "panel/print/parts/doc-header.html" %}
     {% for page in document.pages %}
-        <section {% if not forloop.last %}style="break-after: page;"{% endif %}>
+        <section class="print:break-after-page last:print:break-after-auto">
             <h2 style="font-size: 12pt; margin: 0 0 2mm 0;">
                 {{ page.day|date:"l, j E Y" }}
                 {% if page.space_range_name %}

--- a/tests/e2e/tests/print-flow.spec.ts
+++ b/tests/e2e/tests/print-flow.spec.ts
@@ -95,6 +95,14 @@ test.describe("Panel print pages", () => {
     // Session times, not 4-hour availability slots: an 11:00–13:00 session
     // renders as its own row.
     await expect(page.getByRole("cell", { name: /11:00–13:00/ }).first()).toBeVisible();
+
+    // A sheet torn off the stack still names its event, so every page repeats
+    // the header rather than only the first one carrying it.
+    const sheets = page.locator("section.sheet");
+    expect(await sheets.count()).toBeGreaterThan(1);
+    for (const sheet of await sheets.all()) {
+      await expect(sheet.getByText(eventName).first()).toBeVisible();
+    }
   });
 
   test("door cards render one card per room and day", async ({ page }) => {
@@ -107,12 +115,14 @@ test.describe("Panel print pages", () => {
     expect(await roomHeadings.count()).toBeGreaterThan(1);
     await expect(page.getByText("Capacity: 18").first()).toBeVisible();
 
-    // A card hangs on a door for one day: every page names one room and one day.
-    const cards = page.locator("section");
+    // One h1 for the document, then one room and one day per sheet.
+    await expect(page.getByRole("heading", { level: 1 })).toHaveCount(1);
+    const cards = page.locator("section.sheet");
     expect(await cards.count()).toBeGreaterThan(0);
     for (const card of await cards.all()) {
-      await expect(card.getByRole("heading", { level: 1 })).toHaveCount(1);
       await expect(card.getByRole("heading", { level: 2 })).toHaveCount(1);
+      await expect(card.getByRole("heading", { level: 3 })).toHaveCount(1);
+      await expect(card.getByText(eventName).first()).toBeVisible();
     }
   });
 });

--- a/tests/e2e/tests/print-flow.spec.ts
+++ b/tests/e2e/tests/print-flow.spec.ts
@@ -98,7 +98,7 @@ test.describe("Panel print pages", () => {
 
     // A sheet torn off the stack still names its event, so every page repeats
     // the header rather than only the first one carrying it.
-    const sheets = page.locator("section.sheet");
+    const sheets = page.locator("main").getByRole("group");
     expect(await sheets.count()).toBeGreaterThan(1);
     for (const sheet of await sheets.all()) {
       await expect(sheet.getByText(eventName).first()).toBeVisible();
@@ -108,21 +108,26 @@ test.describe("Panel print pages", () => {
   test("door cards render one card per room and day", async ({ page }) => {
     await page.goto("/panel/event/kapitularz-2025-anonymized/timetable/print/door-cards/");
 
-    // Only rooms with sessions get a card; Miniature Painting always has some,
-    // spread over the three seeded days, so it gets one sheet per day.
-    const roomHeadings = page.getByRole("heading", { name: "Miniature Painting", exact: true });
-    await expect(roomHeadings.first()).toBeVisible();
-    expect(await roomHeadings.count()).toBeGreaterThan(1);
+    // Miniature Painting is the only room in its track and the seed schedules
+    // it on all three days, so it gets exactly three sheets — one per day.
+    await expect(
+      page.getByRole("heading", { name: "Miniature Painting", exact: true }),
+    ).toHaveCount(3);
     await expect(page.getByText("Capacity: 18").first()).toBeVisible();
 
     // One h1 for the document, then one room and one day per sheet.
     await expect(page.getByRole("heading", { level: 1 })).toHaveCount(1);
-    const cards = page.locator("section.sheet");
-    expect(await cards.count()).toBeGreaterThan(0);
+    const cards = page.locator("main").getByRole("group");
+    const labels: string[] = [];
     for (const card of await cards.all()) {
-      await expect(card.getByRole("heading", { level: 2 })).toHaveCount(1);
-      await expect(card.getByRole("heading", { level: 3 })).toHaveCount(1);
+      const room = card.getByRole("heading", { level: 2 });
+      const day = card.getByRole("heading", { level: 3 });
+      await expect(room).toHaveCount(1);
+      await expect(day).toHaveCount(1);
       await expect(card.getByText(eventName).first()).toBeVisible();
+      labels.push(`${await room.innerText()}|${await day.innerText()}`);
     }
+    // No room+day is printed twice.
+    expect(new Set(labels).size).toBe(labels.length);
   });
 });

--- a/tests/e2e/tests/print-flow.spec.ts
+++ b/tests/e2e/tests/print-flow.spec.ts
@@ -97,13 +97,22 @@ test.describe("Panel print pages", () => {
     await expect(page.getByRole("cell", { name: /11:00–13:00/ }).first()).toBeVisible();
   });
 
-  test("door cards render one card per room with its hours", async ({ page }) => {
+  test("door cards render one card per room and day", async ({ page }) => {
     await page.goto("/panel/event/kapitularz-2025-anonymized/timetable/print/door-cards/");
 
-    // Only rooms with sessions get a card; Miniature Painting always has some.
-    await expect(
-      page.getByRole("heading", { name: "Miniature Painting", exact: true }).first(),
-    ).toBeVisible();
+    // Only rooms with sessions get a card; Miniature Painting always has some,
+    // spread over the three seeded days, so it gets one sheet per day.
+    const roomHeadings = page.getByRole("heading", { name: "Miniature Painting", exact: true });
+    await expect(roomHeadings.first()).toBeVisible();
+    expect(await roomHeadings.count()).toBeGreaterThan(1);
     await expect(page.getByText("Capacity: 18").first()).toBeVisible();
+
+    // A card hangs on a door for one day: every page names one room and one day.
+    const cards = page.locator("section");
+    expect(await cards.count()).toBeGreaterThan(0);
+    for (const card of await cards.all()) {
+      await expect(card.getByRole("heading", { level: 1 })).toHaveCount(1);
+      await expect(card.getByRole("heading", { level: 2 })).toHaveCount(1);
+    }
   });
 });

--- a/tests/integration/web/panel/test_timetable_print.py
+++ b/tests/integration/web/panel/test_timetable_print.py
@@ -134,6 +134,29 @@ class TestTimetablePrintView:
             },
         )
 
+    def test_door_cards_page_without_scheduled_rooms(
+        self, authenticated_client, active_user, sphere, event, space
+    ):
+        sphere.managers.add(active_user)
+
+        response = authenticated_client.get(self.door_cards_url(event))
+
+        assert_response(
+            response,
+            HTTPStatus.OK,
+            template_name="panel/print/door-cards.html",
+            context_data={
+                "document": DoorCardsDocumentDTO(
+                    event_name=event.name,
+                    event_description=event.description,
+                    event_start=event.start_time,
+                    event_end=event.end_time,
+                    scope_name=None,
+                    cards=[],
+                )
+            },
+        )
+
     def test_door_cards_limited_to_time_window(
         self,
         authenticated_client,
@@ -195,7 +218,6 @@ class TestTimetablePrintView:
                 )
             },
         )
-        assert later_session.title not in response.content.decode()
 
     def test_opening_print_page_marks_event_printed(
         self, authenticated_client, active_user, sphere, event

--- a/tests/integration/web/panel/test_timetable_print.py
+++ b/tests/integration/web/panel/test_timetable_print.py
@@ -9,7 +9,6 @@ from django.utils.timezone import localdate
 from ludamus.links.db.django.models import Space
 from ludamus.pacts import EventDTO
 from ludamus.pacts.printing import (
-    DoorCardDayDTO,
     DoorCardDTO,
     DoorCardEntryDTO,
     DoorCardsDocumentDTO,
@@ -92,7 +91,8 @@ class TestTimetablePrintView:
         time_slot,
     ):
         sphere.managers.add(active_user)
-        empty_space = SpaceFactory(event=event, name="Empty Hall")
+        # Participant-facing cards: a room with nothing scheduled gets no card.
+        SpaceFactory(event=event, name="Empty Hall")
         AgendaItemFactory(
             session=session,
             space=space,
@@ -106,13 +106,33 @@ class TestTimetablePrintView:
             response,
             HTTPStatus.OK,
             template_name="panel/print/door-cards.html",
-            context_data={"document": ANY},
+            context_data={
+                "document": DoorCardsDocumentDTO(
+                    event_name=event.name,
+                    event_description=event.description,
+                    event_start=event.start_time,
+                    event_end=event.end_time,
+                    scope_name=None,
+                    cards=[
+                        DoorCardDTO(
+                            space_name=space.name,
+                            capacity=space.capacity,
+                            day=localdate(time_slot.start_time),
+                            entries=[
+                                DoorCardEntryDTO(
+                                    start_time=time_slot.start_time,
+                                    end_time=time_slot.start_time + timedelta(hours=1),
+                                    session=PrintSessionDTO(
+                                        title=session.title,
+                                        presenter_name=session.display_name,
+                                    ),
+                                )
+                            ],
+                        )
+                    ],
+                )
+            },
         )
-        content = response.content.decode()
-        assert space.name in content
-        # participant-facing cards: no card for an empty room, no gap rows
-        assert empty_space.name not in content
-        assert "Free slot" not in content
 
     def test_door_cards_limited_to_time_window(
         self,
@@ -159,20 +179,15 @@ class TestTimetablePrintView:
                         DoorCardDTO(
                             space_name=space.name,
                             capacity=space.capacity,
-                            days=[
-                                DoorCardDayDTO(
-                                    day=localdate(time_slot.start_time),
-                                    entries=[
-                                        DoorCardEntryDTO(
-                                            start_time=time_slot.start_time,
-                                            end_time=time_slot.start_time
-                                            + timedelta(hours=1),
-                                            session=PrintSessionDTO(
-                                                title=session.title,
-                                                presenter_name=session.display_name,
-                                            ),
-                                        )
-                                    ],
+                            day=localdate(time_slot.start_time),
+                            entries=[
+                                DoorCardEntryDTO(
+                                    start_time=time_slot.start_time,
+                                    end_time=time_slot.start_time + timedelta(hours=1),
+                                    session=PrintSessionDTO(
+                                        title=session.title,
+                                        presenter_name=session.display_name,
+                                    ),
                                 )
                             ],
                         )

--- a/tests/unit/test_printing_mills.py
+++ b/tests/unit/test_printing_mills.py
@@ -132,6 +132,25 @@ class TestBuildDoorCards:
 
         assert [c.space_name for c in document.cards] == ["Alfa", "Bravo"]
 
+    def test_a_room_used_on_two_days_gets_a_card_per_day(self):
+        spaces = [_space(1, "Alfa", 0)]
+        items = [
+            _item(1, 1, 9, 10, title="RPG", confirmed=True, day=2),
+            _item(2, 1, 9, 10, title="Larp", confirmed=True, day=1),
+        ]
+        service = _service(spaces=spaces, items=items, slots=[])
+
+        document = _door_cards(service)
+
+        assert [(c.space_name, c.day) for c in document.cards] == [
+            ("Alfa", date(2026, 6, 1)),
+            ("Alfa", date(2026, 6, 2)),
+        ]
+        assert [[e.session.title for e in c.entries] for c in document.cards] == [
+            ["Larp"],
+            ["RPG"],
+        ]
+
     def test_time_range_keeps_overlapping_entries_and_drops_empty_rooms(self):
         spaces = [_space(1, "Alfa", 0), _space(2, "Bravo", 1)]
         items = [
@@ -149,7 +168,7 @@ class TestBuildDoorCards:
         )
 
         assert [c.space_name for c in document.cards] == ["Alfa"]
-        entries = document.cards[0].days[0].entries
+        entries = document.cards[0].entries
         assert [entry.session.title for entry in entries] == ["RPG"]
 
     def test_empty_slots_and_sessionless_spaces_are_omitted(self):
@@ -163,7 +182,7 @@ class TestBuildDoorCards:
         document = _door_cards(service)
 
         assert [c.space_name for c in document.cards] == ["Alfa"]
-        entries = document.cards[0].days[0].entries
+        entries = document.cards[0].entries
         assert [e.session.title for e in entries] == ["RPG"]
 
     def test_includes_unconfirmed_scheduled_session(self):
@@ -174,7 +193,7 @@ class TestBuildDoorCards:
 
         document = _door_cards(service)
 
-        entries = document.cards[0].days[0].entries
+        entries = document.cards[0].entries
         assert entries[0].session is not None
         assert entries[0].session.title == "Larp"
 

--- a/tests/unit/test_printing_mills.py
+++ b/tests/unit/test_printing_mills.py
@@ -136,7 +136,8 @@ class TestBuildDoorCards:
         spaces = [_space(1, "Alfa", 0)]
         items = [
             _item(1, 1, 9, 10, title="RPG", confirmed=True, day=2),
-            _item(2, 1, 9, 10, title="Larp", confirmed=True, day=1),
+            _item(2, 1, 14, 15, title="Wieczorny", confirmed=True, day=1),
+            _item(3, 1, 9, 10, title="Larp", confirmed=True, day=1),
         ]
         service = _service(spaces=spaces, items=items, slots=[])
 
@@ -147,7 +148,7 @@ class TestBuildDoorCards:
             ("Alfa", date(2026, 6, 2)),
         ]
         assert [[e.session.title for e in c.entries] for c in document.cards] == [
-            ["Larp"],
+            ["Larp", "Wieczorny"],
             ["RPG"],
         ]
 


### PR DESCRIPTION
Door cards listed every day of the event on a single A4 sheet per room. A card hangs on a door for one day, so break the page per (room, day) and repeat the event header, room name and capacity on each sheet.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Door cards now print as one A4 page per room and day, with entries grouped and ordered clearly.
  * Printed timetables and door cards now include event details and optional scope information on every page.
  * Improved screen previews with consistent A4 sizing, centering, spacing, and page boundaries.
  * Empty print views now display the document header alongside a clear empty-state message.

* **Bug Fixes**
  * Spaces without scheduled items no longer produce empty door cards.

* **Documentation**
  * Added documentation for a local linting issue affecting development environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->