### PR TITLE
Revert "One canonical print page: /print"

### DIFF
--- a/PAPERCUTS.md
+++ b/PAPERCUTS.md
@@ -263,8 +263,3 @@ If you fix a papercut, remove it.
   /etc/ssh/ssh_config.d/20-systemd-ssh-proxy.conf' (symlink owned by
   nobody:nogroup); worked around with git -c credential.helper='!gh auth git-
   credential' push <https://github.com/zagrajmy/ludamus.git> HEAD:the-branch
-- 2026-08-01: mise run lint fails locally on lint:hk: oxlint can't build
-  src/ludamus/client/oxlint.config.ts because eslint-plugin-sonarjs isn't
-  installed in the local node_modules (CI is fine). Same failure on a clean
-  tree, so it's env drift, not a code problem — had to stash and re-run to prove
-  my change was innocent.

--- a/src/ludamus/client/src/actions.ts
+++ b/src/ludamus/client/src/actions.ts
@@ -17,6 +17,14 @@ const swapVisibility = (el: HTMLElement): void => {
   setDisplay(el.dataset.show, "block");
 };
 
+// A picker whose options are URLs: pick one, open it in a new tab, then fall
+// back to the placeholder so the same option can be picked again.
+const openInNewTab = (select: HTMLSelectElement): void => {
+  if (!select.value) return;
+  globalThis.open(select.value, "_blank", "noopener");
+  select.selectedIndex = 0;
+};
+
 const syncExpandedRequired = (box: HTMLInputElement): void => {
   box.setAttribute("aria-expanded", box.checked ? "true" : "false");
   const id = box.dataset.requiredTarget;
@@ -48,6 +56,9 @@ document.addEventListener("change", (e) => {
   const el = (e.target as Element | null)?.closest<HTMLElement>("[data-action]");
   if (!el) return;
   switch (el.dataset.action) {
+    case "open-in-new-tab":
+      openInNewTab(el as HTMLSelectElement);
+      break;
     case "submit-form":
       (el as HTMLInputElement).form?.requestSubmit();
       break;

--- a/src/ludamus/gates/cli/django/management/commands/send_printables_reminders.py
+++ b/src/ludamus/gates/cli/django/management/commands/send_printables_reminders.py
@@ -4,8 +4,8 @@ Manual entry point for ``PrintablesReminderService.send_due_reminders``. The
 primary path is the in-system DBOS schedule (``inits.dbos_scheduler``); with
 ``SCHEDULER_MODE=cron`` run this daily via external cron instead.
 Finds every event starting within the reminder lead time whose organizers
-have not opened the print page and have not already been reminded, then emails
-each sphere manager a link to the event's print page. Safe to run
+have not opened a print page and have not already been reminded, then emails
+each sphere manager a link to the panel's print-materials hub. Safe to run
 repeatedly — each event is reminded once.
 """
 

--- a/src/ludamus/gates/web/django/chronology/panel/views/base.py
+++ b/src/ludamus/gates/web/django/chronology/panel/views/base.py
@@ -20,6 +20,7 @@ if TYPE_CHECKING:
     from collections.abc import Callable
 
     from ludamus.pacts import DependencyInjectorProtocol
+    from ludamus.pacts.venues import PrintScopeOptionDTO
 
 
 class PanelRequest(EventPanelRequest):
@@ -65,6 +66,10 @@ class EventContextMixin(EventPanelContextMixin):
             all_tracks, key=lambda t: (t.pk not in managed_pks, t.name)
         )
         return sorted_tracks, managed_pks, filter_track_pk
+
+    def get_print_scopes(self, event_pk: int) -> list[PrintScopeOptionDTO]:
+        # Non-leaf tree nodes selectable as print scopes.
+        return self.request.services.venues.list_print_scopes(event_pk)
 
 
 def cfp_tab_urls(slug: str) -> dict[str, str]:

--- a/src/ludamus/gates/web/django/chronology/panel/views/print.py
+++ b/src/ludamus/gates/web/django/chronology/panel/views/print.py
@@ -1,0 +1,122 @@
+"""Printable materials panel views (print-styled HTML pages).
+
+Served as standalone print pages; the organizer prints via the browser
+(Save-as-PDF or Ctrl/Cmd+P). Rendered in the request's active locale;
+session titles stay as authored. An optional ``?scope=<pk>`` scopes the
+document to one space-tree node at any level (a room, a floor, a building).
+"""
+
+from __future__ import annotations
+
+from contextlib import suppress
+from datetime import timedelta
+from typing import TYPE_CHECKING
+
+from django.contrib import messages
+from django.shortcuts import redirect
+from django.template.response import TemplateResponse
+from django.utils.dateparse import parse_datetime
+from django.utils.timezone import get_current_timezone, make_aware
+from django.utils.translation import gettext as _
+from django.views.generic.base import View
+
+from ludamus.gates.web.django.chronology.panel.views.base import (
+    EventContextMixin,
+    PanelAccessMixin,
+    PanelRequest,
+)
+from ludamus.pacts import NotFoundError
+from ludamus.pacts.printing import DoorCardsQueryDTO, PrintTimetableQueryDTO
+
+if TYPE_CHECKING:
+    from datetime import datetime, tzinfo
+
+    from django.http import HttpResponse
+
+
+class TimetablePrintView(PanelAccessMixin, EventContextMixin, View):
+    request: PanelRequest
+    material: str = "timetable"
+    DEFAULT_RANGE_HOURS = 6
+    MAX_RANGE_HOURS = 72
+
+    def get(self, request: PanelRequest, slug: str) -> HttpResponse:
+        _context, current_event = self.get_event_context(slug)
+        if current_event is None:
+            return redirect("panel:index")
+
+        raw_scope = self.request.GET.get("scope")
+        try:
+            scope = self.request.services.venues.resolve_scope(
+                current_event.pk, int(raw_scope) if raw_scope else None
+            )
+        except NotFoundError, ValueError:
+            messages.error(request, _("Space not found."))
+            return redirect("panel:timetable", slug=slug)
+
+        tz = get_current_timezone()
+        service = self.request.services.print_materials
+        # Opening a print-ready page is our signal that this event's organizers
+        # have printed, which suppresses the pre-event reminder email.
+        self.request.services.printables_reminder.mark_printed(current_event.pk)
+
+        if self.material == "door-cards":
+            return TemplateResponse(
+                request,
+                "panel/print/door-cards.html",
+                {
+                    "document": service.build_door_cards(
+                        DoorCardsQueryDTO(
+                            event_pk=current_event.pk,
+                            tz=tz,
+                            scope_space_pks=scope.space_pks,
+                            scope_name=scope.scope_name,
+                            time_range=self._time_range(tz),
+                        )
+                    )
+                },
+            )
+        return TemplateResponse(
+            request,
+            "panel/print/timetable.html",
+            {
+                "document": service.build_timetable(
+                    PrintTimetableQueryDTO(
+                        event_pk=current_event.pk,
+                        tz=tz,
+                        scope_space_pks=scope.space_pks,
+                        scope_name=scope.scope_name,
+                    )
+                )
+            },
+        )
+
+    def _time_range(self, tz: tzinfo) -> tuple[datetime, datetime] | None:
+        # No (or unparsable) start means the whole event. The public print page
+        # reads the same ``?start=…&hours=…`` params but defaults differently:
+        # there, hours alone can clip, and missing hours means until event end.
+        if not (raw_start := self.request.GET.get("start")):
+            return None
+        if (parsed := parse_datetime(raw_start)) is None:
+            return None
+        start = parsed if parsed.tzinfo else make_aware(parsed, tz)
+        hours = self.DEFAULT_RANGE_HOURS
+        with suppress(ValueError, TypeError):
+            hours = int(self.request.GET.get("hours") or self.DEFAULT_RANGE_HOURS)
+        hours = max(1, min(hours, self.MAX_RANGE_HOURS))
+        return start, start + timedelta(hours=hours)
+
+
+class PrintMaterialsPageView(PanelAccessMixin, EventContextMixin, View):
+    """Hub page linking to the printable materials for an event."""
+
+    request: PanelRequest
+
+    def get(self, request: PanelRequest, slug: str) -> HttpResponse:
+        context, current_event = self.get_event_context(slug)
+        if current_event is None:
+            return redirect("panel:index")
+
+        context["active_nav"] = "print"
+        context["print_scopes"] = self.get_print_scopes(current_event.pk)
+        return TemplateResponse(request, "panel/print-materials.html", context)

--- a/src/ludamus/gates/web/django/chronology/panel/views/timetable.py
+++ b/src/ludamus/gates/web/django/chronology/panel/views/timetable.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import json
 import re
 from datetime import date, datetime
-from typing import TYPE_CHECKING
 from urllib.parse import urlencode
 
 from django.http import HttpResponse, QueryDict
@@ -31,9 +30,6 @@ from ludamus.pacts import (
     UnscheduledSessionFilter,
 )
 from ludamus.pacts.chronology import DateSelection, SessionPlacement
-
-if TYPE_CHECKING:
-    from ludamus.pacts.legacy import TrackDTO
 
 
 def _parse_iso_duration_minutes(iso: str) -> int:
@@ -62,25 +58,6 @@ _BACK_URL_KEYS = ("track", "category", "max_duration", "search", "date")
 def _build_back_url(slug: str, query: QueryDict) -> str:
     base = reverse("panel:timetable-browse-pane-part", kwargs={"slug": slug})
     params = [(key, query[key]) for key in _BACK_URL_KEYS if query.get(key, "").strip()]
-    return f"{base}?{urlencode(params)}" if params else base
-
-
-def _print_url(
-    *,
-    slug: str,
-    tracks: list[TrackDTO],
-    track_pk: int | None,
-    date_selection: DateSelection,
-) -> str:
-    # The print page is preset to the schedule's current view: an active track
-    # filter prints that track, a picked day prints that day — the filters the
-    # organizer already dialed in aren't wasted.
-    params: list[tuple[str, str]] = []
-    if (track := next((t for t in tracks if t.pk == track_pk), None)) is not None:
-        params += [("material", "track-timetable"), ("track", track.slug)]
-    if date_selection != "all":
-        params += [("start", f"{date_selection.isoformat()}T00:00"), ("hours", "24")]
-    base = reverse("web:chronology:event-print", kwargs={"slug": slug})
     return f"{base}?{urlencode(params)}" if params else base
 
 
@@ -157,12 +134,7 @@ class TimetablePageView(PanelAccessMixin, EventContextMixin, View):
         context["slug"] = slug
         context["tab_urls"] = timetable_tab_urls(slug)
         context["active_tab"] = "timetable"
-        context["print_url"] = _print_url(
-            slug=slug,
-            tracks=sorted_tracks,
-            track_pk=filter_track_pk,
-            date_selection=grid.date_selection,
-        )
+        context["print_scopes"] = self.get_print_scopes(current_event.pk)
         return TemplateResponse(self.request, "panel/timetable.html", context)
 
 

--- a/src/ludamus/gates/web/django/event/panel/urls.py
+++ b/src/ludamus/gates/web/django/event/panel/urls.py
@@ -19,6 +19,7 @@ from ludamus.gates.web.django.chronology.panel.views import (
     tracks,
     venues,
 )
+from ludamus.gates.web.django.chronology.panel.views import print as print_views
 from ludamus.gates.web.django.event.panel.views import (
     confirmations,
     enrollment_settings,
@@ -100,6 +101,16 @@ _timetable_urlpatterns = [
         "confirmations/do/confirm",
         confirmations.ConfirmationsConfirmActionView.as_view(),
         name="timetable-confirmations-confirm",
+    ),
+    path(
+        "print/timetable/",
+        print_views.TimetablePrintView.as_view(material="timetable"),
+        name="timetable-print",
+    ),
+    path(
+        "print/door-cards/",
+        print_views.TimetablePrintView.as_view(material="door-cards"),
+        name="timetable-print-door-cards",
     ),
 ]
 
@@ -446,6 +457,11 @@ urlpatterns = [
         name="discount-delete",
     ),
     path("event/<slug:slug>/timetable/", include(_timetable_urlpatterns)),
+    path(
+        "event/<slug:slug>/print/",
+        print_views.PrintMaterialsPageView.as_view(),
+        name="print-materials",
+    ),
     path(
         "event/<slug:slug>/settings/integrations/check/",
         integrations.IntegrationCheckActionView.as_view(),

--- a/src/ludamus/gates/web/django/event/print.py
+++ b/src/ludamus/gates/web/django/event/print.py
@@ -18,7 +18,7 @@ from ludamus.gates.web.django.access import has_panel_access
 from ludamus.gates.web.django.helpers import is_event_published
 from ludamus.mills.qr import qr_svg
 from ludamus.pacts import NotFoundError
-from ludamus.pacts.printing import PrintQueryDTO
+from ludamus.pacts.printing import AreaScheduleQueryDTO, PrintTimetableQueryDTO
 
 if TYPE_CHECKING:
     from django.utils.functional import _StrPromise
@@ -31,7 +31,7 @@ if TYPE_CHECKING:
     type _LazyStr = str | _StrPromise
 
 
-DocumentKind = Literal["area_schedule", "door_cards", "session_list", "timetable"]
+DocumentKind = Literal["area_schedule", "session_list", "timetable"]
 ScopeKind = Literal["event", "scope", "track"]
 
 
@@ -53,23 +53,16 @@ class MaterialSpec:
     def show_track_control(self) -> bool:
         return self.scope_kind == "track"
 
-    # The "with descriptions" capability swaps the timetable grid or the door
-    # cards for the per-space descriptions pages; the session list carries
-    # descriptions already.
+    # Timetables take a time range and a "with descriptions" toggle (which
+    # swaps the grid for a per-space list); the session list takes neither.
     @property
-    def supports_descriptions(self) -> bool:
-        return self.document_kind in {"timetable", "door_cards"}
-
-    # Timetables and door cards cover a time window; the session list doesn't.
-    @property
-    def show_range_controls(self) -> bool:
-        return self.document_kind in {"timetable", "door_cards"}
+    def show_timetable_controls(self) -> bool:
+        return self.document_kind == "timetable"
 
 
 TIMETABLE = "timetable"
 TRACK_TIMETABLE = "track-timetable"
 SESSION_LIST = "session-list"
-DOOR_CARDS = "door-cards"
 # Retired material value still reachable from old bookmarks; maps to the
 # timetable material with the descriptions checkbox ticked.
 LEGACY_DESCRIPTIONS_MATERIAL = "timetable-descriptions"
@@ -84,7 +77,6 @@ MATERIAL_SPECS = (
     MaterialSpec(
         SESSION_LIST, _("Session list"), "session_list", requires_session_list=True
     ),
-    MaterialSpec(DOOR_CARDS, _("Door cards"), "door_cards", scope_kind="scope"),
 )
 MATERIAL_SPECS_BY_VALUE = {spec.value: spec for spec in MATERIAL_SPECS}
 
@@ -153,8 +145,7 @@ class PublicEventPrintView(View):
             raise Http404 from exc
 
         published = is_event_published(event)
-        panel_user = has_panel_access(request)
-        if not published and not panel_user:
+        if not published and not has_panel_access(request):
             raise Http404
 
         scope_pk = _scope_pk(request.GET.get("scope"))
@@ -163,27 +154,18 @@ class PublicEventPrintView(View):
         except NotFoundError as exc:
             raise Http404 from exc
 
-        if panel_user:
-            # A manager opening the print page is our signal that this event's
-            # organizers have printed, which suppresses the pre-event reminder.
-            request.services.printables_reminder.mark_printed(event.pk)
-
         tz = get_current_timezone()
         resolved_range = self._resolve_range(event, tz)
         descriptions = (
             request.GET.get("descriptions") == "1"
             or request.GET.get("material") == LEGACY_DESCRIPTIONS_MATERIAL
         )
-        # Only sphere managers may pull unconfirmed sessions onto paper; for
-        # everyone else the param is ignored, not an error.
-        unconfirmed = panel_user and request.GET.get("unconfirmed") == "1"
-        confirmed_only = not unconfirmed
 
         service = request.services.print_materials
         tracks = service.list_tracks(event.pk)
         selected_track = self._selected_track(tracks)
         session_list_candidate = service.build_session_list(
-            event.pk, confirmed_only=confirmed_only
+            event.pk, confirmed_only=True
         )
         material_options = _available_materials(
             session_list_available=session_list_candidate is not None,
@@ -193,39 +175,39 @@ class PublicEventPrintView(View):
         print_scope = _resolve_print_scope(
             material=material_spec, scope=scope, track=selected_track
         )
-        # The descriptions toggle swaps the timetable grid or the door cards
-        # for the per-space descriptions pages; the material still names what
-        # is scoped.
+        # The descriptions toggle swaps the timetable grid for the per-space
+        # descriptions list; the material still names what is scoped.
         document_kind: DocumentKind = (
             "area_schedule"
-            if descriptions and material_spec.supports_descriptions
+            if descriptions and material_spec.document_kind == "timetable"
             else material_spec.document_kind
         )
 
-        # One context slot per document kind; the three unselected ones stay
-        # None so the template picks its branch by presence.
-        documents: dict[str, object] = {
-            "timetable": None,
-            "area_schedule": None,
-            "session_list": None,
-            "door_cards": None,
-        }
+        timetable = None
+        area_schedule = None
+        session_list = None
         if document_kind == "session_list":
-            documents["session_list"] = session_list_candidate
+            session_list = session_list_candidate
+        elif document_kind == "area_schedule":
+            area_schedule = service.build_area_schedule(
+                AreaScheduleQueryDTO(
+                    event_pk=event.pk,
+                    time_range=resolved_range.window,
+                    scope_space_pks=print_scope.space_pks,
+                    track_pk=print_scope.track_pk,
+                    scope_name=print_scope.name,
+                    confirmed_only=True,
+                )
+            )
         else:
-            build = {
-                "timetable": service.build_timetable,
-                "area_schedule": service.build_area_schedule,
-                "door_cards": service.build_door_cards,
-            }[document_kind]
-            documents[document_kind] = build(
-                PrintQueryDTO(
+            timetable = service.build_timetable(
+                PrintTimetableQueryDTO(
                     event_pk=event.pk,
                     tz=tz,
                     scope_space_pks=print_scope.space_pks,
                     track_pk=print_scope.track_pk,
                     scope_name=print_scope.name,
-                    confirmed_only=confirmed_only,
+                    confirmed_only=True,
                     time_range=resolved_range.window,
                 )
             )
@@ -241,10 +223,9 @@ class PublicEventPrintView(View):
             {
                 "event": event,
                 "logo": event.logo_url or sphere.logo_url,
-                "timetable": documents["timetable"],
-                "area_schedule": documents["area_schedule"],
-                "session_list": documents["session_list"],
-                "door_cards": documents["door_cards"],
+                "timetable": timetable,
+                "area_schedule": area_schedule,
+                "session_list": session_list,
                 "qr_svg": qr_svg(event_url, xmldecl=False),
                 "print_scopes": request.services.venues.list_print_scopes(event.pk),
                 "tracks": tracks,
@@ -252,11 +233,8 @@ class PublicEventPrintView(View):
                 "material": material_spec.value,
                 "show_scope_control": material_spec.show_scope_control,
                 "show_track_control": material_spec.show_track_control,
-                "show_descriptions_control": material_spec.supports_descriptions,
-                "show_range_controls": material_spec.show_range_controls,
-                "show_unconfirmed_control": panel_user,
+                "show_timetable_controls": material_spec.show_timetable_controls,
                 "descriptions": descriptions,
-                "unconfirmed": unconfirmed,
                 "selected_scope": str(scope_pk) if scope_pk is not None else "",
                 "selected_track": selected_track.slug if selected_track else "",
                 "range_start_value": (
@@ -265,9 +243,7 @@ class PublicEventPrintView(View):
                 "range_hours": resolved_range.hours,
             },
         )
-        # A manager's page differs from the public one (extra materials, the
-        # unconfirmed toggle), so it must never land in a shared cache.
-        if published and not panel_user:
+        if published:
             patch_cache_control(response, public=True, max_age=300)
         else:
             patch_cache_control(response, private=True, max_age=5)

--- a/src/ludamus/links/db/django/notifications.py
+++ b/src/ludamus/links/db/django/notifications.py
@@ -230,9 +230,7 @@ class DjangoUserNotifier:
         self, notification: PrintablesReadyNotification
     ) -> None:
         url = _absolute(
-            reverse(
-                "web:chronology:event-print", kwargs={"slug": notification.event_slug}
-            ),
+            reverse("panel:print-materials", kwargs={"slug": notification.event_slug}),
             domain=notification.sphere_domain,
         )
         title = _("Print your materials for %(event)s") % {

--- a/src/ludamus/locale/pl/LC_MESSAGES/django.po
+++ b/src/ludamus/locale/pl/LC_MESSAGES/django.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-08-02 10:57+0200\n"
+"POT-Creation-Date: 2026-08-01 17:51+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -1462,6 +1462,11 @@ msgstr "Nie można usunąć pola używanego w kategoriach."
 msgid "Personal data field deleted successfully."
 msgstr "Pole danych osobowych zostało usunięte."
 
+#: src/ludamus/gates/web/django/chronology/panel/views/print.py
+#: src/ludamus/gates/web/django/chronology/panel/views/venues.py
+msgid "Space not found."
+msgstr "Przestrzeń nie została znaleziona."
+
 #: src/ludamus/gates/web/django/chronology/panel/views/proposals.py
 msgid "Fix the facilitator personal data below before saving."
 msgstr "Popraw dane osobowe twórców programu poniżej, zanim zapiszesz."
@@ -1695,10 +1700,6 @@ msgstr "Blok programowy został zaktualizowany."
 #: src/ludamus/gates/web/django/chronology/panel/views/tracks.py
 msgid "Track deleted."
 msgstr "Blok programowy usunięty."
-
-#: src/ludamus/gates/web/django/chronology/panel/views/venues.py
-msgid "Space not found."
-msgstr "Przestrzeń nie została znaleziona."
 
 #: src/ludamus/gates/web/django/chronology/panel/views/venues.py
 msgid "Space created successfully."
@@ -2186,10 +2187,6 @@ msgstr "Harmonogram bloku"
 msgid "Session list"
 msgstr "Lista punktów programu"
 
-#: src/ludamus/gates/web/django/event/print.py
-msgid "Door cards"
-msgstr "Tabliczki na drzwi"
-
 #: src/ludamus/gates/web/django/forms.py
 msgid "Max 8 MB. JPG, PNG, WebP, or AVIF."
 msgstr "Maks. 8 MB. JPG, PNG, WebP lub AVIF."
@@ -2407,7 +2404,7 @@ msgstr "Nazwa przestrzeni jest wymagana."
 
 #: src/ludamus/gates/web/django/forms.py
 #: src/ludamus/templates/chronology/parts/session-modal.html
-#: src/ludamus/templates/chronology/print.html
+#: src/ludamus/templates/panel/print/door-cards.html
 msgid "Capacity"
 msgstr "Pojemność"
 
@@ -2531,6 +2528,7 @@ msgstr "Nieprawidłowy wybór kategorii."
 
 #: src/ludamus/gates/web/django/forms.py
 #: src/ludamus/templates/chronology/print.html
+#: src/ludamus/templates/panel/parts/print-controls.html
 msgid "Hours"
 msgstr "Godziny"
 
@@ -3586,6 +3584,7 @@ msgstr "Zachowaj ten kod, aby później zarządzać swoim zapisem"
 #: src/ludamus/templates/chronology/print.html
 #: src/ludamus/templates/panel/content-log.html
 #: src/ludamus/templates/panel/parts/timetable-grid.html
+#: src/ludamus/templates/panel/print/timetable.html
 #: src/ludamus/templates/panel/timetable-log.html
 msgid "Time"
 msgstr "Czas"
@@ -3722,7 +3721,6 @@ msgid "Proposals Open"
 msgstr "Zgłoszenia otwarte"
 
 #: src/ludamus/templates/chronology/event.html
-#: src/ludamus/templates/chronology/print.html
 msgid "Session"
 msgid_plural "Sessions"
 msgstr[0] "Punkt programu"
@@ -4334,6 +4332,7 @@ msgid "Login to Enroll"
 msgstr "Zaloguj się, aby się zapisać"
 
 #: src/ludamus/templates/chronology/print.html
+#: src/ludamus/templates/panel/print/base.html
 #: src/ludamus/templates/panel/timetable.html
 msgid "Print"
 msgstr "Drukuj"
@@ -4356,16 +4355,13 @@ msgstr "Z opisami"
 
 #: src/ludamus/templates/chronology/print.html
 #: src/ludamus/templates/panel/parts/import-recipe-row.html
+#: src/ludamus/templates/panel/parts/print-controls.html
 msgid "Start"
 msgstr "Początek"
 
 #: src/ludamus/templates/chronology/print.html
 msgid "until event end"
 msgstr "do końca wydarzenia"
-
-#: src/ludamus/templates/chronology/print.html
-msgid "Include unconfirmed sessions"
-msgstr "Uwzględnij niepotwierdzone punkty programu"
 
 #: src/ludamus/templates/chronology/print.html
 msgid "Table of contents"
@@ -4380,16 +4376,8 @@ msgid "Print preview"
 msgstr "Podgląd wydruku"
 
 #: src/ludamus/templates/chronology/print.html
-msgid "No sessions scheduled yet."
-msgstr "Nie zaplanowano jeszcze żadnych punktów programu."
-
-#: src/ludamus/templates/chronology/print.html
 msgid "No confirmed sessions scheduled yet."
 msgstr "Nie zaplanowano jeszcze żadnych potwierdzonych punktów programu."
-
-#: src/ludamus/templates/chronology/print.html
-msgid "No rooms to print."
-msgstr "Brak sal do wydruku."
 
 #: src/ludamus/templates/chronology/print.html
 msgid "Program details"
@@ -6114,6 +6102,7 @@ msgid "Venues"
 msgstr "Lokalizacje"
 
 #: src/ludamus/templates/panel/base.html
+#: src/ludamus/templates/panel/print-materials.html
 msgid "Print Materials"
 msgstr "Materiały do druku"
 
@@ -7249,6 +7238,11 @@ msgstr ""
 "Nie ma jeszcze żadnych integracji. Dodaj jedną, aby to wydarzenie mogło "
 "komunikować się przez zewnętrzny system."
 
+#: src/ludamus/templates/panel/parts/_print-scope-control.html
+#: src/ludamus/templates/panel/parts/print-controls.html
+msgid "Whole event…"
+msgstr "Całe wydarzenie…"
+
 #: src/ludamus/templates/panel/parts/confirmation-facilitator-card.html
 #, python-format
 msgid "Handled by %(name)s"
@@ -7477,6 +7471,22 @@ msgid ""
 msgstr ""
 "Nie znaleziono pytań źródłowych. Sprawdź połączenie tej integracji w sekcji "
 "Ustawienia → Integracje."
+
+#: src/ludamus/templates/panel/parts/print-controls.html
+msgid "Print timetable"
+msgstr "Drukuj harmonogram"
+
+#: src/ludamus/templates/panel/parts/print-controls.html
+msgid "Print timetable for a venue or area"
+msgstr "Drukuj harmonogram dla lokalizacji lub strefy"
+
+#: src/ludamus/templates/panel/parts/print-controls.html
+msgid "Print door cards for a venue or area"
+msgstr "Drukuj tabliczki na drzwi dla lokalizacji lub strefy"
+
+#: src/ludamus/templates/panel/parts/print-controls.html
+msgid "Print door cards"
+msgstr "Drukuj tabliczki na drzwi"
 
 #: src/ludamus/templates/panel/parts/proposal-duration.html
 msgid "Custom duration"
@@ -7872,6 +7882,30 @@ msgid ""
 msgstr ""
 "Nie zdefiniowano pól danych osobowych. Dodaj pola, aby zbierać informacje o "
 "twórcach."
+
+#: src/ludamus/templates/panel/print-materials.html
+msgid ""
+"Open a print-ready page, then use your browser to save it as a PDF or print "
+"it. Use the scope menu to print a single space — a room, a floor, or a whole "
+"building. Door cards can be limited to a time window — leave the start empty "
+"to print the whole event."
+msgstr ""
+"Otwórz stronę gotową do druku, a następnie zapisz ją jako PDF lub wydrukuj w "
+"przeglądarce. Użyj menu zakresu, aby wydrukować pojedynczą przestrzeń — "
+"salę, piętro lub cały budynek. Tabliczki na drzwi można ograniczyć do "
+"przedziału czasowego — zostaw pusty początek, aby wydrukować całe wydarzenie."
+
+#: src/ludamus/templates/panel/print/base.html
+msgid "or press Ctrl+P (⌘P on Mac)"
+msgstr "lub naciśnij Ctrl+P (⌘P na Macu)"
+
+#: src/ludamus/templates/panel/print/door-cards.html
+msgid "No rooms to print."
+msgstr "Brak sal do wydruku."
+
+#: src/ludamus/templates/panel/print/timetable.html
+msgid "No time slots scheduled."
+msgstr "Nie zaplanowano przedziałów czasowych."
 
 #: src/ludamus/templates/panel/proposal-detail.html
 msgid "Proposal Details"
@@ -8642,36 +8676,6 @@ msgstr "Temat"
 #: src/ludamus/templates/staging_email_inbox.html
 msgid "No emails captured yet."
 msgstr "Brak przechwyconych e-maili."
-
-#~ msgid "Whole event…"
-#~ msgstr "Całe wydarzenie…"
-
-#~ msgid "Print timetable"
-#~ msgstr "Drukuj harmonogram"
-
-#~ msgid "Print timetable for a venue or area"
-#~ msgstr "Drukuj harmonogram dla lokalizacji lub strefy"
-
-#~ msgid "Print door cards for a venue or area"
-#~ msgstr "Drukuj tabliczki na drzwi dla lokalizacji lub strefy"
-
-#~ msgid ""
-#~ "Open a print-ready page, then use your browser to save it as a PDF or "
-#~ "print it. Use the scope menu to print a single space — a room, a floor, "
-#~ "or a whole building. Door cards can be limited to a time window — leave "
-#~ "the start empty to print the whole event."
-#~ msgstr ""
-#~ "Otwórz stronę gotową do druku, a następnie zapisz ją jako PDF lub "
-#~ "wydrukuj w przeglądarce. Użyj menu zakresu, aby wydrukować pojedynczą "
-#~ "przestrzeń — salę, piętro lub cały budynek. Tabliczki na drzwi można "
-#~ "ograniczyć do przedziału czasowego — zostaw pusty początek, aby "
-#~ "wydrukować całe wydarzenie."
-
-#~ msgid "or press Ctrl+P (⌘P on Mac)"
-#~ msgstr "lub naciśnij Ctrl+P (⌘P na Macu)"
-
-#~ msgid "No time slots scheduled."
-#~ msgstr "Nie zaplanowano przedziałów czasowych."
 
 #~ msgid ""
 #~ "Reimport will overwrite any manual edits to the imported fields on this "

--- a/src/ludamus/mills/printing.py
+++ b/src/ludamus/mills/printing.py
@@ -1,11 +1,11 @@
 """Printing subdomain business logic.
 
-Assembles the printable materials of the public ``/print`` page (per-room-and-day
-door cards, a printed timetable, and description-rich per-area time-range pages)
-from scheduled agenda items. Queries default to confirmed sessions only;
-``confirmed_only=False`` (the sphere managers' toggle) also includes the
-unconfirmed ones. Empty timetable cells render as explicit gaps; door cards are
-participant-facing and list only rooms and hours that actually hold a session.
+Assembles printable materials (per-room door cards, a printed timetable, and
+description-rich per-area time-range pages) from scheduled agenda items. The
+organizer-facing materials include every scheduled session; passing
+``confirmed_only=True`` (the public ``/print`` page) keeps only confirmed ones.
+Empty timetable cells render as explicit gaps; door cards are participant-facing
+and list only rooms and hours that actually hold a session.
 """
 
 from __future__ import annotations
@@ -16,21 +16,24 @@ from typing import TYPE_CHECKING
 
 from ludamus.pacts.printing import (
     AreaScheduleDocumentDTO,
+    AreaScheduleQueryDTO,
     AreaScheduleSessionDTO,
     AreaScheduleSpaceDTO,
+    DoorCardDayDTO,
     DoorCardDTO,
     DoorCardEntryDTO,
     DoorCardsDocumentDTO,
+    DoorCardsQueryDTO,
     PrintablesReadyNotification,
     PrintablesReminderServiceProtocol,
     PrintOptionDTO,
-    PrintQueryDTO,
     PrintSessionDTO,
     PrintSessionListDocumentDTO,
     PrintSessionListItemDTO,
     PrintTimetableCellDTO,
     PrintTimetableDocumentDTO,
     PrintTimetablePageDTO,
+    PrintTimetableQueryDTO,
     PrintTimetableRowDTO,
 )
 
@@ -131,11 +134,9 @@ class PrintMaterialsService:
             for track in self._tracks.list_public_by_event(event_pk)
         ]
 
-    def build_door_cards(self, query: PrintQueryDTO) -> DoorCardsDocumentDTO:
+    def build_door_cards(self, query: DoorCardsQueryDTO) -> DoorCardsDocumentDTO:
         event = self._events.read(query.event_pk)
-        spaces = self._scoped_spaces(
-            query.event_pk, query.scope_space_pks, query.track_pk
-        )
+        spaces = self._scoped_spaces(query.event_pk, query.scope_space_pks, None)
         items = self._agenda_items.list_by_event(query.event_pk)
         if query.time_range is not None:
             items = [item for item in items if _overlaps(item, *query.time_range)]
@@ -147,9 +148,11 @@ class PrintMaterialsService:
         for space in spaces:
             # Cards hang on doors for participants: a room with nothing
             # scheduled gets no card, and empty hours are simply not listed.
+            if not (space_items := items_by_space.get(space.pk)):
+                continue
             entries_by_day: dict[date, list[DoorCardEntryDTO]] = defaultdict(list)
 
-            for item in items_by_space.get(space.pk, []):
+            for item in space_items:
                 day = item.start_time.astimezone(query.tz).date()
                 entries_by_day[day].append(
                     DoorCardEntryDTO(
@@ -159,15 +162,15 @@ class PrintMaterialsService:
                     )
                 )
 
-            cards += [
-                DoorCardDTO(
-                    space_name=space.name,
-                    capacity=space.capacity,
-                    day=day,
-                    entries=sorted(entries_by_day[day], key=_entry_start),
+            days = [
+                DoorCardDayDTO(
+                    day=day, entries=sorted(entries_by_day[day], key=_entry_start)
                 )
                 for day in sorted(entries_by_day)
             ]
+            cards.append(
+                DoorCardDTO(space_name=space.name, capacity=space.capacity, days=days)
+            )
 
         return DoorCardsDocumentDTO(
             event_name=event.name,
@@ -178,7 +181,9 @@ class PrintMaterialsService:
             cards=cards,
         )
 
-    def build_timetable(self, query: PrintQueryDTO) -> PrintTimetableDocumentDTO:
+    def build_timetable(
+        self, query: PrintTimetableQueryDTO
+    ) -> PrintTimetableDocumentDTO:
         event = self._events.read(query.event_pk)
         spaces = self._scoped_spaces(
             query.event_pk, query.scope_space_pks, query.track_pk
@@ -257,7 +262,9 @@ class PrintMaterialsService:
             pages=pages,
         )
 
-    def build_area_schedule(self, query: PrintQueryDTO) -> AreaScheduleDocumentDTO:
+    def build_area_schedule(
+        self, query: AreaScheduleQueryDTO
+    ) -> AreaScheduleDocumentDTO:
         event = self._events.read(query.event_pk)
         range_start, range_end = query.time_range or (event.start_time, event.end_time)
         spaces = self._scoped_spaces(
@@ -301,7 +308,7 @@ class PrintMaterialsService:
         )
 
     def build_session_list(
-        self, event_pk: int, *, confirmed_only: bool = True
+        self, event_pk: int, *, confirmed_only: bool = False
     ) -> PrintSessionListDocumentDTO | None:
         tracks = self._tracks.list_public_by_event(event_pk)
         slots = self._time_slots.list_by_event(event_pk)

--- a/src/ludamus/pacts/printing.py
+++ b/src/ludamus/pacts/printing.py
@@ -1,9 +1,8 @@
 """Printing subdomain DTOs and protocols.
 
-Read-only document shapes for the printable materials on the public
-``/print`` page: a timetable grid, per-room-and-day door cards, per-space
-descriptions pages, and a session list. Rendered as print-styled HTML pages
-in the web gate (browser Save-as-PDF); assembled by `mills.printing`.
+Read-only document shapes for organizer-facing printable materials
+(per-room door cards, a printed timetable). Rendered as print-styled HTML
+pages in the web gate (browser Save-as-PDF); assembled by `mills.printing`.
 """
 
 from __future__ import annotations
@@ -26,20 +25,36 @@ class PrintSessionDTO(BaseModel):
     presenter_name: str
 
 
-# One query shape for every printable document; a builder ignores the fields
-# its document doesn't use (door cards take no track, the area schedule no tz).
 @dataclass(frozen=True)
-class PrintQueryDTO:
+class PrintTimetableQueryDTO:
     event_pk: int
     tz: tzinfo
     scope_space_pks: frozenset[int] | None = None
     track_pk: int | None = None
     scope_name: str | None = None
-    # Confirmed-only is the safe default: unconfirmed sessions reach paper
-    # only when a caller deliberately asks for them.
-    confirmed_only: bool = True
-    # None means the whole event; the mills default to the event bounds.
+    confirmed_only: bool = False
     time_range: tuple[datetime, datetime] | None = None
+
+
+@dataclass(frozen=True)
+class DoorCardsQueryDTO:
+    event_pk: int
+    tz: tzinfo
+    scope_space_pks: frozenset[int] | None = None
+    scope_name: str | None = None
+    confirmed_only: bool = False
+    time_range: tuple[datetime, datetime] | None = None
+
+
+@dataclass(frozen=True)
+class AreaScheduleQueryDTO:
+    event_pk: int
+    # None means the whole event; the mill defaults to the event bounds.
+    time_range: tuple[datetime, datetime] | None = None
+    scope_space_pks: frozenset[int] | None = None
+    track_pk: int | None = None
+    scope_name: str | None = None
+    confirmed_only: bool = False
 
 
 class DoorCardEntryDTO(BaseModel):
@@ -48,12 +63,15 @@ class DoorCardEntryDTO(BaseModel):
     session: PrintSessionDTO
 
 
-# One card is one sheet of paper: it hangs on a door for a single day.
+class DoorCardDayDTO(BaseModel):
+    day: date
+    entries: list[DoorCardEntryDTO]
+
+
 class DoorCardDTO(BaseModel):
     space_name: str
     capacity: int | None
-    day: date
-    entries: list[DoorCardEntryDTO]
+    days: list[DoorCardDayDTO]
 
 
 class DoorCardsDocumentDTO(BaseModel):
@@ -153,7 +171,7 @@ class PrintablesReminderDTO(BaseModel):
     event_name: str
     event_slug: str
     # Site domain of the owning sphere — the notifier composes the absolute
-    # print-page link from it (sphere sites live on different domains).
+    # print-materials link from it (sphere sites live on different domains).
     sphere_domain: str
     recipients: list[PrintablesReminderRecipientDTO]
 
@@ -190,9 +208,13 @@ class PrintablesReminderServiceProtocol(Protocol):
 
 class PrintMaterialsServiceProtocol(Protocol):
     def list_tracks(self, event_pk: int) -> list[PrintOptionDTO]: ...
-    def build_door_cards(self, query: PrintQueryDTO) -> DoorCardsDocumentDTO: ...
-    def build_timetable(self, query: PrintQueryDTO) -> PrintTimetableDocumentDTO: ...
-    def build_area_schedule(self, query: PrintQueryDTO) -> AreaScheduleDocumentDTO: ...
+    def build_door_cards(self, query: DoorCardsQueryDTO) -> DoorCardsDocumentDTO: ...
+    def build_timetable(
+        self, query: PrintTimetableQueryDTO
+    ) -> PrintTimetableDocumentDTO: ...
+    def build_area_schedule(
+        self, query: AreaScheduleQueryDTO
+    ) -> AreaScheduleDocumentDTO: ...
     def build_session_list(
-        self, event_pk: int, *, confirmed_only: bool = True
+        self, event_pk: int, *, confirmed_only: bool = False
     ) -> PrintSessionListDocumentDTO | None: ...

--- a/src/ludamus/templates/chronology/print.html
+++ b/src/ludamus/templates/chronology/print.html
@@ -80,11 +80,9 @@
                                 {% end_select %}
                             </div>
                         {% endif %}
-                        {% if show_descriptions_control %}
+                        {% if show_timetable_controls %}
                             {% translate "With descriptions" as t_descriptions %}
                             {% include "components/checkbox-field.html" with name="descriptions" id="id_descriptions" label=t_descriptions value="1" checked=descriptions %}
-                        {% endif %}
-                        {% if show_range_controls %}
                             <div class="flex flex-col gap-1">
                                 <label class="text-sm font-semibold text-foreground-secondary"
                                        for="id_start">{% translate "Start" %}</label>
@@ -106,10 +104,6 @@
                                        placeholder="{% translate "until event end" %}"
                                        class="w-full rounded-lg border border-border bg-bg-secondary px-3 py-2 text-sm text-foreground">
                             </div>
-                        {% endif %}
-                        {% if show_unconfirmed_control %}
-                            {% translate "Include unconfirmed sessions" as t_unconfirmed %}
-                            {% include "components/checkbox-field.html" with name="unconfirmed" id="id_unconfirmed" label=t_unconfirmed value="1" checked=unconfirmed %}
                         {% endif %}
                         <div class="grid gap-2">
                             {% translate "Print" as t_print %}
@@ -135,16 +129,6 @@
                                         <a class="block rounded-md px-2 py-1.5 text-foreground-muted no-underline hover:bg-background"
                                            href="#area-space-{{ forloop.counter }}">{{ space.space_name }}</a>
                                     {% endif %}
-                                {% endfor %}
-                            {% elif door_cards %}
-                                {% for card in door_cards.cards %}
-                                    <a class="block rounded-md px-2 py-1.5 text-foreground-muted no-underline hover:bg-background"
-                                       href="#door-card-{{ forloop.counter }}">
-                                        {{ card.space_name }}
-                                        <span class="block text-xs">{{ card.day|date:"l, j E" }}</span>
-                                    </a>
-                                {% empty %}
-                                    <span class="px-2 py-1.5 text-foreground-muted">{% translate "No pages" %}</span>
                                 {% endfor %}
                             {% elif session_list %}
                                 <a class="block rounded-md px-2 py-1.5 text-foreground-muted no-underline hover:bg-background"
@@ -214,59 +198,7 @@
                                 <section class="{{ sheet_class }}">
                                     {% include "chronology/parts/print_header.html" with scope_name=timetable.scope_name show_full_schedule_label=True %}
                                     <h2 class="m-0 mb-[3mm] text-[14pt]">{% translate "Timetable" %}</h2>
-                                    <p class="italic text-neutral-500">
-                                        {# A manager printing with unconfirmed included sees the honest variant. #}
-                                        {% if unconfirmed %}
-                                            {% translate "No sessions scheduled yet." %}
-                                        {% else %}
-                                            {% translate "No confirmed sessions scheduled yet." %}
-                                        {% endif %}
-                                    </p>
-                                </section>
-                            {% endfor %}
-                        {% elif door_cards %}
-                            {% for card in door_cards.cards %}
-                                {# One A4 page per card: a card hangs on the door for one day. #}
-                                <section class="{{ sheet_class }}"
-                                         id="door-card-{{ forloop.counter }}"
-                                         role="group"
-                                         aria-labelledby="door-card-{{ forloop.counter }}-room door-card-{{ forloop.counter }}-day">
-                                    {% include "chronology/parts/print_header.html" with scope_name=door_cards.scope_name show_full_schedule_label=True %}
-                                    <h2 id="door-card-{{ forloop.counter }}-room"
-                                        class="m-0 mb-[1mm] text-[26pt]">{{ card.space_name }}</h2>
-                                    {% if card.capacity %}
-                                        <p class="m-0 mb-[1mm] text-neutral-500">{% translate "Capacity" %}: {{ card.capacity }}</p>
-                                    {% endif %}
-                                    <h3 id="door-card-{{ forloop.counter }}-day"
-                                        class="m-0 mt-[5mm] mb-[2mm] border-b-[0.5pt] border-neutral-300 text-[12pt]">
-                                        {{ card.day|date:"l, j E" }}
-                                    </h3>
-                                    <table class="w-full border-collapse">
-                                        <thead class="sr-only">
-                                            <tr>
-                                                <th scope="col">{% translate "Time" %}</th>
-                                                <th scope="col">{% translate "Session" %}</th>
-                                            </tr>
-                                        </thead>
-                                        <tbody>
-                                            {% for entry in card.entries %}
-                                                <tr class="border-b-[0.5pt] border-neutral-200">
-                                                    <td class="w-[28mm] whitespace-nowrap py-[2mm] pr-[3mm] align-top tabular-nums">
-                                                        {{ entry.start_time|time:"H:i" }}–{{ entry.end_time|time:"H:i" }}
-                                                    </td>
-                                                    <td class="py-[2mm] align-top">
-                                                        <strong>{{ entry.session.title }}</strong>
-                                                        {% if entry.session.presenter_name %}<div class="text-neutral-500">{{ entry.session.presenter_name }}</div>{% endif %}
-                                                    </td>
-                                                </tr>
-                                            {% endfor %}
-                                        </tbody>
-                                    </table>
-                                </section>
-                            {% empty %}
-                                <section class="{{ sheet_class }}">
-                                    {% include "chronology/parts/print_header.html" with scope_name=door_cards.scope_name show_full_schedule_label=True %}
-                                    <p class="italic text-neutral-500">{% translate "No rooms to print." %}</p>
+                                    <p class="italic text-neutral-500">{% translate "No confirmed sessions scheduled yet." %}</p>
                                 </section>
                             {% endfor %}
                         {% elif area_schedule %}
@@ -317,14 +249,7 @@
                                         {% if session.description %}<div class="mt-[1mm] whitespace-pre-wrap">{{ session.description }}</div>{% endif %}
                                     </div>
                                 {% empty %}
-                                    <p class="italic text-neutral-500">
-                                        {# A manager printing with unconfirmed included sees the honest variant. #}
-                                        {% if unconfirmed %}
-                                            {% translate "No sessions scheduled yet." %}
-                                        {% else %}
-                                            {% translate "No confirmed sessions scheduled yet." %}
-                                        {% endif %}
-                                    </p>
+                                    <p class="italic text-neutral-500">{% translate "No confirmed sessions scheduled yet." %}</p>
                                 {% endfor %}
                             </section>
                         {% else %}

--- a/src/ludamus/templates/panel/base.html
+++ b/src/ludamus/templates/panel/base.html
@@ -260,12 +260,9 @@
                                     <span class="sidebar-label">{{ t_timetable }}</span>
                                 </a>
                                 {% translate "Print Materials" as t_print %}
-                                {# The public print page is the one canonical print page; it opens in a new tab so the panel stays put. #}
-                                <a href="{% url 'web:chronology:event-print' slug=current_event.slug %}"
-                                   target="_blank"
-                                   rel="noopener"
+                                <a href="{% url 'panel:print-materials' slug=current_event.slug %}"
                                    title="{{ t_print }}"
-                                   class="sidebar-link flex text-sm items-center px-2 py-3 text-foreground-secondary hover:bg-bg-secondary hover:text-foreground dark:hover:bg-bg-tertiary rounded-lg transition hover:duration-0">
+                                   class="sidebar-link flex text-sm items-center px-2 py-3 {% if active_nav == 'print' %}text-foreground bg-bg-secondary dark:bg-bg-tertiary{% else %}text-foreground-secondary hover:bg-bg-secondary hover:text-foreground dark:hover:bg-bg-tertiary{% endif %} rounded-lg transition hover:duration-0">
                                     {% icon "printer" class="size-4.5 mr-2" %}
                                     <span class="sidebar-label">{{ t_print }}</span>
                                 </a>

--- a/src/ludamus/templates/panel/parts/_print-scope-control.html
+++ b/src/ludamus/templates/panel/parts/_print-scope-control.html
@@ -1,0 +1,19 @@
+{% load i18n %}
+<div class="flex items-center gap-1">
+    <a href="{% url url_name slug=current_event.slug %}"
+       target="_blank"
+       rel="noopener"
+       class="filter-toggle inline-flex min-w-36 items-center justify-center whitespace-nowrap rounded-xl border border-border bg-bg-secondary px-3 py-2 text-[0.8125rem] font-semibold text-foreground transition-[color,background-color,border-color,box-shadow] duration-150">
+        {{ label }}
+    </a>
+    {% if print_scopes %}
+        <select data-action="open-in-new-tab"
+                aria-label="{{ aria }}"
+                class="filter-input w-full min-w-40 rounded-xl border border-border bg-bg-secondary px-3 py-2 text-[0.8125rem] font-medium text-foreground transition-[border-color,box-shadow] duration-150">
+            <option value="">{% translate "Whole event…" %}</option>
+            {% for scope in print_scopes %}
+                <option value="{% url url_name slug=current_event.slug %}?scope={{ scope.pk }}">{{ scope.name }}</option>
+            {% endfor %}
+        </select>
+    {% endif %}
+</div>

--- a/src/ludamus/templates/panel/parts/print-controls.html
+++ b/src/ludamus/templates/panel/parts/print-controls.html
@@ -1,0 +1,32 @@
+{% load i18n %}
+{% translate "Print timetable" as label_timetable %}
+{% translate "Print timetable for a venue or area" as aria_timetable %}
+{% include "panel/parts/_print-scope-control.html" with url_name="panel:timetable-print" label=label_timetable aria=aria_timetable %}
+<form method="get"
+      action="{% url 'panel:timetable-print-door-cards' slug=current_event.slug %}"
+      target="_blank"
+      class="flex items-center gap-1 flex-wrap">
+    {% if print_scopes %}
+        <select name="scope"
+                aria-label="{% translate "Print door cards for a venue or area" %}"
+                class="filter-input min-w-40 rounded-xl border border-border bg-bg-secondary px-3 py-2 text-[0.8125rem] font-medium text-foreground transition-[border-color,box-shadow] duration-150">
+            <option value="">{% translate "Whole event…" %}</option>
+            {% for scope in print_scopes %}<option value="{{ scope.pk }}">{{ scope.name }}</option>{% endfor %}
+        </select>
+    {% endif %}
+    <input type="datetime-local"
+           name="start"
+           aria-label="{% translate "Start" %}"
+           class="filter-input rounded-xl border border-border bg-bg-secondary px-3 py-2 text-[0.8125rem] font-medium text-foreground transition-[border-color,box-shadow] duration-150">
+    <input type="number"
+           name="hours"
+           min="1"
+           max="72"
+           placeholder="{% translate "Hours" %}"
+           aria-label="{% translate "Hours" %}"
+           class="filter-input w-24 rounded-xl border border-border bg-bg-secondary px-3 py-2 text-[0.8125rem] font-medium text-foreground transition-[border-color,box-shadow] duration-150">
+    <button type="submit"
+            class="filter-toggle inline-flex min-w-36 items-center justify-center whitespace-nowrap rounded-xl border border-border bg-bg-secondary px-3 py-2 text-[0.8125rem] font-semibold text-foreground transition-[color,background-color,border-color,box-shadow] duration-150">
+        {% translate "Print door cards" %}
+    </button>
+</form>

--- a/src/ludamus/templates/panel/print-materials.html
+++ b/src/ludamus/templates/panel/print-materials.html
@@ -1,0 +1,23 @@
+{% extends "panel/base.html" %}
+{% load i18n %}
+{% block title_prefix %}
+    {% translate "Print Materials" %} —
+{% endblock title_prefix %}
+{% block page_title %}
+    {% translate "Print Materials" %}
+{% endblock page_title %}
+{% block page_subtitle %}
+    {% if current_event %}{{ current_event.name }}{% endif %}
+{% endblock page_subtitle %}
+{% block content %}
+    <div class="p-4">
+        {% if current_event %}
+            <div class="card p-6 max-w-2xl">
+                <p class="text-sm text-foreground-muted mb-4">
+                    {% translate "Open a print-ready page, then use your browser to save it as a PDF or print it. Use the scope menu to print a single space — a room, a floor, or a whole building. Door cards can be limited to a time window — leave the start empty to print the whole event." %}
+                </p>
+                <div class="flex gap-3 flex-wrap items-center">{% include "panel/parts/print-controls.html" %}</div>
+            </div>
+        {% endif %}
+    </div>
+{% endblock content %}

--- a/src/ludamus/templates/panel/print/base.html
+++ b/src/ludamus/templates/panel/print/base.html
@@ -1,0 +1,114 @@
+{% extends "base.html" %}
+{% load i18n %}
+{% block title %}
+    {{ document.event_name }}
+{% endblock title %}
+{% block meta_description %}{{ document.event_description|default:document.event_name }}{% endblock meta_description %}
+{% block og_description %}{{ document.event_description|default:document.event_name }}{% endblock og_description %}
+{% block twitter_description %}{{ document.event_description|default:document.event_name }}{% endblock twitter_description %}
+{% block extra_head %}
+    <style>
+        @page {
+            size: A4;
+            margin: 14mm;
+        }
+
+        /* Document typography + white paper are scoped to the sheet so they
+           never touch the site navbar/footer that now wrap this page, and so
+           the sheet prints white regardless of the active light/dark theme. */
+        .sheet {
+            font-family: sans-serif;
+            color: #111827;
+            font-size: 10pt;
+            background: #fff;
+        }
+
+        .doc-header {
+            border-bottom: 1.5pt solid #111827;
+            padding-bottom: 4mm;
+            margin-bottom: 6mm;
+        }
+
+        .doc-header .event-name {
+            font-size: 16pt;
+            font-weight: 700;
+        }
+
+        .doc-header .event-dates {
+            font-size: 9pt;
+            color: #6b7280;
+            margin-top: 1mm;
+        }
+
+        .doc-header .scope-name {
+            font-size: 11pt;
+            font-weight: 600;
+            margin-top: 1mm;
+        }
+
+        .empty {
+            color: #9ca3af;
+            font-style: italic;
+        }
+
+        .toolbar {
+            margin: 0 0 12px;
+        }
+
+        .print-btn {
+            font: 600 14px sans-serif;
+            padding: 8px 16px;
+            border: 1px solid #111827;
+            border-radius: 8px;
+            background: #111827;
+            color: #fff;
+            cursor: pointer;
+        }
+
+        .print-hint {
+            margin-left: 10px;
+            font: 14px sans-serif;
+            color: #6b7280;
+        }
+
+        @media screen {
+            .sheet {
+                max-width: 210mm;
+                margin: 16px auto;
+                padding: 14mm;
+                box-shadow: 0 1px 6px rgba(0, 0, 0, 0.18);
+            }
+        }
+
+        /* Print only the document: drop the site chrome and the toolbar, and
+           keep the page white even if the user is in dark mode. */
+        @media print {
+            body {
+                background: #fff;
+            }
+
+            .app-scroll>nav,
+            .app-scroll>footer,
+            .no-print {
+                display: none !important;
+            }
+        }
+    </style>
+    {% block extra_style %}
+    {% endblock extra_style %}
+{% endblock extra_head %}
+{% block body_class %}
+    app-shell relative bg-background font-sans text-foreground antialiased print:m-0 print:bg-white print:p-0
+{% endblock body_class %}
+{% block main_region %}
+    <main class="grow w-full">
+        <div class="sheet">
+            <div class="toolbar no-print">
+                <button type="button" class="print-btn" data-action="print">{% translate "Print" %}</button>
+                <span class="print-hint">{% translate "or press Ctrl+P (⌘P on Mac)" %}</span>
+            </div>
+            {% block body %}
+            {% endblock body %}
+        </div>
+    </main>
+{% endblock main_region %}

--- a/src/ludamus/templates/panel/print/door-cards.html
+++ b/src/ludamus/templates/panel/print/door-cards.html
@@ -1,0 +1,42 @@
+{% extends "panel/print/base.html" %}
+{% load i18n %}
+{% block body %}
+    {% for card in document.cards %}
+        {# one A4 page per room #}
+        <section {% if not forloop.last %}style="break-after: page;"{% endif %}>
+            <div class="doc-header">
+                <div class="event-name">{{ document.event_name }}</div>
+                <div class="event-dates">{{ document.event_start|date:"j E Y" }}–{{ document.event_end|date:"j E Y" }}</div>
+                {% if document.scope_name %}<div class="scope-name">{{ document.scope_name }}</div>{% endif %}
+            </div>
+            <h1 style="font-size: 26pt; margin: 0 0 1mm 0;">{{ card.space_name }}</h1>
+            {% if card.capacity %}
+                <p style="margin: 0 0 6mm 0; color: #6b7280;">{% translate "Capacity" %}: {{ card.capacity }}</p>
+            {% endif %}
+            {% for day in card.days %}
+                <h2 style="font-size: 12pt;
+                           margin: 5mm 0 2mm 0;
+                           border-bottom: 0.5pt solid #d1d5db">{{ day.day|date:"l, j E" }}</h2>
+                <table style="width: 100%; border-collapse: collapse;">
+                    {% for entry in day.entries %}
+                        <tr style="border-bottom: 0.5pt solid #e5e7eb;">
+                            <td style="width: 28mm;
+                                       padding: 2mm 3mm 2mm 0;
+                                       vertical-align: top;
+                                       white-space: nowrap;
+                                       font-variant-numeric: tabular-nums">
+                                {{ entry.start_time|time:"H:i" }}–{{ entry.end_time|time:"H:i" }}
+                            </td>
+                            <td style="padding: 2mm 0; vertical-align: top;">
+                                <strong>{{ entry.session.title }}</strong>
+                                {% if entry.session.presenter_name %}<div style="color: #6b7280;">{{ entry.session.presenter_name }}</div>{% endif %}
+                            </td>
+                        </tr>
+                    {% endfor %}
+                </table>
+            {% endfor %}
+        </section>
+    {% empty %}
+        <p class="empty">{% translate "No rooms to print." %}</p>
+    {% endfor %}
+{% endblock body %}

--- a/src/ludamus/templates/panel/print/timetable.html
+++ b/src/ludamus/templates/panel/print/timetable.html
@@ -1,0 +1,76 @@
+{% extends "panel/print/base.html" %}
+{% load i18n %}
+{% block extra_style %}
+    <style>
+        @page {
+            size: A4 landscape;
+        }
+    </style>
+{% endblock extra_style %}
+{% block body %}
+    <div class="doc-header">
+        <div class="event-name">{{ document.event_name }}</div>
+        <div class="event-dates">{{ document.event_start|date:"j E Y" }}–{{ document.event_end|date:"j E Y" }}</div>
+        {% if document.scope_name %}<div class="scope-name">{{ document.scope_name }}</div>{% endif %}
+    </div>
+    {% for page in document.pages %}
+        <section {% if not forloop.last %}style="break-after: page;"{% endif %}>
+            <h2 style="font-size: 12pt; margin: 0 0 2mm 0;">
+                {{ page.day|date:"l, j E Y" }}
+                {% if page.space_range_name %}
+                    <span style="display: block; font-size: 9pt; font-weight: 400;">{{ page.space_range_name }}</span>
+                {% endif %}
+            </h2>
+            <table style="width: 100%;
+                          border-collapse: collapse;
+                          font-size: 8pt;
+                          table-layout: fixed">
+                <thead>
+                    <tr>
+                        <th style="width: 22mm;
+                                   border: 0.5pt solid #111827;
+                                   border-bottom-width: 1.5pt;
+                                   padding: 1.5mm;
+                                   text-align: left">{% translate "Time" %}</th>
+                        {% for name in page.space_names %}
+                            <th style="border: 0.5pt solid #111827;
+                                       border-bottom-width: 1.5pt;
+                                       padding: 1.5mm;
+                                       text-align: left">{{ name }}</th>
+                        {% endfor %}
+                    </tr>
+                </thead>
+                <tbody>
+                    {% for row in page.rows %}
+                        <tr>
+                            <td style="border: 0.5pt solid #d1d5db;
+                                       padding: 1.5mm;
+                                       white-space: nowrap;
+                                       font-variant-numeric: tabular-nums;
+                                       vertical-align: top">
+                                {{ row.start_time|time:"H:i" }}–{{ row.end_time|time:"H:i" }}
+                            </td>
+                            {% for cell in row.cells %}
+                                <td style="border: 0.5pt solid #d1d5db;
+                                           padding: 1.5mm;
+                                           vertical-align: top;
+                                           text-align: {% if cell.sessions %}left{% else %}center{% endif %}">
+                                    {% for session in cell.sessions %}
+                                        <div {% if not forloop.last %}style="margin-bottom: 1mm;"{% endif %}>
+                                            <strong>{{ session.title }}</strong>
+                                            {% if session.presenter_name %}<div style="color: #6b7280;">{{ session.presenter_name }}</div>{% endif %}
+                                        </div>
+                                    {% empty %}
+                                        <span class="empty">—</span>
+                                    {% endfor %}
+                                </td>
+                            {% endfor %}
+                        </tr>
+                    {% endfor %}
+                </tbody>
+            </table>
+        </section>
+    {% empty %}
+        <p class="empty">{% translate "No time slots scheduled." %}</p>
+    {% endfor %}
+{% endblock body %}

--- a/src/ludamus/templates/panel/timetable.html
+++ b/src/ludamus/templates/panel/timetable.html
@@ -64,14 +64,21 @@
         </div>
         <div class="flex items-center gap-2 flex-wrap ml-auto">
             {% translate "Print" as t_print %}
-            {# The public print page is the one canonical print page — this link carries the schedule's current track and day filters over. #}
-            <a href="{{ print_url }}"
-               target="_blank"
-               rel="noopener"
-               class="filter-toggle inline-flex items-center gap-2 px-3 py-1.5 rounded-lg text-sm font-semibold border border-border whitespace-nowrap cursor-pointer bg-bg-secondary text-foreground-muted transition-[color,background-color,border-color,box-shadow] duration-150">
-                {% icon "printer" class="size-4" %}
-                <span class="hidden sm:inline">{{ t_print }}</span>
-            </a>
+            <div class="relative" data-menu>
+                <button type="button"
+                        data-menu-button
+                        aria-expanded="false"
+                        aria-haspopup="true"
+                        class="filter-toggle inline-flex items-center gap-2 px-3 py-1.5 rounded-lg text-sm font-semibold border border-border whitespace-nowrap cursor-pointer bg-bg-secondary text-foreground-muted transition-[color,background-color,border-color,box-shadow] duration-150">
+                    {% icon "printer" class="size-4" %}
+                    <span class="hidden sm:inline">{{ t_print }}</span>
+                </button>
+                <div data-menu-panel hidden class="absolute right-0 mt-1 z-40">
+                    <div {% include "components/menu_surface.html" with extra_class="flex flex-col gap-2 rounded-2xl border border-border bg-bg-secondary p-3 shadow-xl" %}>
+                        {% include "panel/parts/print-controls.html" %}
+                    </div>
+                </div>
+            </div>
             {% if filter_track_pk %}
                 <form hx-post="{% url 'panel:timetable-confirm-block' slug=current_event.slug %}"
                       hx-swap="none">

--- a/tests/e2e/tests/csp-violations.spec.ts
+++ b/tests/e2e/tests/csp-violations.spec.ts
@@ -175,4 +175,33 @@ test.describe("CSP enforcement doesn't break converted inline handlers", () => {
     await expect(page).toHaveURL(new RegExp(`[?&]space=${value}`));
     await assertNoCspViolations(page);
   });
+
+  test("print-scope picker opens the scoped printout in a new tab", async ({ page }) => {
+    await page.goto("/panel/event/kapitularz-2025-anonymized/print/", {
+      waitUntil: "domcontentloaded",
+    });
+
+    const scope = page.getByLabel("Print timetable for a venue or area");
+    const [popup] = await Promise.all([
+      page.waitForEvent("popup"),
+      scope.selectOption({ index: 1 }),
+    ]);
+
+    await expect(popup).toHaveURL(/[?&]scope=\d+/);
+    await popup.close();
+    // The picker resets itself so the same scope can be opened twice.
+    await expect(scope).toHaveValue("");
+    await assertNoCspViolations(page);
+  });
+
+  test("panel printout's Print button", async ({ page }) => {
+    await page.goto("/panel/event/kapitularz-2025-anonymized/timetable/print/timetable/", {
+      waitUntil: "domcontentloaded",
+    });
+
+    await page.getByRole("button", { name: "Print", exact: true }).click();
+
+    expect(await page.evaluate(() => window.__printCalls)).toBe(1);
+    await assertNoCspViolations(page);
+  });
 });

--- a/tests/e2e/tests/print-flow.spec.ts
+++ b/tests/e2e/tests/print-flow.spec.ts
@@ -65,36 +65,9 @@ test.describe("Print page controls", () => {
     await expect(page.getByLabel("With descriptions")).toBeChecked();
     await expect(page.getByRole("heading", { name: "Program details" }).first()).toBeVisible();
   });
-
-  test("door cards print one sheet per room and day", async ({ page }) => {
-    await page.goto(`${printUrl}?material=door-cards`);
-
-    // Miniature Painting is the only room in its track and the seed schedules
-    // it on all three days, so it gets exactly three sheets — one per day.
-    await expect(
-      page.getByRole("heading", { name: "Miniature Painting", exact: true }),
-    ).toHaveCount(3);
-    await expect(page.getByText("Capacity: 18").first()).toBeVisible();
-
-    // One room and one day per sheet, the event named on every sheet — a card
-    // torn off the stack still says where and when it belongs.
-    const preview = page.getByRole("region", { name: "Print preview" });
-    const cards = preview.getByRole("group");
-    const labels: string[] = [];
-    for (const card of await cards.all()) {
-      const room = card.getByRole("heading", { level: 2 });
-      const day = card.getByRole("heading", { level: 3 });
-      await expect(room).toHaveCount(1);
-      await expect(day).toHaveCount(1);
-      await expect(card.getByText(eventName).first()).toBeVisible();
-      labels.push(`${await room.innerText()}|${await day.innerText()}`);
-    }
-    // No room+day is printed twice.
-    expect(new Set(labels).size).toBe(labels.length);
-  });
 });
 
-test.describe("Print page for managers", () => {
+test.describe("Panel print pages", () => {
   test.beforeEach(async ({ page }) => {
     // Log in via Django admin as the manager user (same flow as panel.spec.ts;
     // domcontentloaded because Firefox occasionally never fires `load` here).
@@ -104,28 +77,33 @@ test.describe("Print page for managers", () => {
     await page.getByRole("button", { name: /Log in/i }).click();
   });
 
-  test("the unconfirmed-sessions toggle applies itself to the URL", async ({ page }) => {
-    await page.goto(printUrl);
+  test("print materials hub offers timetable and door cards", async ({ page }) => {
+    await page.goto("/panel/event/kapitularz-2025-anonymized/print/");
 
-    const box = page.getByLabel("Include unconfirmed sessions");
-    await box.check();
-
-    await expect(page).toHaveURL(/unconfirmed=1/);
-    await expect(page.getByLabel("Include unconfirmed sessions")).toBeChecked();
+    await expect(page.getByRole("heading", { name: "Print Materials" })).toBeVisible();
+    await expect(page.getByText("Print timetable").first()).toBeVisible();
+    await expect(page.getByText("Print door cards").first()).toBeVisible();
   });
 
-  test("panel links lead to the canonical print page", async ({ page }) => {
-    await page.goto("/panel/event/kapitularz-2025-anonymized/timetable/");
+  test("panel timetable printout shows session-time rows", async ({ page }) => {
+    await page.goto("/panel/event/kapitularz-2025-anonymized/timetable/print/timetable/");
 
-    // Sidebar "Print Materials" and the schedule toolbar "Print" both point at
-    // the public print page — the panel renders no print pages of its own.
-    await expect(page.getByRole("link", { name: "Print Materials" })).toHaveAttribute(
-      "href",
-      printUrl,
-    );
-    await expect(page.getByRole("link", { name: "Print", exact: true })).toHaveAttribute(
-      "href",
-      printUrl,
-    );
+    await expect(page.getByText(eventName).first()).toBeVisible();
+    await expect(
+      page.getByRole("columnheader", { name: "Time", exact: true }).first(),
+    ).toBeVisible();
+    // Session times, not 4-hour availability slots: an 11:00–13:00 session
+    // renders as its own row.
+    await expect(page.getByRole("cell", { name: /11:00–13:00/ }).first()).toBeVisible();
+  });
+
+  test("door cards render one card per room with its hours", async ({ page }) => {
+    await page.goto("/panel/event/kapitularz-2025-anonymized/timetable/print/door-cards/");
+
+    // Only rooms with sessions get a card; Miniature Painting always has some.
+    await expect(
+      page.getByRole("heading", { name: "Miniature Painting", exact: true }).first(),
+    ).toBeVisible();
+    await expect(page.getByText("Capacity: 18").first()).toBeVisible();
   });
 });

--- a/tests/e2e/tests/print-page.spec.ts
+++ b/tests/e2e/tests/print-page.spec.ts
@@ -47,7 +47,6 @@ test.describe("Public print page", () => {
     const materials = [
       ["timetable", "Timetable"],
       ["track-timetable", "Track timetable"],
-      ["door-cards", "Door cards"],
     ] as const;
 
     await page.goto(densePrintUrl);

--- a/tests/integration/cli/test_send_printables_reminders.py
+++ b/tests/integration/cli/test_send_printables_reminders.py
@@ -32,7 +32,7 @@ class TestSendPrintablesReminders:
         email = mailoutbox[0]
         assert email.to == [active_user.email]
         assert event.name in email.subject
-        path = reverse("web:chronology:event-print", kwargs={"slug": event.slug})
+        path = reverse("panel:print-materials", kwargs={"slug": event.slug})
         assert f"https://{sphere.site.domain}{path}" in email.body
         notification = Notification.objects.get(recipient=active_user)
         assert notification.kind == NotificationKind.PRINTABLES_READY.value

--- a/tests/integration/web/chronology/test_event_print_page.py
+++ b/tests/integration/web/chronology/test_event_print_page.py
@@ -5,15 +5,11 @@ from unittest.mock import ANY
 import pytest
 from django.urls import reverse
 from django.utils import timezone
-from django.utils.timezone import localdate
 
-from ludamus.gates.web.django.event.print import MATERIAL_SPECS_BY_VALUE
+from ludamus.gates.web.django.event.print import MATERIAL_SPECS
 from ludamus.links.db.django.models import Space, Track
 from ludamus.pacts import EventDTO
 from ludamus.pacts.printing import (
-    DoorCardDTO,
-    DoorCardEntryDTO,
-    DoorCardsDocumentDTO,
     PrintOptionDTO,
     PrintSessionDTO,
     PrintTimetableCellDTO,
@@ -34,10 +30,6 @@ from tests.integration.utils import (
     assert_response,
     assert_response_404,
 )
-
-
-def _specs(*values):
-    return tuple(MATERIAL_SPECS_BY_VALUE[value] for value in values)
 
 
 def _scope(space, name=None):
@@ -63,10 +55,8 @@ def _assert_print_ok(
     range_hours=None,
     material="timetable",
     descriptions=False,
-    unconfirmed=False,
     session_list_available=False,
     tracks_available=False,
-    panel_access=False,
     print_scopes=None,
 ):
     if print_scopes is None:
@@ -84,16 +74,10 @@ def _assert_print_ok(
         expected_options.append("track-timetable")
     if session_list_available:
         expected_options.append("session-list")
-    expected_options.append("door-cards")
     assert [option.value for option in ctx["material_options"]] == expected_options
-    show_scope_control = material in {"timetable", "door-cards"}
+    show_scope_control = material == "timetable"
     show_track_control = material == "track-timetable"
-    show_descriptions_control = material in {
-        "timetable",
-        "track-timetable",
-        "door-cards",
-    }
-    show_range_controls = material in {"timetable", "track-timetable", "door-cards"}
+    is_timetable = material in {"timetable", "track-timetable"}
     assert_response(
         response,
         HTTPStatus.OK,
@@ -104,7 +88,6 @@ def _assert_print_ok(
             "timetable": ANY,
             "area_schedule": ANY,
             "session_list": ANY,
-            "door_cards": ANY,
             "qr_svg": ctx["qr_svg"],
             "print_scopes": print_scopes,
             "tracks": ANY,
@@ -112,11 +95,8 @@ def _assert_print_ok(
             "material": material,
             "show_scope_control": show_scope_control,
             "show_track_control": show_track_control,
-            "show_descriptions_control": show_descriptions_control,
-            "show_range_controls": show_range_controls,
-            "show_unconfirmed_control": panel_access,
+            "show_timetable_controls": is_timetable,
             "descriptions": descriptions,
-            "unconfirmed": unconfirmed,
             "selected_scope": selected_scope,
             "selected_track": selected_track,
             "range_start_value": ctx["range_start_value"],
@@ -144,9 +124,6 @@ class TestPublicEventPrintView:
 
         _assert_print_ok(response, print_scopes=[_scope(space)])
         assert_cache_control(response, {"public", "max-age=300"})
-        # The same URL serves a manager variant; only Vary: Cookie keeps a
-        # shared cache from handing it to the wrong audience.
-        assert "Cookie" in response.headers.get("Vary", "")
         content = response.content.decode()
         assert session.title in content
         assert "Table of contents" in content
@@ -297,8 +274,9 @@ class TestPublicEventPrintView:
 
         response = authenticated_client.get(self._url(event.slug))
 
-        _assert_print_ok(response, panel_access=True, print_scopes=[_scope(space)])
+        _assert_print_ok(response, print_scopes=[_scope(space)])
         assert_cache_control(response, {"private", "max-age=5"})
+        assert session.title in response.content.decode()
 
     def test_scoped_to_node_shows_logo_capacity_and_scope_name(
         self, client, event, session, space
@@ -480,15 +458,11 @@ class TestPublicEventPrintView:
             template_name="chronology/print.html",
             context_data={
                 "area_schedule": None,
-                "door_cards": None,
                 "event": EventDTO.model_validate(event),
                 "logo": "",
                 "descriptions": False,
-                "unconfirmed": False,
                 "material": "track-timetable",
-                "material_options": _specs(
-                    "timetable", "track-timetable", "door-cards"
-                ),
+                "material_options": MATERIAL_SPECS[:2],
                 "print_scopes": [_scope(space)],
                 "qr_svg": response.context_data["qr_svg"],
                 "range_hours": None,
@@ -497,9 +471,7 @@ class TestPublicEventPrintView:
                 "selected_track": "focused-track",
                 "session_list": None,
                 "show_scope_control": False,
-                "show_descriptions_control": True,
-                "show_range_controls": True,
-                "show_unconfirmed_control": False,
+                "show_timetable_controls": True,
                 "show_track_control": True,
                 "timetable": PrintTimetableDocumentDTO(
                     event_name=event.name,
@@ -530,13 +502,11 @@ class TestPublicEventPrintView:
             template_name="chronology/print.html",
             context_data={
                 "area_schedule": None,
-                "door_cards": None,
                 "event": EventDTO.model_validate(event),
                 "logo": "",
                 "descriptions": False,
-                "unconfirmed": False,
                 "material": "timetable",
-                "material_options": _specs("timetable", "door-cards"),
+                "material_options": MATERIAL_SPECS[:1],
                 "print_scopes": [_scope(space)],
                 "qr_svg": response.context_data["qr_svg"],
                 "range_hours": None,
@@ -545,9 +515,7 @@ class TestPublicEventPrintView:
                 "selected_track": "",
                 "session_list": None,
                 "show_scope_control": True,
-                "show_descriptions_control": True,
-                "show_range_controls": True,
-                "show_unconfirmed_control": False,
+                "show_timetable_controls": True,
                 "show_track_control": False,
                 "timetable": PrintTimetableDocumentDTO(
                     event_name=event.name,
@@ -585,6 +553,7 @@ class TestPublicEventPrintView:
         )
         assert response.context_data["material"] == "timetable"
         assert response.context_data["selected_scope"] == str(space.pk)
+        assert session.title in response.content.decode()
 
     def test_track_timetable_scoped_to_selected_track(
         self, client, event, session, space
@@ -606,15 +575,11 @@ class TestPublicEventPrintView:
             template_name="chronology/print.html",
             context_data={
                 "area_schedule": None,
-                "door_cards": None,
                 "event": EventDTO.model_validate(event),
                 "logo": "",
                 "descriptions": False,
-                "unconfirmed": False,
                 "material": "track-timetable",
-                "material_options": _specs(
-                    "timetable", "track-timetable", "door-cards"
-                ),
+                "material_options": MATERIAL_SPECS[:2],
                 "print_scopes": [_scope(space)],
                 "qr_svg": response.context_data["qr_svg"],
                 "range_hours": None,
@@ -623,9 +588,7 @@ class TestPublicEventPrintView:
                 "selected_track": "main-track",
                 "session_list": None,
                 "show_scope_control": False,
-                "show_descriptions_control": True,
-                "show_range_controls": True,
-                "show_unconfirmed_control": False,
+                "show_timetable_controls": True,
                 "show_track_control": True,
                 "timetable": PrintTimetableDocumentDTO(
                     event_name=event.name,
@@ -665,222 +628,7 @@ class TestPublicEventPrintView:
         )
         assert response.context_data["material"] == "track-timetable"
         assert response.context_data["selected_track"] == "main-track"
-
-    def test_door_cards_material_renders_one_card_per_room_and_day(
-        self, client, event, session, space
-    ):
-        # Participant-facing cards: a room with nothing scheduled gets no card.
-        empty_hall = SpaceFactory(event=event, name="Empty Hall")
-        space.capacity = 18
-        space.save(update_fields=["capacity"])
-        _confirmed_item(event, session, space)
-
-        response = client.get(self._url(event.slug), {"material": "door-cards"})
-
-        # Both rooms are root leaves, listed in (order, name) order.
-        expected_scopes = sorted(
-            [_scope(space), _scope(empty_hall)], key=lambda scope: scope.name
-        )
-        _assert_print_ok(response, material="door-cards", print_scopes=expected_scopes)
-        assert response.context_data["timetable"] is None
-        assert response.context_data["door_cards"] == DoorCardsDocumentDTO(
-            event_name=event.name,
-            event_description=event.description,
-            event_start=event.start_time,
-            event_end=event.end_time,
-            scope_name=None,
-            cards=[
-                DoorCardDTO(
-                    space_name=space.name,
-                    capacity=space.capacity,
-                    day=localdate(event.start_time),
-                    entries=[
-                        DoorCardEntryDTO(
-                            start_time=event.start_time,
-                            end_time=event.start_time + timedelta(hours=1),
-                            session=PrintSessionDTO(
-                                title=session.title, presenter_name=session.display_name
-                            ),
-                        )
-                    ],
-                )
-            ],
-        )
-
-    def test_door_cards_without_scheduled_rooms_render_the_empty_sheet(
-        self, client, event
-    ):
-        response = client.get(self._url(event.slug), {"material": "door-cards"})
-
-        _assert_print_ok(response, material="door-cards")
-        assert response.context_data["door_cards"].cards == []
-
-    def test_unconfirmed_toggle_with_nothing_scheduled_keeps_empty_timetable(
-        self, authenticated_client, active_user, sphere, event
-    ):
-        sphere.managers.add(active_user)
-
-        response = authenticated_client.get(self._url(event.slug), {"unconfirmed": "1"})
-
-        _assert_print_ok(response, unconfirmed=True, panel_access=True)
-        assert response.context_data["timetable"].pages == []
-
-    def test_empty_session_list_renders_empty_state(self, client, event, space):
-        Track.objects.create(
-            event=event, name="Focused Track", slug="focused-track", is_public=True
-        )
-        TimeSlotFactory(
-            event=event,
-            start_time=event.start_time,
-            end_time=event.start_time + timedelta(hours=2),
-        )
-
-        response = client.get(self._url(event.slug), {"material": "session-list"})
-
-        _assert_print_ok(
-            response,
-            material="session-list",
-            session_list_available=True,
-            tracks_available=True,
-            print_scopes=[_scope(space)],
-        )
-        assert response.context_data["session_list"].sessions == []
-
-    def test_empty_session_list_with_unconfirmed_toggle(
-        self, authenticated_client, active_user, sphere, event, space
-    ):
-        sphere.managers.add(active_user)
-        Track.objects.create(
-            event=event, name="Focused Track", slug="focused-track", is_public=True
-        )
-        TimeSlotFactory(
-            event=event,
-            start_time=event.start_time,
-            end_time=event.start_time + timedelta(hours=2),
-        )
-
-        response = authenticated_client.get(
-            self._url(event.slug), {"material": "session-list", "unconfirmed": "1"}
-        )
-
-        _assert_print_ok(
-            response,
-            material="session-list",
-            unconfirmed=True,
-            session_list_available=True,
-            tracks_available=True,
-            panel_access=True,
-            print_scopes=[_scope(space)],
-        )
-        assert response.context_data["session_list"].sessions == []
-
-    def test_door_cards_with_descriptions_swap_to_the_area_schedule(
-        self, client, event, session, space
-    ):
-        _confirmed_item(event, session, space)
-
-        response = client.get(
-            self._url(event.slug), {"material": "door-cards", "descriptions": "1"}
-        )
-
-        _assert_print_ok(
-            response,
-            material="door-cards",
-            descriptions=True,
-            print_scopes=[_scope(space)],
-        )
-        assert response.context_data["door_cards"] is None
-        assert response.context_data["area_schedule"] is not None
-
-    def test_door_cards_limited_to_time_window(self, client, event, session, space):
-        _confirmed_item(event, session, space)
-        later_session = SessionFactory(event=event, category=None, title="Late Larp")
-        AgendaItemFactory(
-            session=later_session,
-            space=space,
-            session_confirmed=True,
-            start_time=event.start_time + timedelta(hours=6),
-            end_time=event.start_time + timedelta(hours=7),
-        )
-        start = event.start_time.strftime("%Y-%m-%dT%H:%M")
-
-        response = client.get(
-            self._url(event.slug),
-            {"material": "door-cards", "start": start, "hours": "3"},
-        )
-
-        _assert_print_ok(
-            response, material="door-cards", range_hours=3, print_scopes=[_scope(space)]
-        )
-        cards = response.context_data["door_cards"].cards
-        assert [[e.session.title for e in card.entries] for card in cards] == [
-            [session.title]
-        ]
-
-    def test_manager_can_include_unconfirmed_sessions(
-        self, authenticated_client, active_user, sphere, event, session, space
-    ):
-        sphere.managers.add(active_user)
-        AgendaItemFactory(
-            session=session,
-            space=space,
-            session_confirmed=False,
-            start_time=event.start_time,
-            end_time=event.start_time + timedelta(hours=1),
-        )
-
-        response = authenticated_client.get(self._url(event.slug), {"unconfirmed": "1"})
-
-        _assert_print_ok(
-            response, unconfirmed=True, panel_access=True, print_scopes=[_scope(space)]
-        )
-        assert_cache_control(response, {"private", "max-age=5"})
-        titles = [
-            s.title
-            for page in response.context_data["timetable"].pages
-            for row in page.rows
-            for cell in row.cells
-            for s in cell.sessions
-        ]
-        assert titles == [session.title]
-
-    def test_unconfirmed_param_is_ignored_for_participants(
-        self, client, event, session, space
-    ):
-        AgendaItemFactory(
-            session=session,
-            space=space,
-            session_confirmed=False,
-            start_time=event.start_time,
-            end_time=event.start_time + timedelta(hours=1),
-        )
-
-        response = client.get(self._url(event.slug), {"unconfirmed": "1"})
-
-        _assert_print_ok(response, print_scopes=[_scope(space)])
-        assert_cache_control(response, {"public", "max-age=300"})
-        assert response.context_data["timetable"].pages == []
-
-    def test_manager_visit_is_privately_cached_and_marks_printed(
-        self, authenticated_client, active_user, sphere, event
-    ):
-        sphere.managers.add(active_user)
-        assert event.printables_last_printed_at is None
-
-        response = authenticated_client.get(self._url(event.slug))
-
-        _assert_print_ok(response, panel_access=True)
-        assert_cache_control(response, {"private", "max-age=5"})
-        assert "Cookie" in response.headers.get("Vary", "")
-        event.refresh_from_db()
-        assert event.printables_last_printed_at is not None
-
-    def test_participant_visit_does_not_mark_printed(self, client, event):
-        response = client.get(self._url(event.slug))
-
-        _assert_print_ok(response)
-        event.refresh_from_db()
-        assert event.printables_last_printed_at is None
+        assert session.title in response.content.decode()
 
 
 class TestEventPagePrintHijack:

--- a/tests/integration/web/panel/test_timetable.py
+++ b/tests/integration/web/panel/test_timetable.py
@@ -146,31 +146,10 @@ class TestTimetablePageView:
                     ),
                 },
                 "active_tab": "timetable",
-                "print_url": reverse(
-                    "web:chronology:event-print", kwargs={"slug": event.slug}
-                ),
+                "print_scopes": [],
             },
         )
         assert response.context["grid"].spaces == []
-
-    def test_print_link_carries_track_and_day_filters(
-        self, authenticated_client, active_user, sphere, event, space, time_slot
-    ):
-        sphere.managers.add(active_user)
-        track = Track.objects.create(
-            event=event, name="Main Track", slug="main-track", is_public=True
-        )
-        day = time_slot.start_time.date()
-
-        response = authenticated_client.get(
-            self.get_url(event), {"track": track.pk, "date": day.isoformat()}
-        )
-
-        base = reverse("web:chronology:event-print", kwargs={"slug": event.slug})
-        assert response.context["print_url"] == (
-            f"{base}?material=track-timetable&track=main-track"
-            f"&start={day.isoformat()}T00%3A00&hours=24"
-        )
 
     def test_grid_shows_spaces_and_time_labels(
         self, authenticated_client, active_user, sphere, event, space, time_slot

--- a/tests/integration/web/panel/test_timetable_print.py
+++ b/tests/integration/web/panel/test_timetable_print.py
@@ -1,0 +1,300 @@
+from datetime import timedelta
+from http import HTTPStatus
+from unittest.mock import ANY
+
+from django.contrib import messages
+from django.urls import reverse
+from django.utils.timezone import localdate
+
+from ludamus.links.db.django.models import Space
+from ludamus.pacts import EventDTO
+from ludamus.pacts.printing import (
+    DoorCardDayDTO,
+    DoorCardDTO,
+    DoorCardEntryDTO,
+    DoorCardsDocumentDTO,
+    PrintSessionDTO,
+)
+from tests.integration.conftest import AgendaItemFactory, SessionFactory, SpaceFactory
+from tests.integration.utils import assert_response
+
+PERMISSION_ERROR = "You don't have permission to access the backoffice panel."
+
+
+class TestTimetablePrintView:
+    @staticmethod
+    def timetable_url(event):
+        return reverse("panel:timetable-print", kwargs={"slug": event.slug})
+
+    @staticmethod
+    def door_cards_url(event):
+        return reverse("panel:timetable-print-door-cards", kwargs={"slug": event.slug})
+
+    def test_redirects_anonymous_user_to_login(self, client, event):
+        url = self.timetable_url(event)
+
+        response = client.get(url)
+
+        assert_response(
+            response, HTTPStatus.FOUND, url=f"/crowd/login-required/?next={url}"
+        )
+
+    def test_redirects_non_manager_user(self, authenticated_client, event):
+        response = authenticated_client.get(self.timetable_url(event))
+
+        assert_response(
+            response,
+            HTTPStatus.FOUND,
+            messages=[(messages.ERROR, PERMISSION_ERROR)],
+            url="/",
+        )
+
+    def test_timetable_page_for_sphere_manager(
+        self,
+        authenticated_client,
+        active_user,
+        sphere,
+        event,
+        session,
+        space,
+        time_slot,
+    ):
+        sphere.managers.add(active_user)
+        empty_space = SpaceFactory(event=event, name="Empty Hall")
+        AgendaItemFactory(
+            session=session,
+            space=space,
+            start_time=time_slot.start_time,
+            end_time=time_slot.start_time + timedelta(hours=1),
+        )
+
+        response = authenticated_client.get(self.timetable_url(event))
+
+        assert_response(
+            response,
+            HTTPStatus.OK,
+            template_name="panel/print/timetable.html",
+            context_data={"document": ANY},
+        )
+        content = response.content.decode()
+        assert session.title in content
+        assert empty_space.name in content  # empty room is still a column
+        assert "—" in content  # its empty cell renders a visible gap marker
+
+    def test_door_cards_page_for_sphere_manager(
+        self,
+        authenticated_client,
+        active_user,
+        sphere,
+        event,
+        session,
+        space,
+        time_slot,
+    ):
+        sphere.managers.add(active_user)
+        empty_space = SpaceFactory(event=event, name="Empty Hall")
+        AgendaItemFactory(
+            session=session,
+            space=space,
+            start_time=time_slot.start_time,
+            end_time=time_slot.start_time + timedelta(hours=1),
+        )
+
+        response = authenticated_client.get(self.door_cards_url(event))
+
+        assert_response(
+            response,
+            HTTPStatus.OK,
+            template_name="panel/print/door-cards.html",
+            context_data={"document": ANY},
+        )
+        content = response.content.decode()
+        assert space.name in content
+        # participant-facing cards: no card for an empty room, no gap rows
+        assert empty_space.name not in content
+        assert "Free slot" not in content
+
+    def test_door_cards_limited_to_time_window(
+        self,
+        authenticated_client,
+        active_user,
+        sphere,
+        event,
+        session,
+        space,
+        time_slot,
+    ):
+        sphere.managers.add(active_user)
+        AgendaItemFactory(
+            session=session,
+            space=space,
+            start_time=time_slot.start_time,
+            end_time=time_slot.start_time + timedelta(hours=1),
+        )
+        later_session = SessionFactory(event=event, category=None, title="Late Larp")
+        AgendaItemFactory(
+            session=later_session,
+            space=space,
+            start_time=time_slot.start_time + timedelta(hours=6),
+            end_time=time_slot.start_time + timedelta(hours=7),
+        )
+
+        response = authenticated_client.get(
+            self.door_cards_url(event),
+            {"start": time_slot.start_time.isoformat(), "hours": "2"},
+        )
+
+        assert_response(
+            response,
+            HTTPStatus.OK,
+            template_name="panel/print/door-cards.html",
+            context_data={
+                "document": DoorCardsDocumentDTO(
+                    event_name=event.name,
+                    event_description=event.description,
+                    event_start=event.start_time,
+                    event_end=event.end_time,
+                    scope_name=None,
+                    cards=[
+                        DoorCardDTO(
+                            space_name=space.name,
+                            capacity=space.capacity,
+                            days=[
+                                DoorCardDayDTO(
+                                    day=localdate(time_slot.start_time),
+                                    entries=[
+                                        DoorCardEntryDTO(
+                                            start_time=time_slot.start_time,
+                                            end_time=time_slot.start_time
+                                            + timedelta(hours=1),
+                                            session=PrintSessionDTO(
+                                                title=session.title,
+                                                presenter_name=session.display_name,
+                                            ),
+                                        )
+                                    ],
+                                )
+                            ],
+                        )
+                    ],
+                )
+            },
+        )
+        assert later_session.title not in response.content.decode()
+
+    def test_opening_print_page_marks_event_printed(
+        self, authenticated_client, active_user, sphere, event
+    ):
+        sphere.managers.add(active_user)
+        assert event.printables_last_printed_at is None
+
+        authenticated_client.get(self.timetable_url(event))
+
+        event.refresh_from_db()
+        assert event.printables_last_printed_at is not None
+
+    def test_timetable_scoped_to_node(
+        self, authenticated_client, active_user, sphere, event, session, time_slot
+    ):
+        sphere.managers.add(active_user)
+        parent = Space.objects.create(event=event, name="Hall", slug="hall")
+        leaf = Space.objects.create(
+            event=event, parent=parent, name="Room", slug="room"
+        )
+        AgendaItemFactory(
+            session=session,
+            space=leaf,
+            start_time=time_slot.start_time,
+            end_time=time_slot.start_time + timedelta(hours=1),
+        )
+
+        response = authenticated_client.get(
+            self.timetable_url(event), {"scope": parent.pk}
+        )
+
+        assert_response(
+            response,
+            HTTPStatus.OK,
+            template_name="panel/print/timetable.html",
+            context_data={"document": ANY},
+        )
+        content = response.content.decode()
+        assert "Hall" in content  # scope name in the header
+        assert session.title in content
+
+    def test_unknown_scope_redirects_with_message(
+        self, authenticated_client, active_user, sphere, event
+    ):
+        sphere.managers.add(active_user)
+
+        response = authenticated_client.get(
+            self.timetable_url(event), {"scope": "987654"}
+        )
+
+        assert_response(
+            response,
+            HTTPStatus.FOUND,
+            messages=[(messages.ERROR, "Space not found.")],
+            url=reverse("panel:timetable", kwargs={"slug": event.slug}),
+        )
+
+
+class TestPrintMaterialsPageView:
+    @staticmethod
+    def url(event):
+        return reverse("panel:print-materials", kwargs={"slug": event.slug})
+
+    def test_redirects_non_manager_user(self, authenticated_client, event):
+        response = authenticated_client.get(self.url(event))
+
+        assert_response(
+            response,
+            HTTPStatus.FOUND,
+            messages=[(messages.ERROR, PERMISSION_ERROR)],
+            url="/",
+        )
+
+    def test_renders_for_sphere_manager(
+        self, authenticated_client, active_user, sphere, event
+    ):
+        sphere.managers.add(active_user)
+
+        response = authenticated_client.get(self.url(event))
+
+        assert_response(
+            response,
+            HTTPStatus.OK,
+            template_name="panel/print-materials.html",
+            context_data={
+                "active_nav": "print",
+                "current_event": EventDTO.model_validate(event),
+                "events": [EventDTO.model_validate(event)],
+                "is_proposal_active": False,
+                "print_scopes": [],
+                "stats": {
+                    "hosts_count": 0,
+                    "pending_proposals": 0,
+                    "rooms_count": 0,
+                    "scheduled_sessions": 0,
+                    "total_proposals": 0,
+                    "total_sessions": 0,
+                },
+            },
+        )
+        content = response.content.decode()
+        assert "Print timetable" in content
+        assert "Print door cards" in content
+        assert response.context_data["active_nav"] == "print"
+
+    def test_scope_menu_lists_non_leaf_nodes(
+        self, authenticated_client, active_user, sphere, event
+    ):
+        sphere.managers.add(active_user)
+        parent = Space.objects.create(event=event, name="Hall", slug="hall")
+        Space.objects.create(event=event, parent=parent, name="Room", slug="room")
+
+        response = authenticated_client.get(self.url(event))
+
+        content = response.content.decode()
+        assert "Hall" in content  # scope option label (non-leaf node)
+        assert f"?scope={parent.pk}" in content  # scoped print link

--- a/tests/unit/test_printing_mills.py
+++ b/tests/unit/test_printing_mills.py
@@ -2,7 +2,11 @@ from datetime import UTC, date, datetime
 
 from ludamus.mills.printing import PrintMaterialsService
 from ludamus.pacts import AgendaItemDTO, EventDTO, SpaceDTO, TimeSlotDTO
-from ludamus.pacts.printing import PrintQueryDTO
+from ludamus.pacts.printing import (
+    AreaScheduleQueryDTO,
+    DoorCardsQueryDTO,
+    PrintTimetableQueryDTO,
+)
 
 
 def _event():
@@ -102,16 +106,16 @@ def _service(*, spaces, items, slots, tracks=None):
 
 
 def _door_cards(service, **kwargs):
-    return service.build_door_cards(PrintQueryDTO(event_pk=1, tz=UTC, **kwargs))
+    return service.build_door_cards(DoorCardsQueryDTO(event_pk=1, tz=UTC, **kwargs))
 
 
 def _timetable(service, **kwargs):
-    return service.build_timetable(PrintQueryDTO(event_pk=1, tz=UTC, **kwargs))
+    return service.build_timetable(PrintTimetableQueryDTO(event_pk=1, tz=UTC, **kwargs))
 
 
 def _area_schedule(service, window, **kwargs):
     return service.build_area_schedule(
-        PrintQueryDTO(event_pk=1, tz=UTC, time_range=window, **kwargs)
+        AreaScheduleQueryDTO(event_pk=1, time_range=window, **kwargs)
     )
 
 
@@ -127,26 +131,6 @@ class TestBuildDoorCards:
         document = _door_cards(service)
 
         assert [c.space_name for c in document.cards] == ["Alfa", "Bravo"]
-
-    def test_a_room_used_on_two_days_gets_a_card_per_day(self):
-        spaces = [_space(1, "Alfa", 0)]
-        items = [
-            _item(1, 1, 9, 10, title="RPG", confirmed=True, day=2),
-            _item(2, 1, 14, 15, title="Wieczorny", confirmed=True, day=1),
-            _item(3, 1, 9, 10, title="Larp", confirmed=True, day=1),
-        ]
-        service = _service(spaces=spaces, items=items, slots=[])
-
-        document = _door_cards(service)
-
-        assert [(c.space_name, c.day) for c in document.cards] == [
-            ("Alfa", date(2026, 6, 1)),
-            ("Alfa", date(2026, 6, 2)),
-        ]
-        assert [[e.session.title for e in c.entries] for c in document.cards] == [
-            ["Larp", "Wieczorny"],
-            ["RPG"],
-        ]
 
     def test_time_range_keeps_overlapping_entries_and_drops_empty_rooms(self):
         spaces = [_space(1, "Alfa", 0), _space(2, "Bravo", 1)]
@@ -165,7 +149,7 @@ class TestBuildDoorCards:
         )
 
         assert [c.space_name for c in document.cards] == ["Alfa"]
-        entries = document.cards[0].entries
+        entries = document.cards[0].days[0].entries
         assert [entry.session.title for entry in entries] == ["RPG"]
 
     def test_empty_slots_and_sessionless_spaces_are_omitted(self):
@@ -179,7 +163,7 @@ class TestBuildDoorCards:
         document = _door_cards(service)
 
         assert [c.space_name for c in document.cards] == ["Alfa"]
-        entries = document.cards[0].entries
+        entries = document.cards[0].days[0].entries
         assert [e.session.title for e in entries] == ["RPG"]
 
     def test_includes_unconfirmed_scheduled_session(self):
@@ -188,10 +172,9 @@ class TestBuildDoorCards:
         items = [_item(1, 1, 9, 10, title="Larp", confirmed=False)]
         service = _service(spaces=spaces, items=items, slots=slots)
 
-        # The manager toggle: only an explicit opt-in prints pending sessions.
-        document = _door_cards(service, confirmed_only=False)
+        document = _door_cards(service)
 
-        entries = document.cards[0].entries
+        entries = document.cards[0].days[0].entries
         assert entries[0].session is not None
         assert entries[0].session.title == "Larp"
 
@@ -484,7 +467,7 @@ class TestBuildAreaSchedule:
         items = [_item(1, 1, 10, 11, title="RPG", confirmed=True)]
         service = _service(spaces=spaces, items=items, slots=[])
 
-        document = service.build_area_schedule(PrintQueryDTO(event_pk=1, tz=UTC))
+        document = service.build_area_schedule(AreaScheduleQueryDTO(event_pk=1))
 
         assert document.range_start == _event().start_time
         assert document.range_end == _event().end_time


### PR DESCRIPTION
Reverts zagrajmy/ludamus#771

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a panel-based Print Materials hub for event organizers.
  * Added printable timetables and room door cards with event, venue, scope, date, and time-range options.
  * Print views open in a new tab and support browser printing.
  * Added clearer empty states and localized print-related messaging.
* **Improvements**
  * Updated timetable and reminder links to use the new Print Materials page.
  * Simplified print controls and removed obsolete unconfirmed-session options.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->