### PR TITLE
Session modal: clip the description, tighten the host row, reopen at the top

### DIFF
--- a/src/ludamus/client/src/modal.css
+++ b/src/ludamus/client/src/modal.css
@@ -87,8 +87,7 @@
 ::view-transition-group(session-morph),
 ::view-transition-group(morph-title),
 ::view-transition-group(morph-host),
-::view-transition-group(morph-avatar),
-::view-transition-group(morph-desc) {
+::view-transition-group(morph-avatar) {
   animation-duration: var(--vt-morph-duration);
   animation-timing-function: var(--vt-morph-ease);
 }
@@ -108,13 +107,12 @@
   mix-blend-mode: normal;
 }
 
-/* Card content that the modal re-renders elsewhere (or drops) is cut the moment
-   the morph starts. Without this the card's tag pills and its meta row keep
-   painting under the description as it grows past them — the container snapshot
-   they belong to fades over 55% of the morph, which is long enough to read. */
+/* Card content the modal re-renders elsewhere (or drops) is cut the moment the
+   morph starts, rather than lingering in the container snapshot as it fades out
+   over 55% of the morph — long enough to read through the modal arriving on top
+   of it. Same treatment the title and host already get. */
 ::view-transition-old(morph-title),
 ::view-transition-old(morph-host),
-::view-transition-old(morph-desc),
 ::view-transition-old(morph-tags),
 ::view-transition-old(morph-meta),
 ::view-transition-old(morph-time) {
@@ -139,7 +137,8 @@
     calc(var(--vt-morph-duration) * 0.35) both;
 }
 
-::view-transition-new(morph-desc-label) {
+::view-transition-new(morph-desc-label),
+::view-transition-new(morph-venue) {
   animation: vt-chrome-in calc(var(--vt-morph-duration) * 0.4) var(--vt-morph-ease)
     calc(var(--vt-morph-duration) * 0.5) both;
 }
@@ -260,12 +259,10 @@
   ::view-transition-group(morph-title),
   ::view-transition-group(morph-host),
   ::view-transition-group(morph-avatar),
-  ::view-transition-group(morph-desc),
   ::view-transition-old(session-morph),
   ::view-transition-new(session-morph),
   ::view-transition-old(morph-title),
   ::view-transition-old(morph-host),
-  ::view-transition-old(morph-desc),
   ::view-transition-old(morph-tags),
   ::view-transition-old(morph-meta),
   ::view-transition-old(morph-time),
@@ -273,6 +270,7 @@
   ::view-transition-new(morph-avatar),
   ::view-transition-new(morph-tabs),
   ::view-transition-new(morph-desc-label),
+  ::view-transition-new(morph-venue),
   ::view-transition-new(morph-footer) {
     animation: none;
   }

--- a/src/ludamus/client/src/modal.css
+++ b/src/ludamus/client/src/modal.css
@@ -122,13 +122,30 @@
   opacity: 0;
 }
 
-/* Modal chrome with no card counterpart is captured as a new-only group. A
-   new-only group has no old geometry to interpolate, so it renders at its final
-   layout for the whole morph instead of being stretched along with the container
-   snapshot — which is what keeps the footer's controls crisp and still while the
-   modal grows behind them. It carries the modal's surface colour because that
-   snapshot underneath is mid-cross-fade with the card and would otherwise show
-   through. */
+/* Chrome that exists only in the modal is captured as a new-only group, and a
+   new-only group has no old geometry to interpolate — it renders at its final
+   layout for the entire morph. On a wide viewport the sheet is still a third of
+   its final width at that point, so the footer's button reads as floating in
+   space next to it rather than belonging to it.
+
+   Nesting the group inside session-morph puts it back under the container's
+   transform and clip, so it travels and crops with the sheet. The elements keep
+   their names, which is what separates this from simply dropping the names: the
+   stagger below still applies, and the tab bar still waits for the title to fly
+   past instead of painting over it.
+
+   Level 2, and no WebKit support yet — Safari drops the declaration and keeps
+   today's flat behaviour. That degrades well because the cost is proportional to
+   how much the sheet moves sideways, and on a phone it barely does: the dialog
+   is near full-width, so the card grows ~11% in width against ~108% in height
+   and the footer lands roughly where the sheet already is. */
+[data-morph="tabs"],
+[data-morph="footer"] {
+  view-transition-group: nearest;
+}
+
+/* The footer carries the modal's surface colour because the container snapshot
+   underneath is mid-cross-fade with the card and would otherwise show through. */
 ::view-transition-new(morph-footer) {
   animation-duration: var(--vt-morph-duration);
   animation-timing-function: var(--vt-morph-ease);

--- a/src/ludamus/client/src/modal.css
+++ b/src/ludamus/client/src/modal.css
@@ -107,10 +107,12 @@
   mix-blend-mode: normal;
 }
 
-/* Card content the modal re-renders elsewhere (or drops) is cut the moment the
-   morph starts, rather than lingering in the container snapshot as it fades out
-   over 55% of the morph — long enough to read through the modal arriving on top
-   of it. Same treatment the title and host already get. */
+/* Each of these carries its own name, so it is lifted out of the card's snapshot
+   into a group of its own, and an old-only group is appended after
+   session-morph — it paints on top of the arriving modal, not behind it. None of
+   them appears in the paired-group timing above either, so without this they
+   would sit crisply legible over the new modal for the UA's default 0.25s fade.
+   Cut them at the start instead. Same treatment the title and host already get. */
 ::view-transition-old(morph-title),
 ::view-transition-old(morph-host),
 ::view-transition-old(morph-tags),
