### PR TITLE
fix(panel): lay the proposal form out with grid, not multicol

### DIFF
--- a/src/ludamus/templates/panel/parts/proposal-session-fields.html
+++ b/src/ludamus/templates/panel/parts/proposal-session-fields.html
@@ -1,11 +1,10 @@
 {% load i18n %}
 {% load tessera %}
-<div id="proposal-session-fields"
-     class="space-y-6 break-inside-avoid mb-6">
+<div id="proposal-session-fields" class="space-y-6">
     <div class="card">
         <div class="card-body">
             <h3 class="text-lg font-semibold text-foreground mb-2">{% translate "Participants and duration" %}</h3>
-            {# Stacked, not columns: the card sits in a narrow masonry column, #}
+            {# Stacked, not columns: the card sits in a narrow grid column, #}
             {# where a two-up grid squeezes the duration steppers into a wrap. #}
             <div class="space-y-4">
                 <div>{% tessera_field form.participants_limit %}</div>

--- a/src/ludamus/templates/panel/parts/proposal-session-fields.html
+++ b/src/ludamus/templates/panel/parts/proposal-session-fields.html
@@ -1,5 +1,7 @@
 {% load i18n %}
 {% load tessera %}
+{# One grid cell on purpose: hx-swap="outerHTML" needs a real element to #}
+{# replace, so these cards stack together instead of each taking a cell. #}
 <div id="proposal-session-fields" class="space-y-6">
     <div class="card">
         <div class="card-body">

--- a/src/ludamus/templates/panel/proposal-form.html
+++ b/src/ludamus/templates/panel/proposal-form.html
@@ -45,10 +45,10 @@
         <form id="proposal-form"
               method="post"
               enctype="multipart/form-data"
-              class="p-4 lg:p-6 columns-1 lg:columns-2 xl:columns-3 gap-6">
+              class="p-4 lg:p-6 grid grid-cols-1 lg:grid-cols-2 xl:grid-cols-3 gap-6 items-start">
             {% csrf_token %}
             <div class="contents">
-                <div class="card break-inside-avoid mb-6">
+                <div class="card">
                     <div class="card-body">
                         <h3 class="text-lg font-semibold text-foreground mb-2">{% translate "Session Details" %}</h3>
                         <div class="space-y-6">
@@ -90,7 +90,7 @@
             </div>
             <div class="contents">
                 {% if all_facilitators %}
-                    <div class="card break-inside-avoid mb-6">
+                    <div class="card">
                         <div class="card-body">
                             <input type="hidden" name="facilitators_submitted" value="1">
                             <h3 class="text-lg font-semibold text-foreground mb-2">
@@ -101,7 +101,7 @@
                         </div>
                     </div>
                 {% elif not proposal %}
-                    <div class="card break-inside-avoid mb-6">
+                    <div class="card">
                         <div class="card-body">
                             <h3 class="text-lg font-semibold text-foreground mb-2">
                                 {% translate "Facilitators" %}<span class="text-danger ml-0.5">*</span>
@@ -118,7 +118,7 @@
                     </div>
                 {% endif %}
                 {% if all_tracks %}
-                    <div class="card break-inside-avoid mb-6">
+                    <div class="card">
                         <div class="card-body">
                             <input type="hidden" name="tracks_submitted" value="1">
                             <h3 class="text-lg font-semibold text-foreground mb-2">{% translate "Tracks" %}</h3>
@@ -137,7 +137,7 @@
                     </div>
                 {% endif %}
                 {% if all_time_slots %}
-                    <div class="card break-inside-avoid mb-6">
+                    <div class="card">
                         <div class="card-body">
                             <input type="hidden" name="time_slots_submitted" value="1">
                             {% include "panel/parts/time-slot-picker.html" %}
@@ -145,7 +145,7 @@
                     </div>
                 {% endif %}
                 {% if facilitator_personal_data %}
-                    <div class="card break-inside-avoid mb-6">
+                    <div class="card">
                         <div class="card-body">
                             <input type="hidden" name="personal_data_submitted" value="1">
                             <h3 class="text-lg font-semibold text-foreground mb-2">{% translate "Facilitator personal data" %}</h3>

--- a/src/ludamus/templates/panel/proposal-form.html
+++ b/src/ludamus/templates/panel/proposal-form.html
@@ -37,7 +37,7 @@
 {% endblock header_actions %}
 {% block content %}
     {% if current_event %}
-        {# Form-level errors live here, outside the column flow, so they show #}
+        {# Form-level errors live here, outside the grid, so they show #}
         {# whichever cards the event's data happens to render. #}
         {% if form.non_field_errors %}
             <div class="px-4 pt-4 lg:px-6 lg:pt-6">{% tessera_errors form %}</div>
@@ -47,129 +47,125 @@
               enctype="multipart/form-data"
               class="p-4 lg:p-6 grid grid-cols-1 lg:grid-cols-2 xl:grid-cols-3 gap-6 items-start">
             {% csrf_token %}
-            <div class="contents">
+            <div class="card">
+                <div class="card-body">
+                    <h3 class="text-lg font-semibold text-foreground mb-2">{% translate "Session Details" %}</h3>
+                    <div class="space-y-6">
+                        <div>{% tessera_field form.title %}</div>
+                        <div>
+                            <div class="flex items-center gap-1 mb-1">
+                                {% translate "Category" as t_category %}
+                                {% include "components/label.html" with for_id="id_category_id" text=t_category required=True only %}
+                                <span id="category-spinner"
+                                      class="htmx-indicator inline-block h-4 w-4 rounded-full border-2 border-border border-t-primary motion-safe:animate-spin"
+                                      role="status"
+                                      aria-label="{% translate "Loading" %}"></span>
+                            </div>
+                            {% select name="category_id" id="id_category_id" hx-get=fields_url hx-target="#proposal-session-fields" hx-swap="outerHTML" hx-indicator="#category-spinner" has_errors=form.category_id.errors aria-describedby=form.category_id.errors|yesno:"id_category_id_errors," %}
+                                {% for value, label in form.category_id.field.choices %}
+                                    <option value="{{ value }}"
+                                            {% if form.category_id.value|stringformat:"s" == value|stringformat:"s" %}selected{% endif %}>
+                                        {{ label }}
+                                    </option>
+                                {% endfor %}
+                            {% end_select %}
+                            {% if form.category_id.errors %}
+                                <p id="id_category_id_errors" class="text-xs mt-1 text-danger">{{ form.category_id.errors.0 }}</p>
+                            {% endif %}
+                        </div>
+                        <div>{% tessera_field form.cover_image %}</div>
+                        <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+                            <div>{% tessera_field form.display_name %}</div>
+                            <div>{% tessera_field form.contact_email %}</div>
+                        </div>
+                        <div>{% tessera_field form.description %}</div>
+                        {# Participants limit and duration live in the swapped #}
+                        {# region below: the category rebuilds them, min age it doesn't. #}
+                        <div>{% tessera_field form.min_age %}</div>
+                    </div>
+                </div>
+            </div>
+            {% include "panel/parts/proposal-session-fields.html" %}
+            {% if all_facilitators %}
                 <div class="card">
                     <div class="card-body">
-                        <h3 class="text-lg font-semibold text-foreground mb-2">{% translate "Session Details" %}</h3>
-                        <div class="space-y-6">
-                            <div>{% tessera_field form.title %}</div>
-                            <div>
-                                <div class="flex items-center gap-1 mb-1">
-                                    {% translate "Category" as t_category %}
-                                    {% include "components/label.html" with for_id="id_category_id" text=t_category required=True only %}
-                                    <span id="category-spinner"
-                                          class="htmx-indicator inline-block h-4 w-4 rounded-full border-2 border-border border-t-primary motion-safe:animate-spin"
-                                          role="status"
-                                          aria-label="{% translate "Loading" %}"></span>
-                                </div>
-                                {% select name="category_id" id="id_category_id" hx-get=fields_url hx-target="#proposal-session-fields" hx-swap="outerHTML" hx-indicator="#category-spinner" has_errors=form.category_id.errors aria-describedby=form.category_id.errors|yesno:"id_category_id_errors," %}
-                                    {% for value, label in form.category_id.field.choices %}
-                                        <option value="{{ value }}"
-                                                {% if form.category_id.value|stringformat:"s" == value|stringformat:"s" %}selected{% endif %}>
-                                            {{ label }}
-                                        </option>
-                                    {% endfor %}
-                                {% end_select %}
-                                {% if form.category_id.errors %}
-                                    <p id="id_category_id_errors" class="text-xs mt-1 text-danger">{{ form.category_id.errors.0 }}</p>
-                                {% endif %}
-                            </div>
-                            <div>{% tessera_field form.cover_image %}</div>
-                            <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
-                                <div>{% tessera_field form.display_name %}</div>
-                                <div>{% tessera_field form.contact_email %}</div>
-                            </div>
-                            <div>{% tessera_field form.description %}</div>
-                            {# Participants limit and duration live in the swapped #}
-                            {# region below: the category rebuilds them, min age it doesn't. #}
-                            <div>{% tessera_field form.min_age %}</div>
+                        <input type="hidden" name="facilitators_submitted" value="1">
+                        <h3 class="text-lg font-semibold text-foreground mb-2">
+                            {% translate "Facilitators" %}
+                            {% if not proposal %}<span class="text-danger ml-0.5">*</span>{% endif %}
+                        </h3>
+                        {% include "panel/parts/facilitator-picker.html" %}
+                    </div>
+                </div>
+            {% elif not proposal %}
+                <div class="card">
+                    <div class="card-body">
+                        <h3 class="text-lg font-semibold text-foreground mb-2">
+                            {% translate "Facilitators" %}<span class="text-danger ml-0.5">*</span>
+                        </h3>
+                        <p class="text-sm text-foreground-muted">
+                            {% translate "This event has no facilitators yet." %}
+                            {# New tab: the proposal being typed here has no draft storage. #}
+                            <a href="{% url 'panel:facilitator-create' slug=current_event.slug %}"
+                               target="_blank"
+                               rel="noopener"
+                               class="text-primary underline hover:no-underline ml-1">{% translate "Create one first" %}</a>
+                        </p>
+                    </div>
+                </div>
+            {% endif %}
+            {% if all_tracks %}
+                <div class="card">
+                    <div class="card-body">
+                        <input type="hidden" name="tracks_submitted" value="1">
+                        <h3 class="text-lg font-semibold text-foreground mb-2">{% translate "Tracks" %}</h3>
+                        <p class="text-sm text-foreground-muted mb-4">
+                            {% translate "Assign this proposal to one or more programme tracks." %}
+                        </p>
+                        <div class="space-y-2">
+                            {% for t in all_tracks %}
+                                <label class="flex items-center gap-2 py-2 text-sm">
+                                    {% include "components/checkbox-field.html" with name="track_ids" value=t.pk checked_values=assigned_track_pks label="" only %}
+                                    {{ t.name }}
+                                </label>
+                            {% endfor %}
                         </div>
                     </div>
                 </div>
-                {% include "panel/parts/proposal-session-fields.html" %}
-            </div>
-            <div class="contents">
-                {% if all_facilitators %}
-                    <div class="card">
-                        <div class="card-body">
-                            <input type="hidden" name="facilitators_submitted" value="1">
-                            <h3 class="text-lg font-semibold text-foreground mb-2">
-                                {% translate "Facilitators" %}
-                                {% if not proposal %}<span class="text-danger ml-0.5">*</span>{% endif %}
-                            </h3>
-                            {% include "panel/parts/facilitator-picker.html" %}
+            {% endif %}
+            {% if all_time_slots %}
+                <div class="card">
+                    <div class="card-body">
+                        <input type="hidden" name="time_slots_submitted" value="1">
+                        {% include "panel/parts/time-slot-picker.html" %}
+                    </div>
+                </div>
+            {% endif %}
+            {% if facilitator_personal_data %}
+                <div class="card">
+                    <div class="card-body">
+                        <input type="hidden" name="personal_data_submitted" value="1">
+                        <h3 class="text-lg font-semibold text-foreground mb-2">{% translate "Facilitator personal data" %}</h3>
+                        <p class="text-sm text-foreground-muted mb-4">
+                            {% translate "Personal-data answers for each assigned facilitator." %}
+                        </p>
+                        <div class="space-y-3">
+                            {% for card in facilitator_personal_data %}
+                                <details class="border border-border rounded-lg"
+                                         {% if card.has_errors %}open{% endif %}>
+                                    <summary class="cursor-pointer px-4 py-2 text-sm font-medium text-foreground">{{ card.facilitator.display_name }}</summary>
+                                    <div class="px-4 pb-4 pt-2">
+                                        <input type="hidden"
+                                               name="personal_data_facilitator_ids"
+                                               value="{{ card.facilitator.pk }}">
+                                        {% include "panel/_personal_data_fields.html" with descriptors=card.descriptors %}
+                                    </div>
+                                </details>
+                            {% endfor %}
                         </div>
                     </div>
-                {% elif not proposal %}
-                    <div class="card">
-                        <div class="card-body">
-                            <h3 class="text-lg font-semibold text-foreground mb-2">
-                                {% translate "Facilitators" %}<span class="text-danger ml-0.5">*</span>
-                            </h3>
-                            <p class="text-sm text-foreground-muted">
-                                {% translate "This event has no facilitators yet." %}
-                                {# New tab: the proposal being typed here has no draft storage. #}
-                                <a href="{% url 'panel:facilitator-create' slug=current_event.slug %}"
-                                   target="_blank"
-                                   rel="noopener"
-                                   class="text-primary underline hover:no-underline ml-1">{% translate "Create one first" %}</a>
-                            </p>
-                        </div>
-                    </div>
-                {% endif %}
-                {% if all_tracks %}
-                    <div class="card">
-                        <div class="card-body">
-                            <input type="hidden" name="tracks_submitted" value="1">
-                            <h3 class="text-lg font-semibold text-foreground mb-2">{% translate "Tracks" %}</h3>
-                            <p class="text-sm text-foreground-muted mb-4">
-                                {% translate "Assign this proposal to one or more programme tracks." %}
-                            </p>
-                            <div class="space-y-2">
-                                {% for t in all_tracks %}
-                                    <label class="flex items-center gap-2 py-2 text-sm">
-                                        {% include "components/checkbox-field.html" with name="track_ids" value=t.pk checked_values=assigned_track_pks label="" only %}
-                                        {{ t.name }}
-                                    </label>
-                                {% endfor %}
-                            </div>
-                        </div>
-                    </div>
-                {% endif %}
-                {% if all_time_slots %}
-                    <div class="card">
-                        <div class="card-body">
-                            <input type="hidden" name="time_slots_submitted" value="1">
-                            {% include "panel/parts/time-slot-picker.html" %}
-                        </div>
-                    </div>
-                {% endif %}
-                {% if facilitator_personal_data %}
-                    <div class="card">
-                        <div class="card-body">
-                            <input type="hidden" name="personal_data_submitted" value="1">
-                            <h3 class="text-lg font-semibold text-foreground mb-2">{% translate "Facilitator personal data" %}</h3>
-                            <p class="text-sm text-foreground-muted mb-4">
-                                {% translate "Personal-data answers for each assigned facilitator." %}
-                            </p>
-                            <div class="space-y-3">
-                                {% for card in facilitator_personal_data %}
-                                    <details class="border border-border rounded-lg"
-                                             {% if card.has_errors %}open{% endif %}>
-                                        <summary class="cursor-pointer px-4 py-2 text-sm font-medium text-foreground">{{ card.facilitator.display_name }}</summary>
-                                        <div class="px-4 pb-4 pt-2">
-                                            <input type="hidden"
-                                                   name="personal_data_facilitator_ids"
-                                                   value="{{ card.facilitator.pk }}">
-                                            {% include "panel/_personal_data_fields.html" with descriptors=card.descriptors %}
-                                        </div>
-                                    </details>
-                                {% endfor %}
-                            </div>
-                        </div>
-                    </div>
-                {% endif %}
-            </div>
+                </div>
+            {% endif %}
         </form>
     {% endif %}
 {% endblock content %}

--- a/tests/e2e/tests/proposal-form-layout.spec.ts
+++ b/tests/e2e/tests/proposal-form-layout.spec.ts
@@ -1,0 +1,37 @@
+import { expect, test } from "./helpers/fixtures";
+
+// The form used to be a CSS multi-column masonry. Cards carrying
+// break-inside-avoid overflowed the balanced column box, so the tall column
+// painted over the footer and the page ended mid-content.
+const columnLefts = async (page: import("@playwright/test").Page) =>
+  page
+    .locator("#proposal-form .card")
+    .evaluateAll((cards) => [
+      ...new Set(cards.map((card) => Math.round(card.getBoundingClientRect().left))),
+    ]);
+
+test.describe("Proposal form layout", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto("/admin/login/", { waitUntil: "domcontentloaded" });
+    await page.getByLabel("Username:").fill("e2e-manager");
+    await page.getByLabel("Password:").fill("e2e-manager-123");
+    await page.getByRole("button", { name: /Log in/i }).click();
+  });
+
+  test("keeps three columns wide, one narrow, and never covers the footer", async ({ page }) => {
+    await page.setViewportSize({ width: 1440, height: 900 });
+    await page.goto("/panel/event/frostfire-con/proposals/create/");
+    await expect(page.locator("#proposal-form")).toBeVisible();
+
+    expect(await columnLefts(page)).toHaveLength(3);
+
+    const form = await page.locator("#proposal-form").boundingBox();
+    const footer = await page.locator("footer").boundingBox();
+    expect(form).not.toBeNull();
+    expect(footer).not.toBeNull();
+    expect(form!.y + form!.height).toBeLessThanOrEqual(footer!.y + 1);
+
+    await page.setViewportSize({ width: 480, height: 900 });
+    expect(await columnLefts(page)).toHaveLength(1);
+  });
+});

--- a/tests/e2e/tests/proposal-form-layout.spec.ts
+++ b/tests/e2e/tests/proposal-form-layout.spec.ts
@@ -1,14 +1,19 @@
 import { expect, test } from "./helpers/fixtures";
 
-// The form used to be a CSS multi-column masonry. Cards carrying
-// break-inside-avoid overflowed the balanced column box, so the tall column
-// painted over the footer and the page ended mid-content.
-const columnLefts = async (page: import("@playwright/test").Page) =>
-  page
-    .locator("#proposal-form .card")
-    .evaluateAll((cards) => [
-      ...new Set(cards.map((card) => Math.round(card.getBoundingClientRect().left))),
-    ]);
+// The form used to be a CSS multi-column masonry, and the tall column painted
+// over the footer. Read the layout mode itself, not how many cards the event's
+// data happens to render: multicol computes grid-template-columns: none, grid
+// computes one px track per column.
+//
+// Only the column contract is pinned. The overlap it caused is not: measuring
+// the lowest card's bottom against the footer passes on the pre-fix markup too
+// (Chromium expands the multicol box to its tallest column), so an assertion
+// about it would read as coverage without ever failing.
+const columnCount = async (page: import("@playwright/test").Page) =>
+  page.locator("#proposal-form").evaluate((form) => {
+    const { display, gridTemplateColumns } = getComputedStyle(form);
+    return display === "grid" ? gridTemplateColumns.split(" ").length : 0;
+  });
 
 test.describe("Proposal form layout", () => {
   test.beforeEach(async ({ page }) => {
@@ -18,20 +23,17 @@ test.describe("Proposal form layout", () => {
     await page.getByRole("button", { name: /Log in/i }).click();
   });
 
-  test("keeps three columns wide, one narrow, and never covers the footer", async ({ page }) => {
+  test("keeps three columns wide, two medium, one narrow", async ({ page }) => {
     await page.setViewportSize({ width: 1440, height: 900 });
     await page.goto("/panel/event/frostfire-con/proposals/create/");
     await expect(page.locator("#proposal-form")).toBeVisible();
 
-    expect(await columnLefts(page)).toHaveLength(3);
+    expect(await columnCount(page)).toBe(3);
 
-    const form = await page.locator("#proposal-form").boundingBox();
-    const footer = await page.locator("footer").boundingBox();
-    expect(form).not.toBeNull();
-    expect(footer).not.toBeNull();
-    expect(form!.y + form!.height).toBeLessThanOrEqual(footer!.y + 1);
+    await page.setViewportSize({ width: 1100, height: 900 });
+    expect(await columnCount(page)).toBe(2);
 
     await page.setViewportSize({ width: 480, height: 900 });
-    expect(await columnLefts(page)).toHaveLength(1);
+    expect(await columnCount(page)).toBe(1);
   });
 });


### PR DESCRIPTION
The form was a CSS multi-column masonry. Every card carried break-inside-avoid, so a column the browser couldn't split overflowed the balanced column box: the footer was laid out after the (too short) container height and the tall column painted straight over it — theme switcher and copyright line ended up behind the facilitators card, with cards continuing below the end of the page.

Real grid columns instead: three at xl, two at lg, one below. The display:contents wrappers stay — they're only broken inside multicol — so the conditional cards keep flowing into the grid on their own. items-start keeps each card at its content height.

Lost with masonry: column height balancing. Rows align now, so a short card leaves whitespace under it. In exchange the cards no longer get shuffled between columns as the event's data changes.

The e2e regression pins three columns at 1440px, one at 480px, and that the form's box never reaches past the footer's top. Against the old markup it fails at the first assertion — multicol put the cards in two columns, not three.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Updated the proposal form to use a responsive grid layout.
  * Improved spacing and alignment across proposal form sections.
  * The form now displays in three columns on desktop and collapses to one column on mobile.
  * Prevented the form from overlapping the footer.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->