### PR TITLE
fix(timetable): show only leaf spaces in the overview heatmap

### DIFF
--- a/src/ludamus/mills/timetable.py
+++ b/src/ludamus/mills/timetable.py
@@ -104,6 +104,25 @@ def _position_sessions(
     return positions
 
 
+def _leaves_in_tree_order(nodes: list[SpaceDTO]) -> list[SpaceDTO]:
+    children: dict[int | None, list[SpaceDTO]] = defaultdict(list)
+    for node in nodes:
+        children[node.parent_id].append(node)
+
+    leaves: list[SpaceDTO] = []
+
+    def walk(node: SpaceDTO) -> None:
+        if kids := children.get(node.pk, []):
+            for kid in kids:
+                walk(kid)
+        else:
+            leaves.append(node)
+
+    for root in children.get(None, []):
+        walk(root)
+    return leaves
+
+
 class TimetableService:
     def __init__(self, uow: UnitOfWorkProtocol) -> None:
         self._uow = uow
@@ -119,7 +138,7 @@ class TimetableService:
     ) -> TimetableGridDTO:
         all_nodes = self._uow.spaces.list_by_event(event_pk)
         node_name_by_pk = {node.pk: node.name for node in all_nodes}
-        leaf_spaces = self._leaves_in_tree_order(all_nodes)
+        leaf_spaces = _leaves_in_tree_order(all_nodes)
         if track_pk is not None:
             track_space_pks = set(self._uow.tracks.list_space_pks(track_pk))
             leaf_spaces = [
@@ -276,25 +295,6 @@ class TimetableService:
         )
 
     @staticmethod
-    def _leaves_in_tree_order(nodes: list[SpaceDTO]) -> list[SpaceDTO]:
-        children: dict[int | None, list[SpaceDTO]] = defaultdict(list)
-        for node in nodes:
-            children[node.parent_id].append(node)
-
-        leaves: list[SpaceDTO] = []
-
-        def walk(node: SpaceDTO) -> None:
-            if kids := children.get(node.pk, []):
-                for kid in kids:
-                    walk(kid)
-            else:
-                leaves.append(node)
-
-        for root in children.get(None, []):
-            walk(root)
-        return leaves
-
-    @staticmethod
     def _build_space_groups(
         spaces: list[SpaceDTO], name_by_pk: dict[int, str]
     ) -> list[SpaceGroupDTO]:
@@ -319,9 +319,7 @@ class TimetableService:
     def _require_space_in_event(self, space_pk: int, event_pk: int) -> None:
         leaf_pks = {
             space.pk
-            for space in self._leaves_in_tree_order(
-                self._uow.spaces.list_by_event(event_pk)
-            )
+            for space in _leaves_in_tree_order(self._uow.spaces.list_by_event(event_pk))
         }
         if space_pk not in leaf_pks:
             raise NotFoundError
@@ -742,7 +740,9 @@ class TimetableOverviewService:
     def build_heatmap(
         self, event_pk: int, tz: tzinfo, conflicts: list[ConflictDTO] | None = None
     ) -> HeatmapDTO:
-        spaces = self._uow.spaces.list_by_event(event_pk)
+        # Only leaf spaces are bookable rooms; a venue or area column would be
+        # permanently empty.
+        spaces = _leaves_in_tree_order(self._uow.spaces.list_by_event(event_pk))
         all_items = self._uow.agenda_items.list_by_event(event_pk)
         if conflicts is None:
             conflicts = self.get_all_conflicts(event_pk)

--- a/src/ludamus/mills/timetable.py
+++ b/src/ludamus/mills/timetable.py
@@ -855,11 +855,7 @@ class TimetableOverviewService:
         # Capacity = one program slot per room: every room is bookable for the
         # whole of each event time slot. Scheduled = hours already occupied by
         # placed agenda items in those rooms. Hours-to-fill is the remainder.
-        # Only leaf spaces are bookable rooms — a venue or area node would
-        # inflate capacity with slots nothing can ever fill.
-        spaces = self._uow.spaces.list_by_event(event_pk)
-        parent_pks = {s.parent_id for s in spaces if s.parent_id is not None}
-        rooms = [s for s in spaces if s.pk not in parent_pks]
+        rooms = _leaves_in_tree_order(self._uow.spaces.list_by_event(event_pk))
         room_count = len(rooms)
 
         slots = self._uow.time_slots.list_by_event(event_pk)

--- a/tests/unit/test_timetable_mills.py
+++ b/tests/unit/test_timetable_mills.py
@@ -864,6 +864,27 @@ class TestTimetableOverviewServiceDefaults:
         assert result.spaces == []
         assert not result.days
 
+    def test_build_heatmap_columns_are_leaf_spaces_only(self, mock_uow):
+        # Venue (1) > area (2) > rooms (3, 4): only the rooms are bookable.
+        mock_uow.spaces.list_by_event.return_value = [
+            _space(1),
+            _space(2, parent_id=1),
+            _space(3, parent_id=2),
+            _space(4, parent_id=2),
+        ]
+        mock_uow.time_slots.list_by_event.return_value = [
+            _slot(
+                datetime(2026, 1, 1, 10, 0, tzinfo=UTC),
+                datetime(2026, 1, 1, 11, 0, tzinfo=UTC),
+            )
+        ]
+        svc = TimetableOverviewService(mock_uow)
+
+        result = svc.build_heatmap(event_pk=1, tz=UTC, conflicts=[])
+
+        assert [s.pk for s in result.spaces] == [3, 4]
+        assert [c.space_pk for c in result.rows[0].cells] == [3, 4]
+
     def test_all_conflicts_grouped_fetches_conflicts_when_none(self, mock_uow):
         # conflicts=None makes all_conflicts_grouped fetch conflicts itself.
         svc = TimetableOverviewService(mock_uow)

--- a/tests/unit/test_timetable_mills.py
+++ b/tests/unit/test_timetable_mills.py
@@ -17,7 +17,12 @@ from ludamus.pacts import (
     TimeSlotDTO,
     TrackSessionCountsDTO,
 )
-from ludamus.pacts.chronology import CapacityHoursDTO, ConflictType, SessionPlacement
+from ludamus.pacts.chronology import (
+    CapacityHoursDTO,
+    ConflictType,
+    HeatmapCellStatus,
+    SessionPlacement,
+)
 
 
 def _make_item(**overrides):
@@ -878,12 +883,18 @@ class TestTimetableOverviewServiceDefaults:
                 datetime(2026, 1, 1, 11, 0, tzinfo=UTC),
             )
         ]
+        # An item in room 3 must survive the leaf filter and colour its cell.
+        mock_uow.agenda_items.list_by_event.return_value = [_make_item(space_id=3)]
         svc = TimetableOverviewService(mock_uow)
 
         result = svc.build_heatmap(event_pk=1, tz=UTC, conflicts=[])
 
         assert [s.pk for s in result.spaces] == [3, 4]
         assert [c.space_pk for c in result.rows[0].cells] == [3, 4]
+        assert [c.status for c in result.rows[0].cells] == [
+            HeatmapCellStatus.SCHEDULED,
+            HeatmapCellStatus.EMPTY,
+        ]
 
     def test_all_conflicts_grouped_fetches_conflicts_when_none(self, mock_uow):
         # conflicts=None makes all_conflicts_grouped fetch conflicts itself.


### PR DESCRIPTION
build_heatmap rendered a column for every Space in the event, so venue and area branch nodes appeared as permanently empty rooms. Filter to leaves, matching the timetable grid and capacity_hours.

_leaves_in_tree_order moves from a TimetableService staticmethod to a module-level function now that two services use it.