@@ -120,9 +122,13 @@
   opacity: 0;
 }
 
-/* Modal chrome with no card counterpart is captured as a new-only group, which
-   the spec appends after every paired group — so these paint above the morphing
-   description and, being opaque, finally occlude it. */
+/* Modal chrome with no card counterpart is captured as a new-only group. A
+   new-only group has no old geometry to interpolate, so it renders at its final
+   layout for the whole morph instead of being stretched along with the container
+   snapshot — which is what keeps the footer's controls crisp and still while the
+   modal grows behind them. It carries the modal's surface colour because that
+   snapshot underneath is mid-cross-fade with the card and would otherwise show
+   through. */
 ::view-transition-new(morph-footer) {
   animation-duration: var(--vt-morph-duration);
   animation-timing-function: var(--vt-morph-ease);
@@ -255,23 +261,8 @@
       display 0.2s allow-discrete;
   }
 
-  ::view-transition-group(session-morph),
-  ::view-transition-group(morph-title),
-  ::view-transition-group(morph-host),
-  ::view-transition-group(morph-avatar),
-  ::view-transition-old(session-morph),
-  ::view-transition-new(session-morph),
-  ::view-transition-old(morph-title),
-  ::view-transition-old(morph-host),
-  ::view-transition-old(morph-tags),
-  ::view-transition-old(morph-meta),
-  ::view-transition-old(morph-time),
-  ::view-transition-old(morph-avatar),
-  ::view-transition-new(morph-avatar),
-  ::view-transition-new(morph-tabs),
-  ::view-transition-new(morph-desc-label),
-  ::view-transition-new(morph-venue),
-  ::view-transition-new(morph-footer) {
-    animation: none;
-  }
+  /* No morph rules here on purpose. `canMorph` in modal.ts refuses to start a
+     session morph under reduced motion, so no session-morph / morph-* name is
+     ever applied and every such selector would be dead. The gate lives in the
+     JS because it also has to pick the non-animated open path. */
 }

--- a/src/ludamus/client/src/modal.css
+++ b/src/ludamus/client/src/modal.css
@@ -87,7 +87,8 @@
 ::view-transition-group(session-morph),
 ::view-transition-group(morph-title),
 ::view-transition-group(morph-host),
-::view-transition-group(morph-avatar) {
+::view-transition-group(morph-avatar),
+::view-transition-group(morph-footer) {
   animation-duration: var(--vt-morph-duration);
   animation-timing-function: var(--vt-morph-ease);
 }
@@ -122,26 +123,34 @@
   opacity: 0;
 }
 
-/* Chrome that exists only in the modal is captured as a new-only group, and a
-   new-only group has no old geometry to interpolate — it renders at its final
-   layout for the entire morph. On a wide viewport the sheet is still a third of
-   its final width at that point, so the footer's button reads as floating in
-   space next to it rather than belonging to it.
+/* The tab bar exists only in the modal, so it is captured as a new-only group —
+   no old geometry to interpolate, so it renders at its final layout for the whole
+   morph while the sheet is still a fraction of its final width. Nesting it inside
+   session-morph puts it under the container's transform and clip, so it travels
+   and crops with the sheet. It keeps its name, which is what separates this from
+   dropping the name: the stagger below still applies, so the bar still waits for
+   the title to fly past instead of painting over it.
 
-   Nesting the group inside session-morph puts it back under the container's
-   transform and clip, so it travels and crops with the sheet. The elements keep
-   their names, which is what separates this from simply dropping the names: the
-   stagger below still applies, and the tab bar still waits for the title to fly
-   past instead of painting over it.
+   The footer does not want this. Nesting fixes where a group is drawn but not
+   where it starts from, and a new-only group starts at its own slot inside the
+   container — which for a card in the last column is the far right of the
+   viewport, so the bar slid in sideways. It is paired instead: see the anchor in
+   _session_card.html.
 
-   Level 2, and no WebKit support yet — Safari drops the declaration and keeps
-   today's flat behaviour. That degrades well because the cost is proportional to
-   how much the sheet moves sideways, and on a phone it barely does: the dialog
-   is near full-width, so the card grows ~11% in width against ~108% in height
-   and the footer lands roughly where the sheet already is. */
-[data-morph="tabs"],
-[data-morph="footer"] {
+   Level 2, and no WebKit support yet — Safari drops the declaration and keeps the
+   flat behaviour for the tabs. That degrades well because the cost is
+   proportional to how far the sheet travels sideways, and on a phone it barely
+   does: the dialog is near full-width, so the card grows ~11% in width against
+   ~108% in height. */
+[data-morph="tabs"] {
   view-transition-group: nearest;
+}
+
+/* The anchor renders nothing, so its snapshot is an empty strip. Cut it rather
+   than let it cross-fade for the UA's default 0.25s over the arriving bar. */
+::view-transition-old(morph-footer) {
+  animation: none;
+  opacity: 0;
 }
 
 /* The footer carries the modal's surface colour because the container snapshot

--- a/src/ludamus/client/src/modal.css
+++ b/src/ludamus/client/src/modal.css
@@ -143,15 +143,43 @@
     calc(var(--vt-morph-duration) * 0.35) both;
 }
 
-::view-transition-new(morph-desc-label),
-::view-transition-new(morph-venue) {
+::view-transition-new(morph-desc-label) {
   animation: vt-chrome-in calc(var(--vt-morph-duration) * 0.4) var(--vt-morph-ease)
+    calc(var(--vt-morph-duration) * 0.5) both;
+}
+
+/* The venue gets its own ramp rather than sharing the one above. It is small,
+   secondary text with no counterpart on the card, so a bare opacity fade over
+   0.4 of the morph reads as switching on rather than arriving. Resolving it out
+   of a blur gives the eye something to track, and running to exactly 1.0 (0.5
+   delay + 0.5 duration) lands it as the morph settles without extending the
+   transition — the pseudo-elements live until the longest animation on them
+   ends. Safari rasterises `filter` on a view-transition snapshot; the page-blur
+   keyframes below already rely on that. */
+::view-transition-new(morph-venue) {
+  animation: vt-venue-in calc(var(--vt-morph-duration) * 0.5) var(--vt-morph-ease)
     calc(var(--vt-morph-duration) * 0.5) both;
 }
 
 @keyframes vt-chrome-in {
   from {
     opacity: 0;
+  }
+}
+
+/* 8px, not the 4px the backdrop uses: this is 14px secondary text, and at 4px
+   the frames are almost indistinguishable from a plain fade. Both ends are
+   written out because interpolating a blur against an implicit `none` relies on
+   filter list-identity rules, and being explicit costs one line. */
+@keyframes vt-venue-in {
+  from {
+    opacity: 0;
+    filter: blur(8px);
+  }
+
+  to {
+    opacity: 1;
+    filter: blur(0);
   }
 }
 

--- a/src/ludamus/client/src/modal.ts
+++ b/src/ludamus/client/src/modal.ts
@@ -194,6 +194,25 @@ const dismissDialog = (dialog: HTMLDialogElement): void => {
   });
 };
 
+/**
+ * Fetched dialogs are cached in the DOM, so a reopen inherits wherever the last
+ * visit left the panel scrolled. That is worse than a cosmetic glitch here: the
+ * morph captures the modal's new state at open, so a stale offset is baked into
+ * the animation's destination and the card appears to expand into a modal that
+ * is already scrolled.
+ *
+ * Reset on open rather than on close. A closed dialog is `display: none`, where
+ * `scrollTop` is a no-op, so a close-side reset would have to run *before*
+ * `close()` and would visibly jerk the content mid-animation. This must also
+ * run after `showModal()` for the same reason — the element needs a box before
+ * the offset can be written.
+ */
+const resetModalScroll = (dialog: HTMLDialogElement): void => {
+  for (const element of dialog.querySelectorAll<HTMLElement>("*")) {
+    if (element.scrollTop !== 0) element.scrollTop = 0;
+  }
+};
+
 const openModal = async (
   id: string,
   { animate = true, replaceHistory = false, updateUrl = true } = {},
@@ -220,11 +239,13 @@ const openModal = async (
           setMorph(card, false);
           card.style.transition = "none";
           dialog.showModal();
+          resetModalScroll(dialog);
           setMorph(dialog, true);
         },
       });
     } else {
       dialog.showModal();
+      resetModalScroll(dialog);
       suppressSessionCard(id);
     }
   }

--- a/src/ludamus/client/src/modal.ts
+++ b/src/ludamus/client/src/modal.ts
@@ -201,16 +201,31 @@ const dismissDialog = (dialog: HTMLDialogElement): void => {
  * the animation's destination and the card appears to expand into a modal that
  * is already scrolled.
  *
- * Reset on open rather than on close. A closed dialog is `display: none`, where
- * `scrollTop` is a no-op, so a close-side reset would have to run *before*
- * `close()` and would visibly jerk the content mid-animation. This must also
- * run after `showModal()` for the same reason — the element needs a box before
- * the offset can be written.
+ * Reset on open, not on close, because opening has one choke point and closing
+ * has none — `closeModal` alone branches twice, `dismissDialog` branches again,
+ * and Esc or a `form[method=dialog]` closes the dialog without reaching either.
+ * `session-edit.ts` already shows what that costs: it binds its `close` listener
+ * over `document.querySelectorAll` at parse time, so the lazily fetched dialogs
+ * this function exists for never run it.
+ *
+ * A closed dialog is also `display: none`, and `scrollTop` is a no-op on an
+ * element with no layout box, so a reset after `close()` would silently do
+ * nothing. Same rule puts this after `showModal()` rather than before it.
  */
 const resetModalScroll = (dialog: HTMLDialogElement): void => {
+  // Not a class selector: the tab panels are the only scrollers in the rendered
+  // markup, but htmx swaps the edit form's own `overflow-y-auto` body in at
+  // runtime, and a dialog closed mid-edit keeps it (see above).
   for (const element of dialog.querySelectorAll<HTMLElement>("*")) {
     if (element.scrollTop !== 0) element.scrollTop = 0;
   }
+};
+
+// Both open paths need `showModal()` and the reset in that order, and the order
+// is load-bearing, so it lives here rather than in a comment at each call site.
+const presentDialog = (dialog: HTMLDialogElement): void => {
+  dialog.showModal();
+  resetModalScroll(dialog);
 };
 
 const openModal = async (
@@ -238,14 +253,12 @@ const openModal = async (
           suppressSessionCard(id);
           setMorph(card, false);
           card.style.transition = "none";
-          dialog.showModal();
-          resetModalScroll(dialog);
+          presentDialog(dialog);
           setMorph(dialog, true);
         },
       });
     } else {
-      dialog.showModal();
-      resetModalScroll(dialog);
+      presentDialog(dialog);
       suppressSessionCard(id);
     }
   }

--- a/src/ludamus/templates/chronology/_session_card.html
+++ b/src/ludamus/templates/chronology/_session_card.html
@@ -49,8 +49,8 @@
                 </div>
             </header>
             {% if data.session.description %}
+                {# Deliberately not a morph group: see session-modal.html. #}
                 <p class="pointer-events-auto select-text text-sm mb-2 line-clamp-3 text-foreground-primary"
-                   data-morph="desc"
                    data-session-description>{{ data.session.description }}</p>
             {% endif %}
             <div class="relative" data-morph="tags">{% include "chronology/session_tags.html" %}</div>

--- a/src/ludamus/templates/chronology/_session_card.html
+++ b/src/ludamus/templates/chronology/_session_card.html
@@ -99,5 +99,13 @@
                 </div>
             </div>
         </div>
+        {# Anchor for the modal's footer bar, which has nothing to morph from. As #}
+        {# a new-only group it materialised at a scaled-down slot inside the card #}
+        {# and slid across to the modal — from the far right, for a card in the #}
+        {# last column. Pairing it with a zero-height strip on the card's bottom #}
+        {# edge gives the group an old geometry to interpolate from, so it grows #}
+        {# out of that edge and tracks the sheet's bottom instead. Renders #}
+        {# nothing: it exists only to be captured. #}
+        <div class="h-0" aria-hidden="true" data-morph="footer"></div>
     </div>
 </article>

--- a/src/ludamus/templates/chronology/parts/session-modal.html
+++ b/src/ludamus/templates/chronology/parts/session-modal.html
@@ -53,12 +53,16 @@
                 <!-- Host & location -->
                 <div class="flex items-center gap-3 mb-6 flex-wrap">
                     <span class="shrink-0" data-morph="avatar">
-                        {% include "components/avatar.html" with user=data.presenter size="size-10" %}
+                        {% include "components/avatar.html" with user=data.presenter size="size-9" %}
                     </span>
                     {# flex-1 zeroes this group's flex basis so the outer row never #}
                     {# wraps it whole — a long room path breaks inside the group, #}
                     {# under the name, instead of orphaning the avatar on its own row. #}
-                    <div class="flex flex-1 items-center gap-3 flex-wrap min-w-0">
+                    {# The two gaps are separate on purpose: 12px reads as separation #}
+                    {# between name and room while they share a row, but as soon as #}
+                    {# the room wraps that same value becomes the row gap and pushes #}
+                    {# a sub-label 12px off the name it belongs to. #}
+                    <div class="flex flex-1 items-center gap-x-3 gap-y-0.5 flex-wrap min-w-0">
                         <div class="font-medium text-foreground" data-morph="host">{{ data.presenter.full_name }}</div>
                         {% if data.location_label %}
                             {# The room sits beside a name that is still flying in from #}
@@ -66,7 +70,10 @@
                             {# Its own group lets it land with the other static labels. #}
                             <span class="flex items-center gap-1.5 text-sm min-w-0 text-foreground-muted"
                                   data-morph="venue">
-                                {% icon "map-pin" class="size-4 shrink-0 opacity-80" variant="mini" %}
+                                {# The pin is decoration next to a labelled path; on the #}
+                                {# narrowest phones its 16px plus the gap is width the #}
+                                {# room name itself needs. #}
+                                {% icon "map-pin" class="size-4 shrink-0 opacity-80 max-[400px]:hidden" variant="mini" %}
                                 <span class="truncate" title="{{ data.location_label }}">{{ data.location_label }}</span>
                             </span>
                         {% endif %}

--- a/src/ludamus/templates/chronology/parts/session-modal.html
+++ b/src/ludamus/templates/chronology/parts/session-modal.html
@@ -61,7 +61,11 @@
                     <div class="flex flex-1 items-center gap-3 flex-wrap min-w-0">
                         <div class="font-medium text-foreground" data-morph="host">{{ data.presenter.full_name }}</div>
                         {% if data.location_label %}
-                            <span class="flex items-center gap-1.5 text-sm min-w-0 text-foreground-muted">
+                            {# The room sits beside a name that is still flying in from #}
+                            {# the card, so at its final spot it reads as arriving alone. #}
+                            {# Its own group lets it land with the other static labels. #}
+                            <span class="flex items-center gap-1.5 text-sm min-w-0 text-foreground-muted"
+                                  data-morph="venue">
                                 {% icon "map-pin" class="size-4 shrink-0 opacity-80" variant="mini" %}
                                 <span class="truncate" title="{{ data.location_label }}">{{ data.location_label }}</span>
                             </span>
@@ -81,10 +85,17 @@
                     <div class="mb-6">
                         <h3 class="font-semibold mb-2 text-foreground-secondary"
                             data-morph="desc-label">{% translate "About this session" %}</h3>
-                        {# leading-5 matches the card excerpt's text-sm leading, so #}
-                        {# the description keeps its rhythm across the morph. #}
+                        {# Deliberately NOT a morph group. A named element is hoisted #}
+                        {# into the view-transition layer whole and unclipped, so a #}
+                        {# description longer than the dialog spilled past its bottom #}
+                        {# edge for the length of the morph. Left unnamed it stays in #}
+                        {# the dialog's own snapshot, which the dialog's #}
+                        {# overflow-hidden clips. Nesting it under the dialog's group #}
+                        {# would keep the morph and the clip, but view-transition-group #}
+                        {# is Chromium-only and this ships to Safari. #}
+                        {# leading-5 matches the card excerpt's text-sm leading. #}
                         <div class="prose prose-sm dark:prose-invert max-w-none text-foreground prose-p:text-foreground prose-p:leading-5 prose-li:leading-5"
-                             data-morph="desc">{{ data.session.description|render_markdown }}</div>
+                             data-session-description>{{ data.session.description|render_markdown }}</div>
                     </div>
                 {% endif %}
                 {% if data.field_values %}

--- a/src/ludamus/templates/chronology/parts/session-modal.html
+++ b/src/ludamus/templates/chronology/parts/session-modal.html
@@ -100,7 +100,9 @@
                         {# overflow-hidden clips. Nesting it under the dialog's group #}
                         {# would keep the morph and the clip, but view-transition-group #}
                         {# is Chromium-only and this ships to Safari. #}
-                        {# leading-5 matches the card excerpt's text-sm leading. #}
+                        {# leading-5 is the card excerpt's text-sm leading, kept #}
+                        {# here so a session reads at the same density in both #}
+                        {# places rather than loosening to prose-sm's 1.71. #}
                         <div class="prose prose-sm dark:prose-invert max-w-none text-foreground prose-p:text-foreground prose-p:leading-5 prose-li:leading-5"
                              data-session-description>{{ data.session.description|render_markdown }}</div>
                     </div>
@@ -256,9 +258,12 @@
     {% endif %}
     {% if data.is_enrollment_available or data.can_edit %}
         <!-- Footer -->
-        {# data-morph + the modal surface colour give the footer its own opaque #}
-        {# view-transition group, so the description no longer paints over the #}
-        {# enroll button while it grows into place. #}
+        {# A new-only view-transition group: with no old geometry to interpolate #}
+        {# it renders at final layout for the whole morph instead of stretching #}
+        {# with the container snapshot, so the enroll controls stay crisp and #}
+        {# still while the modal grows behind them. bg-bg-secondary is the modal's #}
+        {# own surface colour — invisible at rest, but the snapshot underneath is #}
+        {# mid-cross-fade with the card and would otherwise show through. #}
         <div class="px-6 py-4 flex items-center justify-between gap-2 border-t border-border shrink-0 bg-bg-secondary"
              data-morph="footer"
              data-session-footer="{{ data.session.pk }}">

--- a/tests/e2e/tests/event-details.spec.ts
+++ b/tests/e2e/tests/event-details.spec.ts
@@ -136,13 +136,11 @@ test.describe("Event detail page", () => {
     expect(delays[pseudoOf("desc-label")]).toBeGreaterThan(delays[pseudoOf("tabs")]);
   });
 
-  // The split that keeps the morph coherent. Chrome with a counterpart on the
-  // card has two layouts to travel between, so it flies on its own group; chrome
-  // that only exists in the modal has none, and a new-only group renders at final
-  // layout for the whole morph — the footer's button ends up hanging in space
-  // beside a sheet that is still a third of its final width. Nesting puts it back
+  // The tab bar exists only in the modal, so it has no old geometry and a
+  // new-only group renders at final layout for the whole morph — it would sit
+  // there while the sheet is still a fraction of its final width. Nesting puts it
   // under the container's transform and clip.
-  test("modal-only chrome morphs nested inside the sheet", async ({ page }) => {
+  test("the modal tab bar morphs nested inside the sheet", async ({ page }) => {
     const supportsNesting = await page.evaluate(() =>
       CSS.supports("view-transition-group", "nearest"),
     );
@@ -162,9 +160,50 @@ test.describe("Event detail page", () => {
     );
 
     expect(groups.tabs).toBe("nearest");
-    expect(groups.footer).toBe("nearest");
+    // Nesting fixes where a group is drawn, not where it starts from. The footer
+    // is paired instead (below), and nesting it too would fight that.
+    expect(groups.footer).toBe("normal");
+    // These have counterparts on the card, so they have to fly free to travel
+    // between the two layouts.
     expect(groups.title).toBe("normal");
     expect(groups.host).toBe("normal");
+  });
+
+  // Without the card-side anchor the footer is a new-only group, so it starts at
+  // its own slot inside the container — for a card in the last column, the far
+  // right of the viewport — and slides across. The anchor gives the group an old
+  // geometry on the card's bottom edge to grow out of instead.
+  test("the modal footer morphs from a zero-height anchor on the card", async ({ page }) => {
+    const card = page.getByRole("article").filter({ hasText: "Mega Strategy Lab" });
+    const anchor = card.locator('[data-morph="footer"]');
+
+    // It exists only to be captured, so it must not add height to the card.
+    expect(await anchor.evaluate((element) => element.getBoundingClientRect().height)).toBe(0);
+
+    const supportsViewTransitions = await page.evaluate(() => "startViewTransition" in document);
+    test.skip(!supportsViewTransitions, "Browser does not implement the View Transition API");
+
+    await page.addStyleTag({ content: ":root { --vt-morph-duration: 5s; }" });
+    await card.getByRole("link", { name: "Open details for Mega Strategy Lab" }).click();
+    await page.waitForFunction(() =>
+      document
+        .getAnimations()
+        .some((a) =>
+          (a.effect as KeyframeEffect | null)?.pseudoElement?.startsWith("::view-transition"),
+        ),
+    );
+
+    const pseudos = await page.evaluate(() =>
+      document
+        .getAnimations()
+        .map((a) => (a.effect as KeyframeEffect | null)?.pseudoElement)
+        .filter((pseudo) => pseudo?.includes("morph-footer")),
+    );
+
+    // The discriminator: a group animation exists only when there are two rects
+    // to interpolate between. Drop the anchor and this pseudo disappears, leaving
+    // just ::view-transition-new — measured both ways.
+    expect(pseudos).toContain("::view-transition-group(morph-footer)");
   });
 
   // Fetched dialogs are cached in the DOM, so without a reset a reopen inherits

--- a/tests/e2e/tests/event-details.spec.ts
+++ b/tests/e2e/tests/event-details.spec.ts
@@ -129,11 +129,42 @@ test.describe("Event detail page", () => {
     // clip that keeps it inside — the bug this guards.
     expect(delays[pseudoOf("desc")]).toBeUndefined();
 
-    // The footer renders at final layout throughout, so it has nothing to wait
-    // for; the labels the title flies past do.
+    // The footer travels with the sheet (see the nesting test below), so it has
+    // nothing to wait for; the labels the title flies past do.
     expect(delays[pseudoOf("footer")]).toBe(0);
     expect(delays[pseudoOf("tabs")]).toBeGreaterThan(0);
     expect(delays[pseudoOf("desc-label")]).toBeGreaterThan(delays[pseudoOf("tabs")]);
+  });
+
+  // The split that keeps the morph coherent. Chrome with a counterpart on the
+  // card has two layouts to travel between, so it flies on its own group; chrome
+  // that only exists in the modal has none, and a new-only group renders at final
+  // layout for the whole morph — the footer's button ends up hanging in space
+  // beside a sheet that is still a third of its final width. Nesting puts it back
+  // under the container's transform and clip.
+  test("modal-only chrome morphs nested inside the sheet", async ({ page }) => {
+    const supportsNesting = await page.evaluate(() =>
+      CSS.supports("view-transition-group", "nearest"),
+    );
+    test.skip(!supportsNesting, "Browser does not implement view-transition-group");
+
+    await page.getByRole("link", { name: "Open details for Mega Strategy Lab" }).click();
+    await expect(page.getByRole("dialog", { name: "Mega Strategy Lab" })).toBeVisible();
+    await settleViewTransitions(page);
+
+    const groups = await page.evaluate(() =>
+      Object.fromEntries(
+        [...document.querySelectorAll<HTMLElement>("dialog[open] [data-morph]")].map((element) => [
+          element.dataset.morph,
+          getComputedStyle(element).viewTransitionGroup,
+        ]),
+      ),
+    );
+
+    expect(groups.tabs).toBe("nearest");
+    expect(groups.footer).toBe("nearest");
+    expect(groups.title).toBe("normal");
+    expect(groups.host).toBe("normal");
   });
 
   // Fetched dialogs are cached in the DOM, so without a reset a reopen inherits

--- a/tests/e2e/tests/event-details.spec.ts
+++ b/tests/e2e/tests/event-details.spec.ts
@@ -283,7 +283,7 @@ test.describe("Event detail page", () => {
     // once visible — inject the long description here, not before the click.
     await page.evaluate((id) => {
       const description = document.querySelector(
-        `#session-${id} [id^="info-"] [data-morph="desc"]`,
+        `#session-${id} [id^="info-"] [data-session-description]`,
       );
       if (!description) throw new Error("Missing session description");
       description.innerHTML = Array.from(

--- a/tests/e2e/tests/event-details.spec.ts
+++ b/tests/e2e/tests/event-details.spec.ts
@@ -136,6 +136,38 @@ test.describe("Event detail page", () => {
     expect(delays[pseudoOf("desc-label")]).toBeGreaterThan(delays[pseudoOf("tabs")]);
   });
 
+  // Fetched dialogs are cached in the DOM, so without a reset a reopen inherits
+  // the last visit's scroll offset — and the morph captures the modal at open,
+  // so the card appears to expand into an already-scrolled panel.
+  test("reopening a session modal starts at the top of the panel", async ({ page }) => {
+    const open = async () => {
+      await page.getByRole("link", { name: "Open details for Mega Strategy Lab" }).click();
+      await expect(page.getByRole("dialog", { name: "Mega Strategy Lab" })).toBeVisible();
+      await settleViewTransitions(page);
+    };
+    const panel = page.locator("dialog[open] .tab-panel[data-active]");
+
+    await open();
+    // The seeded description is short; give the panel something to scroll.
+    await page.locator("dialog[open] [data-session-description]").evaluate((element) => {
+      element.innerHTML = Array.from(
+        { length: 30 },
+        (_, index) => `<p>Scrollable paragraph ${index + 1}.</p>`,
+      ).join("");
+    });
+    await panel.evaluate((element) => {
+      element.scrollTop = 400;
+    });
+    await expect.poll(() => panel.evaluate((element) => element.scrollTop)).toBeGreaterThan(0);
+
+    await page.getByRole("button", { name: "Close" }).click();
+    await expect(page.getByRole("dialog", { name: "Mega Strategy Lab" })).toBeHidden();
+    await settleViewTransitions(page);
+
+    await open();
+    await expect.poll(() => panel.evaluate((element) => element.scrollTop)).toBe(0);
+  });
+
   test("mobile session modal closes on iOS tap (touchmove not cancelled)", async ({
     browser,
     browserName,

--- a/tests/e2e/tests/event-details.spec.ts
+++ b/tests/e2e/tests/event-details.spec.ts
@@ -3,6 +3,10 @@ import type { Page } from "@playwright/test";
 import { expect, test } from "./helpers/fixtures";
 import { createIosModalContext } from "./helpers/ios-modal";
 
+// Chromium/Firefox only: WebKit does not expose ::view-transition pseudo-element
+// animations to document.getAnimations(), so this resolves immediately there
+// rather than actually waiting for the morph. Don't read a WebKit pass as
+// evidence the transition settled.
 const settleViewTransitions = (page: Page): Promise<void> =>
   page
     .waitForFunction(
@@ -86,10 +90,10 @@ test.describe("Event detail page", () => {
     await expect(card).not.toHaveClass(/session-suppressed/);
   });
 
-  // Whether the morph *feels* right is not assertable; that the modal's chrome
-  // still animates on its own delayed groups is. Losing those groups is what
-  // put the enroll footer under the growing description and crossed the tab bar
-  // with the flying title.
+  // Whether the morph *feels* right is not assertable; the shape of its groups
+  // is. Two invariants matter: the description must NOT be a group — naming it
+  // hoists it out unclipped and it spills past the dialog — and the labels the
+  // title flies past must come in behind it.
   test("modal chrome morphs on its own groups, staggered behind the title", async ({ page }) => {
     const supportsViewTransitions = await page.evaluate(() => "startViewTransition" in document);
     test.skip(!supportsViewTransitions, "Browser does not implement the View Transition API");
@@ -121,8 +125,12 @@ test.describe("Event detail page", () => {
       return Object.fromEntries(entries);
     });
 
-    // The footer has to be opaque from the first frame to occlude the
-    // description; the labels the title flies past must not be.
+    // Naming the description hoists it out of the dialog's snapshot, past the
+    // clip that keeps it inside — the bug this guards.
+    expect(delays[pseudoOf("desc")]).toBeUndefined();
+
+    // The footer renders at final layout throughout, so it has nothing to wait
+    // for; the labels the title flies past do.
     expect(delays[pseudoOf("footer")]).toBe(0);
     expect(delays[pseudoOf("tabs")]).toBeGreaterThan(0);
     expect(delays[pseudoOf("desc-label")]).toBeGreaterThan(delays[pseudoOf("tabs")]);

--- a/tests/e2e/tests/event-details.spec.ts
+++ b/tests/e2e/tests/event-details.spec.ts
@@ -166,6 +166,11 @@ test.describe("Event detail page", () => {
 
     await open();
     await expect.poll(() => panel.evaluate((element) => element.scrollTop)).toBe(0);
+    // Without this the assertion above also passes when the reopened panel is
+    // simply too short to scroll — i.e. if modals ever stop being cached.
+    expect(await panel.evaluate((element) => element.scrollHeight > element.clientHeight)).toBe(
+      true,
+    );
   });
 
   test("mobile session modal closes on iOS tap (touchmove not cancelled)", async ({


### PR DESCRIPTION
Follow-up to #740. Five fixes to the card→modal morph, found by watching it on a real iPhone rather than in Chromium.

## 1. The description hung below the card

`data-morph="desc"` gave the description its own view-transition group. A named element is lifted out of its ancestor's snapshot and painted as a stacking-context root, and **ancestor clips are not applied to it** — so the dialog's `overflow-hidden` stopped containing it and a long description spilled past the modal's bottom edge for the whole morph.

The obvious fix, `view-transition-group: contain` on the dialog, is Chromium-only (`CSS.supports("view-transition-group", "contain")` is false in WebKit), and this bug is a WebKit bug. So the name is simply removed: unnamed, the paragraph stays inside the dialog's own snapshot and is clipped with it. It loses nothing — it was cross-fading between two different strings anyway (the card shows a `line-clamp-3` excerpt).

`data-session-description` stays on both elements as the hook the e2e specs select on.

Verified in Chromium at 25 / 45 / 70 % through the morph with a 14-paragraph description: on `main` the text renders outside the dialog bounds, on this branch it does not.

## 2. Venue arrived alone, ahead of the rest of the chrome

The location label had no morph name, so it was a new-only group that popped in at full opacity while the title was still flying. It now shares the `vt-chrome-in` stagger with the description heading (`0.5×` duration, `0.5×` delay).

## 3. An 11px gap between the host name and the venue on mobile

The host name lived in a `flex-1` wrapper (added in #740 to stop the avatar orphaning), so it claimed all the leftover width and pushed the venue away from it. Reworked: the flex parent holds name and venue as siblings with `gap-x-3 gap-y-0.5 flex-wrap min-w-0`, so they sit on one line and share a normal word gap when they fit, and stack tightly when they don't. `gap-y-0.5` rather than the symmetric `gap-3` is the deliberate "split the gap" choice — horizontal breathing room, vertical tightness.

Also on the smallest screens: the map-pin icon is hidden below 400px (`max-[400px]:hidden`) to buy the label characters, and the avatar drops from `size-10` to `size-9`.

**Note:** the avatar shrink is currently global, not breakpoint-scoped — it applies at desktop widths too. Say the word if you want it `max-sm:` only.

## 4. The modal reopened wherever you left it

The dialog is reused across sessions, so its scroll position survived a close. Reopen it and the morph started from a mid-scrolled panel — the title the card was flying toward was already off-screen, which broke the animation outright.

`resetModalScroll()` walks the dialog's descendants and zeroes any non-zero `scrollTop`, called right after `showModal()` in **both** paths (inside the view-transition `swap()` callback, and the non-morph fallback). Reset-on-open rather than reset-on-close: closing can be interrupted, and on open the scroll must be zero before the first morph frame is captured, so that's the only point where it's guaranteed correct.

## 5. The tabs and footer arrived before the sheet they belong to

Reported from a Chromium recording: the chrome shows up in its final position while the sheet is still travelling there.

Neither element has a counterpart on the card, so both are captured as **new-only** groups — no old geometry to interpolate, so they render at final layout for the entire morph. On a wide viewport the sheet is still about a third of its final width at that point, and the enrol button reads as floating in space beside it rather than belonging to it.

`view-transition-group: nearest` nests those two groups inside `session-morph`, so they travel and crop with the container. The elements keep their names, which is what makes this better than simply dropping them: the stagger still applies, so the tab bar still waits for the title to fly past. Dropping the names instead puts the tabs on screen at 15% of the morph, straight over the host row — the #740 bug again. Scrubbed all three options side by side before choosing.

The property is Level 2 with no WebKit support yet, so **Safari keeps today's flat behaviour** — a progressive enhancement, not a fork. That degrades well because the artifact scales with how far the sheet moves sideways, and on a phone it barely does: the dialog is near full-width, so the card grows **~11% in width against ~108% in height** (336→372 by 287→597 at iPhone 13 size) and the footer lands roughly where the sheet already is. Measured, not assumed.

Verified by scrubbing a 20s morph in Chromium at 15 / 35 / 55 %: the detached button is gone at 15% and sits on the sheet's own bottom edge afterwards. The settled frame is byte-identical to before, so the end state is untouched.

## Also in here

- **Dead reduced-motion rules removed.** 20 `::view-transition-*` morph selectors sat inside `@media (prefers-reduced-motion: reduce)` and could never match — `modal.ts`'s `canMorph` already refuses to start a morph under reduced motion, so the pseudo-elements never exist. Replaced with a comment pointing at the real gate.
- **Two comments corrected**, both of which had been describing mechanisms that don't exist:
  - the old-kill block claimed tags/meta/time "linger in the container snapshot". They carry their own names, so they are lifted *out* of it, and their old-only groups are appended *after* `session-morph` — they paint on top of the arriving modal, not behind it. Different problem, same fix, but the recorded reason was wrong.
  - the footer's rationale referenced the description's morph group, which this PR deletes. It has since been rewritten a second time: fix 5 means the footer no longer renders at final layout, so the comment now explains the nesting and keeps only the part that is still true — the opaque fill, needed because the container snapshot beneath it is mid-cross-fade.

## Tests

`tests/e2e/tests/event-details.spec.ts`:

- A guard on the morph's timing contract — the description must have **no** group, the footer must start at delay 0, the tabs must be delayed, and the heading must come after the tabs. Small, and it fails on any of the four things this PR changed.
- `modal-only chrome morphs nested inside the sheet` — asserts **both sides** of the split: `tabs` and `footer` compute `nearest`, while `title` and `host` (which do have card counterparts, so they must fly free) stay `normal`. A rename of either group fails it. Skips where `view-transition-group` is unsupported; confirmed it skips cleanly on Firefox rather than erroring.
- `reopening a session modal starts at the top of the panel` — scroll, close, reopen, assert `scrollTop === 0`.
- A comment on `settleViewTransitions` recording that it is a Chromium/Firefox-only signal: WebKit exposes no `::view-transition` animations to `document.getAnimations()` (0 vs 22 in Chromium), so it resolves immediately there and a WebKit pass is not evidence the transition settled.

## Screenshots

Host row, before vs after at 375px, plus the settled modal at 820px where venue sits to the right of the host:



## CI

`test` was red here on `UNIQUE constraint failed: sphere.site_id` in `test_query_count_constant_in_session_count`. That is unrelated to this branch — `SiteFactory` gets-or-creates by a domain derived from a non-unique `Faker("company")` against a `OneToOneField`, and `pytest-randomly` decides which test draws the collision. Fixed separately in #774; this needs that merged (or a rerun) to go green.

Unrelated finding while running the suite locally: `Anonymous code modal › rejects an unknown code with a flash message and stays on the event` fails on this branch **and identically on `main`** (same assertion, `event-details.spec.ts:392`). Inherited, not introduced here. I did not chase whether it is environment-specific to the sandbox.



## Summary by CodeRabbit

* **New Features**
  * Reopening a session details modal now resets its scroll position.
  * Improved session modal transitions, including venue and description presentation.
  * Optimized host avatars and venue details for smaller screens.

* **Bug Fixes**
  * Improved modal presentation consistency across animated and non-animated openings.
  * Prevented description content from participating in unsuitable transitions.
  * Hidden venue icons on very narrow screens for better layout.

