### PR TITLE
Unify document and link-preview titles across the app

### DIFF
--- a/PAPERCUTS.md
+++ b/PAPERCUTS.md
@@ -263,3 +263,7 @@ If you fix a papercut, remove it.
   /etc/ssh/ssh_config.d/20-systemd-ssh-proxy.conf' (symlink owned by
   nobody:nogroup); worked around with git -c credential.helper='!gh auth git-
   credential' push <https://github.com/zagrajmy/ludamus.git> HEAD:the-branch
+- 2026-08-02: mise run lint printed 'Finished in 198s' with every check green,
+  then hung for another ~8 minutes in an 'npm exec github...' -> 'npm install'
+  child (sandbox egress is slow); had to pstree and kill -9 the mise process to
+  get the shell back.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -130,7 +130,7 @@ template_extensions = 'html'
 
 [tool.djlint]
 ignore = "H021,H031,H037,D018"
-custom_blocks = "select"
+custom_blocks = "select,document_title"
 
 # DEPTRY
 
@@ -518,6 +518,7 @@ ignore_names = [
 ignore_decorators = [
     "@register.filter",
     "@register.simple_tag",
+    "@register.tag",
     "@admin.register",
     "@field_validator",
 ]

--- a/src/ludamus/gates/web/django/templatetags/meta_tags.py
+++ b/src/ludamus/gates/web/django/templatetags/meta_tags.py
@@ -25,7 +25,6 @@ class DocumentTitleNode(template.Node):
     # and a block can't hand its output to a variable, so capture it here. The
     # inner nodes escape their own output; collapsing whitespace only drops the
     # newlines the template's indentation left behind, so the result stays safe.
-    #
     # The name lands in the context the tag was reached with, so the tag belongs
     # at the top level of the page shell, ahead of every {{ document_title }}
     # that reads it. Nested inside a block it would be popped with that block.

--- a/src/ludamus/gates/web/django/templatetags/meta_tags.py
+++ b/src/ludamus/gates/web/django/templatetags/meta_tags.py
@@ -2,14 +2,39 @@ from typing import TYPE_CHECKING
 
 from django import template
 from django.templatetags.static import static
+from django.utils.safestring import SafeString
 
 if TYPE_CHECKING:
     from django.http import HttpRequest
+    from django.template.base import Parser, Token
 
 register = template.Library()
+
+DOCUMENT_TITLE_VARIABLE = "document_title"
 
 
 @register.simple_tag(takes_context=True)
 def meta_image_url(context: template.Context, url: str = "") -> str:
     request: HttpRequest = context["request"]
     return request.build_absolute_uri(url or static("logo.png"))
+
+
+class DocumentTitleNode(template.Node):
+    def __init__(self, nodelist: template.NodeList) -> None:
+        self.nodelist = nodelist
+
+    # The title is one value in three tags (<title>, og:title, twitter:title)
+    # and a block can't hand its output to a variable, so capture it here. The
+    # inner nodes escape their own output; collapsing whitespace only drops the
+    # newlines the template's indentation left behind, so the result stays safe.
+    def render(self, context: template.Context) -> str:
+        rendered = self.nodelist.render(context)
+        context[DOCUMENT_TITLE_VARIABLE] = SafeString(" ".join(rendered.split()))
+        return ""
+
+
+@register.tag("document_title")
+def document_title(parser: Parser, _token: Token) -> DocumentTitleNode:
+    nodelist = parser.parse(("enddocument_title",))
+    parser.delete_first_token()
+    return DocumentTitleNode(nodelist)

--- a/src/ludamus/gates/web/django/templatetags/meta_tags.py
+++ b/src/ludamus/gates/web/django/templatetags/meta_tags.py
@@ -10,8 +10,6 @@ if TYPE_CHECKING:
 
 register = template.Library()
 
-DOCUMENT_TITLE_VARIABLE = "document_title"
-
 
 @register.simple_tag(takes_context=True)
 def meta_image_url(context: template.Context, url: str = "") -> str:
@@ -27,9 +25,13 @@ class DocumentTitleNode(template.Node):
     # and a block can't hand its output to a variable, so capture it here. The
     # inner nodes escape their own output; collapsing whitespace only drops the
     # newlines the template's indentation left behind, so the result stays safe.
+    #
+    # The name lands in the context the tag was reached with, so the tag belongs
+    # at the top level of the page shell, ahead of every {{ document_title }}
+    # that reads it. Nested inside a block it would be popped with that block.
     def render(self, context: template.Context) -> str:
         rendered = self.nodelist.render(context)
-        context[DOCUMENT_TITLE_VARIABLE] = SafeString(" ".join(rendered.split()))
+        context["document_title"] = SafeString(" ".join(rendered.split()))
         return ""
 
 

--- a/src/ludamus/locale/pl/LC_MESSAGES/django.po
+++ b/src/ludamus/locale/pl/LC_MESSAGES/django.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-08-01 17:51+0200\n"
+"POT-Creation-Date: 2026-08-02 10:53+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -2176,6 +2176,7 @@ msgstr "Kategoria została zaktualizowana."
 
 #: src/ludamus/gates/web/django/event/print.py
 #: src/ludamus/templates/chronology/print.html
+#: src/ludamus/templates/panel/print/timetable.html
 msgid "Timetable"
 msgstr "Harmonogram"
 
@@ -7898,6 +7899,10 @@ msgstr ""
 #: src/ludamus/templates/panel/print/base.html
 msgid "or press Ctrl+P (⌘P on Mac)"
 msgstr "lub naciśnij Ctrl+P (⌘P na Macu)"
+
+#: src/ludamus/templates/panel/print/door-cards.html
+msgid "Door cards"
+msgstr "Tabliczki na drzwi"
 
 #: src/ludamus/templates/panel/print/door-cards.html
 msgid "No rooms to print."

--- a/src/ludamus/templates/404_dynamic.html
+++ b/src/ludamus/templates/404_dynamic.html
@@ -2,7 +2,7 @@
 {% load i18n %}
 {% load tessera %}
 {% block title %}
-    {% translate "Page Not Found" %} - 404
+    {% translate "Page Not Found" %} • 404
 {% endblock title %}
 {% block header_section %}
 {% endblock header_section %}

--- a/src/ludamus/templates/500_dynamic.html
+++ b/src/ludamus/templates/500_dynamic.html
@@ -10,7 +10,7 @@
         <meta name="viewport" content="width=device-width, initial-scale=1.0">
         <meta name="description"
               content="Server error - Something went wrong on our server">
-        <title>Server Error - 500</title>
+        <title>Server Error • 500</title>
         <!-- This page does not extend base.html (it must stay self-contained
              so it renders even if something upstream is broken), so it is its
              own root: this is where its CSP nonce gets generated, and the

--- a/src/ludamus/templates/base.html
+++ b/src/ludamus/templates/base.html
@@ -23,9 +23,10 @@
         {% comment %}Title standard: "{page name} • {sphere name} • Zagrajmy",
         bullets all the way down — never a dash, which reads as a second kind of
         separator and costs more room. Pages set block title; pages whose name IS
-        the sphere (landing) empty out title_suffix instead. The root sphere is
-        Zagrajmy, so it takes no brand tail. Captured once here so the document
-        title and the link-preview titles below can never drift apart.{% endcomment %}
+        the sphere (landing) empty out title_suffix instead, and panel pages swap
+        it for the event they manage. The root sphere is Zagrajmy, so it takes no
+        brand tail. Captured once here so the document title and the link-preview
+        titles below can never drift apart.{% endcomment %}
         {% document_title %}
             {% block title %}
             {% endblock title %}

--- a/src/ludamus/templates/base.html
+++ b/src/ludamus/templates/base.html
@@ -12,22 +12,36 @@
         <meta name="viewport" content="width=device-width, initial-scale=1">
         <meta name="htmx-config" content="{&quot;allowEval&quot;:false}">
         {% comment %}One value, three tags: a block can't hand its output to a
-        variable. Object pages override all three with one shared expression or
-        partial. Sphere subdomains name the sphere; the brand domain pitches the
-        product.{% endcomment %}
+        variable, so object pages override all three description blocks with one
+        shared expression. Sphere subdomains name the sphere; the brand domain
+        pitches the product.{% endcomment %}
         {% if not is_root_sphere %}
             {% blocktranslate asvar default_description with sphere=current_sphere.name %}Programme and sign-ups for {{ sphere }}.{% endblocktranslate %}
         {% else %}
             {% translate "A convention without spreadsheet chaos. Programme proposals, a schedule of rooms and tracks, sign-ups with seat limits and a waitlist." as default_description %}
         {% endif %}
+        {% comment %}Title standard: "{page name} • {sphere name} • Zagrajmy",
+        bullets all the way down — never a dash, which reads as a second kind of
+        separator and costs more room. Pages set block title; pages whose name IS
+        the sphere (landing) empty out title_suffix instead. The root sphere is
+        Zagrajmy, so it takes no brand tail. Captured once here so the document
+        title and the link-preview titles below can never drift apart.{% endcomment %}
+        {% document_title %}
+            {% block title %}
+            {% endblock title %}
+            {% block title_suffix %}
+                {% if current_sphere %}• {{ current_sphere.name }}{% endif %}
+            {% endblock title_suffix %}
+            {% if not is_root_sphere %}• Zagrajmy{% endif %}
+        {% enddocument_title %}
+        <title>{{ document_title }}</title>
         <meta name="description"
               content="{% block meta_description %}{{ default_description }}{% endblock meta_description %}">
         <!-- Open Graph / Facebook -->
         <meta property="og:type" content="website">
         <meta property="og:url" content="{{ request.build_absolute_uri }}">
         <meta property="og:site_name" content="{{ current_sphere.name }}">
-        <meta property="og:title"
-              content="{% block og_title %}{{ current_sphere.name }}{% endblock og_title %}">
+        <meta property="og:title" content="{{ document_title }}">
         <meta property="og:description"
               content="{% block og_description %}{{ default_description }}{% endblock og_description %}">
         {% comment %}Not the sphere logo: it may be an SVG, which every link
@@ -36,24 +50,11 @@
               content="{% block og_image %}{% meta_image_url %}{% endblock og_image %}">
         <!-- Twitter -->
         <meta name="twitter:card" content="summary_large_image">
-        <meta name="twitter:title"
-              content="{% block twitter_title %}{{ current_sphere.name }}{% endblock twitter_title %}">
+        <meta name="twitter:title" content="{{ document_title }}">
         <meta name="twitter:description"
               content="{% block twitter_description %}{{ default_description }}{% endblock twitter_description %}">
         <meta name="twitter:image"
               content="{% block twitter_image %}{% meta_image_url %}{% endblock twitter_image %}">
-        {% comment %}Title standard: "{page name} • {sphere name} • Zagrajmy".
-        Pages set block title; pages whose name IS the sphere (landing) empty
-        out title_suffix instead. The root sphere is Zagrajmy, so it takes no
-        brand tail.{% endcomment %}
-        <title>
-            {% block title %}
-            {% endblock title %}
-            {% block title_suffix %}
-                {% if current_sphere %}• {{ current_sphere.name }}{% endif %}
-            {% endblock title_suffix %}
-            {% if not is_root_sphere %}• Zagrajmy{% endif %}
-        </title>
         {% comment %}Dark tab bars are handled by prefers-color-scheme rules
         inside the SVGs themselves; the .ico covers pre-26 Safari and agents
         that request /favicon.ico blindly.{% endcomment %}

--- a/src/ludamus/templates/chronology/accept_proposal.html
+++ b/src/ludamus/templates/chronology/accept_proposal.html
@@ -3,7 +3,7 @@
 {% load cfp_tags %}
 {% load tessera %}
 {% block title %}
-    {% translate "Accept Proposal" %} - {{ session.title }}
+    {% translate "Accept Proposal" %} • {{ session.title }}
 {% endblock title %}
 {% block header %}
     <h1 class="text-2xl sm:text-3xl font-bold text-foreground mb-2">{% translate "Accept Proposal" %}</h1>

--- a/src/ludamus/templates/chronology/anonymous_enroll.html
+++ b/src/ludamus/templates/chronology/anonymous_enroll.html
@@ -2,7 +2,7 @@
 {% load i18n %}
 {% load tessera %}
 {% block title %}
-    {% translate "Anonymous Enrollment" %} - {{ session.title }}
+    {% translate "Anonymous Enrollment" %} • {{ session.title }}
 {% endblock title %}
 {% block header %}
     <h1 class="text-2xl sm:text-3xl font-bold text-foreground mb-2">{% translate "Anonymous Enrollment" %}</h1>

--- a/src/ludamus/templates/chronology/enroll_select.html
+++ b/src/ludamus/templates/chronology/enroll_select.html
@@ -6,7 +6,7 @@
 {% load markdown_tags %}
 {% load django_vite %}
 {% block title %}
-    {% translate "Enrollment" %} - {{ session.title }}
+    {% translate "Enrollment" %} • {{ session.title }}
 {% endblock title %}
 {% block header_section %}
 {% endblock header_section %}

--- a/src/ludamus/templates/chronology/event.html
+++ b/src/ludamus/templates/chronology/event.html
@@ -8,12 +8,6 @@
 {% block title %}
     {{ event.name }}
 {% endblock title %}
-{% block og_title %}
-    {{ event.name }}
-{% endblock og_title %}
-{% block twitter_title %}
-    {{ event.name }}
-{% endblock twitter_title %}
 {% block meta_description %}
     {% firstof event.description|truncatewords:20 default_description %}
 {% endblock meta_description %}

--- a/src/ludamus/templates/chronology/offer_claim.html
+++ b/src/ludamus/templates/chronology/offer_claim.html
@@ -1,7 +1,7 @@
 {% extends "base.html" %}
 {% load i18n %}
 {% block title %}
-    {% translate "Claim your spot" %} - {{ offer.session_title }}
+    {% translate "Claim your spot" %} • {{ offer.session_title }}
 {% endblock title %}
 {% block header %}
     <h1 class="text-2xl sm:text-3xl font-bold text-foreground mb-2">{% translate "Claim your spot" %}</h1>

--- a/src/ludamus/templates/chronology/panel/integrations/create.html
+++ b/src/ludamus/templates/chronology/panel/integrations/create.html
@@ -1,9 +1,9 @@
 {% extends "panel/base.html" %}
 {% load i18n %}
 {% load tessera %}
-{% block title_prefix %}
-    {% translate "New integration" %} -
-{% endblock title_prefix %}
+{% block title %}
+    {% translate "New integration" %}
+{% endblock title %}
 {% block page_title %}
     {% translate "New integration" %}
 {% endblock page_title %}

--- a/src/ludamus/templates/chronology/panel/integrations/delete.html
+++ b/src/ludamus/templates/chronology/panel/integrations/delete.html
@@ -1,9 +1,9 @@
 {% extends "panel/base.html" %}
 {% load i18n %}
 {% load tessera %}
-{% block title_prefix %}
-    {% translate "Delete integration" %} -
-{% endblock title_prefix %}
+{% block title %}
+    {% translate "Delete integration" %}
+{% endblock title %}
 {% block page_title %}
     {% translate "Delete integration" %}
 {% endblock page_title %}

--- a/src/ludamus/templates/chronology/panel/integrations/edit.html
+++ b/src/ludamus/templates/chronology/panel/integrations/edit.html
@@ -1,9 +1,9 @@
 {% extends "panel/base.html" %}
 {% load i18n %}
 {% load tessera %}
-{% block title_prefix %}
-    {% translate "Edit integration" %} -
-{% endblock title_prefix %}
+{% block title %}
+    {% translate "Edit integration" %}
+{% endblock title %}
 {% block page_title %}
     {% translate "Edit integration" %}
 {% endblock page_title %}

--- a/src/ludamus/templates/chronology/print.html
+++ b/src/ludamus/templates/chronology/print.html
@@ -1,7 +1,7 @@
 {% extends "base.html" %}
 {% load django_vite i18n tessera %}
 {% block title %}
-    {{ event.name }} — {% translate "Print" %}
+    {{ event.name }} • {% translate "Print" %}
 {% endblock title %}
 {% block body_class %}
     app-shell relative bg-background font-sans text-foreground antialiased print:m-0 print:bg-white print:p-0

--- a/src/ludamus/templates/multiverse/panel/announcements/create.html
+++ b/src/ludamus/templates/multiverse/panel/announcements/create.html
@@ -1,8 +1,8 @@
 {% extends "panel/base.html" %}
 {% load i18n %}
-{% block title_prefix %}
-    {% translate "New announcement" %} -
-{% endblock title_prefix %}
+{% block title %}
+    {% translate "New announcement" %}
+{% endblock title %}
 {% block page_title %}
     {% translate "New announcement" %}
 {% endblock page_title %}

--- a/src/ludamus/templates/multiverse/panel/announcements/delete.html
+++ b/src/ludamus/templates/multiverse/panel/announcements/delete.html
@@ -1,8 +1,8 @@
 {% extends "panel/base.html" %}
 {% load i18n %}
-{% block title_prefix %}
-    {% translate "Delete announcement" %} -
-{% endblock title_prefix %}
+{% block title %}
+    {% translate "Delete announcement" %}
+{% endblock title %}
 {% block page_title %}
     {% translate "Delete announcement" %}
 {% endblock page_title %}

--- a/src/ludamus/templates/multiverse/panel/announcements/edit.html
+++ b/src/ludamus/templates/multiverse/panel/announcements/edit.html
@@ -1,8 +1,8 @@
 {% extends "panel/base.html" %}
 {% load i18n %}
-{% block title_prefix %}
-    {% translate "Edit announcement" %} -
-{% endblock title_prefix %}
+{% block title %}
+    {% translate "Edit announcement" %}
+{% endblock title %}
 {% block page_title %}
     {% translate "Edit announcement" %}
 {% endblock page_title %}

--- a/src/ludamus/templates/multiverse/panel/announcements/list.html
+++ b/src/ludamus/templates/multiverse/panel/announcements/list.html
@@ -1,9 +1,9 @@
 {% extends "panel/base.html" %}
 {% load i18n %}
 {% load tessera %}
-{% block title_prefix %}
-    {% translate "Organization announcements" %} -
-{% endblock title_prefix %}
+{% block title %}
+    {% translate "Organization announcements" %}
+{% endblock title %}
 {% block page_title %}
     {% translate "Organization announcements" %}
 {% endblock page_title %}

--- a/src/ludamus/templates/multiverse/panel/connections/create.html
+++ b/src/ludamus/templates/multiverse/panel/connections/create.html
@@ -1,8 +1,8 @@
 {% extends "panel/base.html" %}
 {% load i18n %}
-{% block title_prefix %}
-    {% translate "New connection" %} -
-{% endblock title_prefix %}
+{% block title %}
+    {% translate "New connection" %}
+{% endblock title %}
 {% block page_title %}
     {% translate "New connection" %}
 {% endblock page_title %}

--- a/src/ludamus/templates/multiverse/panel/connections/delete.html
+++ b/src/ludamus/templates/multiverse/panel/connections/delete.html
@@ -1,8 +1,8 @@
 {% extends "panel/base.html" %}
 {% load i18n %}
-{% block title_prefix %}
-    {% translate "Delete connection" %} -
-{% endblock title_prefix %}
+{% block title %}
+    {% translate "Delete connection" %}
+{% endblock title %}
 {% block page_title %}
     {% translate "Delete connection" %}
 {% endblock page_title %}

--- a/src/ludamus/templates/multiverse/panel/connections/edit.html
+++ b/src/ludamus/templates/multiverse/panel/connections/edit.html
@@ -1,9 +1,9 @@
 {% extends "panel/base.html" %}
 {% load i18n %}
 {% load tessera %}
-{% block title_prefix %}
-    {% translate "Edit connection" %} -
-{% endblock title_prefix %}
+{% block title %}
+    {% translate "Edit connection" %}
+{% endblock title %}
 {% block page_title %}
     {% translate "Edit connection" %}
 {% endblock page_title %}

--- a/src/ludamus/templates/multiverse/panel/connections/list.html
+++ b/src/ludamus/templates/multiverse/panel/connections/list.html
@@ -1,9 +1,9 @@
 {% extends "panel/base.html" %}
 {% load i18n %}
 {% load tessera %}
-{% block title_prefix %}
-    {% translate "Import connections" %} -
-{% endblock title_prefix %}
+{% block title %}
+    {% translate "Import connections" %}
+{% endblock title %}
 {% block page_title %}
     {% translate "Import connections" %}
 {% endblock page_title %}

--- a/src/ludamus/templates/multiverse/panel/mcp-token.html
+++ b/src/ludamus/templates/multiverse/panel/mcp-token.html
@@ -1,9 +1,9 @@
 {% extends "panel/base.html" %}
 {% load i18n %}
 {% load tessera %}
-{% block title_prefix %}
-    {% translate "MCP access" %} -
-{% endblock title_prefix %}
+{% block title %}
+    {% translate "MCP access" %}
+{% endblock title %}
 {% block page_title %}
     {% translate "MCP access" %}
 {% endblock page_title %}

--- a/src/ludamus/templates/multiverse/panel/sphere-settings.html
+++ b/src/ludamus/templates/multiverse/panel/sphere-settings.html
@@ -1,9 +1,9 @@
 {% extends "panel/base.html" %}
 {% load i18n %}
 {% load tessera %}
-{% block title_prefix %}
-    {% translate "Sphere settings" %} -
-{% endblock title_prefix %}
+{% block title %}
+    {% translate "Sphere settings" %}
+{% endblock title %}
 {% block page_title %}
     {% translate "Sphere settings" %}
 {% endblock page_title %}

--- a/src/ludamus/templates/notice_board/detail.html
+++ b/src/ludamus/templates/notice_board/detail.html
@@ -5,12 +5,6 @@
 {% block title %}
     {{ encounter.title }}
 {% endblock title %}
-{% block og_title %}
-    {{ encounter.title }}
-{% endblock og_title %}
-{% block twitter_title %}
-    {{ encounter.title }}
-{% endblock twitter_title %}
 {% block meta_description %}{{ encounter_meta_description }}{% endblock meta_description %}
 {% block og_description %}{{ encounter_meta_description }}{% endblock og_description %}
 {% block twitter_description %}{{ encounter_meta_description }}{% endblock twitter_description %}

--- a/src/ludamus/templates/panel/bans.html
+++ b/src/ludamus/templates/panel/bans.html
@@ -1,9 +1,9 @@
 {% extends "panel/base.html" %}
 {% load i18n %}
 {% load tessera %}
-{% block title_prefix %}
-    {% translate "Bans" %} -
-{% endblock title_prefix %}
+{% block title %}
+    {% translate "Bans" %}
+{% endblock title %}
 {% block page_title %}
     {% translate "Bans" %}
 {% endblock page_title %}

--- a/src/ludamus/templates/panel/base.html
+++ b/src/ludamus/templates/panel/base.html
@@ -4,13 +4,6 @@
 {% load static %}
 {% load django_vite %}
 {% load tessera %}
-{% block title %}
-    {% block title_prefix %}
-    {% endblock title_prefix %}
-    {{ current_sphere.name }}
-{% endblock title %}
-{% block title_suffix %}
-{% endblock title_suffix %}
 {% block extra_head %}
     {# The nav progress bar builds its DOM in JS; ship its one label through #}
     {# the translation catalog instead of hardcoding locale logic client-side. #}

--- a/src/ludamus/templates/panel/base.html
+++ b/src/ludamus/templates/panel/base.html
@@ -4,6 +4,17 @@
 {% load static %}
 {% load django_vite %}
 {% load tessera %}
+{% comment %}An organizer runs one panel page per event, not per sphere: the
+event is what tells two tabs apart, so it takes the sphere's slot in the title.
+Sphere-wide pages (settings, announcements, connections) have no event and keep
+the sphere.{% endcomment %}
+{% block title_suffix %}
+    {% if current_event %}
+        • {{ current_event.name }}
+    {% elif current_sphere %}
+        • {{ current_sphere.name }}
+    {% endif %}
+{% endblock title_suffix %}
 {% block extra_head %}
     {# The nav progress bar builds its DOM in JS; ship its one label through #}
     {# the translation catalog instead of hardcoding locale logic client-side. #}

--- a/src/ludamus/templates/panel/cfp-create.html
+++ b/src/ludamus/templates/panel/cfp-create.html
@@ -1,9 +1,9 @@
 {% extends "panel/base.html" %}
 {% load i18n %}
 {% load tessera %}
-{% block title_prefix %}
-    {% translate "New Category" %} -
-{% endblock title_prefix %}
+{% block title %}
+    {% translate "New Category" %}
+{% endblock title %}
 {% block page_title %}
     {% translate "New Category" %}
 {% endblock page_title %}

--- a/src/ludamus/templates/panel/cfp-edit.html
+++ b/src/ludamus/templates/panel/cfp-edit.html
@@ -4,9 +4,9 @@
 {% load tessera %}
 {% load cfp_tags %}
 {% load django_vite %}
-{% block title_prefix %}
-    {% translate "Configure Category" %} -
-{% endblock title_prefix %}
+{% block title %}
+    {% translate "Configure Category" %}
+{% endblock title %}
 {% block page_title %}
     {% translate "Configure Category" %}
 {% endblock page_title %}

--- a/src/ludamus/templates/panel/cfp.html
+++ b/src/ludamus/templates/panel/cfp.html
@@ -2,9 +2,9 @@
 {% load i18n %}
 {% load tessera %}
 {% load cfp_tags %}
-{% block title_prefix %}
-    {% translate "Call for Proposals" %} -
-{% endblock title_prefix %}
+{% block title %}
+    {% translate "Call for Proposals" %}
+{% endblock title %}
 {% block page_title %}
     {% translate "Call for Proposals" %}
 {% endblock page_title %}

--- a/src/ludamus/templates/panel/content-log.html
+++ b/src/ludamus/templates/panel/content-log.html
@@ -2,9 +2,9 @@
 {% load i18n %}
 {% load cfp_tags %}
 {% load tessera %}
-{% block title_prefix %}
-    {% translate "Content Activity Log" %} —
-{% endblock title_prefix %}
+{% block title %}
+    {% translate "Content Activity Log" %}
+{% endblock title %}
 {% block page_title %}
     {% translate "Content Activity Log" %}
 {% endblock page_title %}

--- a/src/ludamus/templates/panel/discounts/edit.html
+++ b/src/ludamus/templates/panel/discounts/edit.html
@@ -1,9 +1,9 @@
 {% extends "panel/base.html" %}
 {% load i18n %}
 {% load tessera %}
-{% block title_prefix %}
-    {% translate "Edit discount" %} -
-{% endblock title_prefix %}
+{% block title %}
+    {% translate "Edit discount" %}
+{% endblock title %}
 {% block page_title %}
     {% translate "Edit discount" %}
 {% endblock page_title %}

--- a/src/ludamus/templates/panel/discounts/export.html
+++ b/src/ludamus/templates/panel/discounts/export.html
@@ -1,9 +1,9 @@
 {% extends "panel/base.html" %}
 {% load i18n %}
 {% load tessera %}
-{% block title_prefix %}
-    {% translate "Export accreditation sheet" %} -
-{% endblock title_prefix %}
+{% block title %}
+    {% translate "Export accreditation sheet" %}
+{% endblock title %}
 {% block page_title %}
     {% translate "Export accreditation sheet" %}
 {% endblock page_title %}

--- a/src/ludamus/templates/panel/discounts/list.html
+++ b/src/ludamus/templates/panel/discounts/list.html
@@ -1,9 +1,9 @@
 {% extends "panel/base.html" %}
 {% load i18n %}
 {% load tessera %}
-{% block title_prefix %}
-    {% translate "Discounts" %} -
-{% endblock title_prefix %}
+{% block title %}
+    {% translate "Discounts" %}
+{% endblock title %}
 {% block page_title %}
     {% translate "Discounts" %}
 {% endblock page_title %}

--- a/src/ludamus/templates/panel/display-settings.html
+++ b/src/ludamus/templates/panel/display-settings.html
@@ -1,9 +1,9 @@
 {% extends "panel/base.html" %}
 {% load i18n %}
 {% load tessera %}
-{% block title_prefix %}
-    {% translate "Display Settings" %} -
-{% endblock title_prefix %}
+{% block title %}
+    {% translate "Display Settings" %}
+{% endblock title %}
 {% block page_title %}
     {% translate "Event Settings" %}
 {% endblock page_title %}

--- a/src/ludamus/templates/panel/enrollment-settings.html
+++ b/src/ludamus/templates/panel/enrollment-settings.html
@@ -1,8 +1,8 @@
 {% extends "panel/base.html" %}
 {% load i18n tessera %}
-{% block title_prefix %}
-    {% translate "Enrollment Settings" %} -
-{% endblock title_prefix %}
+{% block title %}
+    {% translate "Enrollment Settings" %}
+{% endblock title %}
 {% block page_title %}
     {% translate "Event Settings" %}
 {% endblock page_title %}

--- a/src/ludamus/templates/panel/enrollment-window-form.html
+++ b/src/ludamus/templates/panel/enrollment-window-form.html
@@ -1,12 +1,12 @@
 {% extends "panel/base.html" %}
 {% load i18n tessera %}
-{% block title_prefix %}
+{% block title %}
     {% if window %}
-        {% translate "Edit Enrollment Window" %} -
+        {% translate "Edit Enrollment Window" %}
     {% else %}
-        {% translate "Add Enrollment Window" %} -
+        {% translate "Add Enrollment Window" %}
     {% endif %}
-{% endblock title_prefix %}
+{% endblock title %}
 {% block page_title %}
     {% if window %}
         {% translate "Edit Enrollment Window" %}

--- a/src/ludamus/templates/panel/facilitator-columns.html
+++ b/src/ludamus/templates/panel/facilitator-columns.html
@@ -3,9 +3,9 @@
 {% load django_vite %}
 {% load tessera %}
 {% load cfp_tags %}
-{% block title_prefix %}
-    {% translate "Columns" %} -
-{% endblock title_prefix %}
+{% block title %}
+    {% translate "Columns" %}
+{% endblock title %}
 {% block page_title %}
     {% translate "Facilitator columns" %}
 {% endblock page_title %}

--- a/src/ludamus/templates/panel/facilitator-create.html
+++ b/src/ludamus/templates/panel/facilitator-create.html
@@ -1,9 +1,9 @@
 {% extends "panel/base.html" %}
 {% load i18n %}
 {% load tessera %}
-{% block title_prefix %}
-    {% translate "New Facilitator" %} -
-{% endblock title_prefix %}
+{% block title %}
+    {% translate "New Facilitator" %}
+{% endblock title %}
 {% block page_title %}
     {% translate "New Facilitator" %}
 {% endblock page_title %}

--- a/src/ludamus/templates/panel/facilitator-detail.html
+++ b/src/ludamus/templates/panel/facilitator-detail.html
@@ -1,9 +1,9 @@
 {% extends "panel/base.html" %}
 {% load i18n %}
 {% load tessera %}
-{% block title_prefix %}
-    {{ facilitator.display_name }} - {% translate "Facilitators" %} -
-{% endblock title_prefix %}
+{% block title %}
+    {{ facilitator.display_name }} • {% translate "Facilitators" %}
+{% endblock title %}
 {% block page_title %}
     {{ facilitator.display_name }}
 {% endblock page_title %}

--- a/src/ludamus/templates/panel/facilitator-edit.html
+++ b/src/ludamus/templates/panel/facilitator-edit.html
@@ -1,9 +1,9 @@
 {% extends "panel/base.html" %}
 {% load i18n %}
 {% load tessera %}
-{% block title_prefix %}
-    {% translate "Edit Facilitator" %} -
-{% endblock title_prefix %}
+{% block title %}
+    {% translate "Edit Facilitator" %}
+{% endblock title %}
 {% block page_title %}
     {{ facilitator.display_name }}
 {% endblock page_title %}

--- a/src/ludamus/templates/panel/facilitator-merge.html
+++ b/src/ludamus/templates/panel/facilitator-merge.html
@@ -3,9 +3,9 @@
 {% load i18n %}
 {% load tessera %}
 {% load cfp_tags %}
-{% block title_prefix %}
-    {% translate "Merge Facilitators" %} -
-{% endblock title_prefix %}
+{% block title %}
+    {% translate "Merge Facilitators" %}
+{% endblock title %}
 {% block page_title %}
     {% translate "Merge Facilitators" %}
 {% endblock page_title %}

--- a/src/ludamus/templates/panel/facilitators.html
+++ b/src/ludamus/templates/panel/facilitators.html
@@ -2,9 +2,9 @@
 {% load i18n %}
 {% load tessera %}
 {% load cfp_tags %}
-{% block title_prefix %}
-    {% translate "Facilitators" %} -
-{% endblock title_prefix %}
+{% block title %}
+    {% translate "Facilitators" %}
+{% endblock title %}
 {% block page_title %}
     {% translate "Facilitators" %}
 {% endblock page_title %}

--- a/src/ludamus/templates/panel/import-json.html
+++ b/src/ludamus/templates/panel/import-json.html
@@ -1,9 +1,9 @@
 {% extends "panel/base.html" %}
 {% load i18n %}
 {% load tessera %}
-{% block title_prefix %}
-    {% translate "Google Docs Import" %} -
-{% endblock title_prefix %}
+{% block title %}
+    {% translate "Google Docs Import" %}
+{% endblock title %}
 {% block page_title %}
     {% translate "Google Docs Import" %}
 {% endblock page_title %}

--- a/src/ludamus/templates/panel/import-log.html
+++ b/src/ludamus/templates/panel/import-log.html
@@ -1,9 +1,9 @@
 {% extends "panel/base.html" %}
 {% load i18n %}
 {% load tessera %}
-{% block title_prefix %}
-    {% translate "Google Docs Import" %} -
-{% endblock title_prefix %}
+{% block title %}
+    {% translate "Google Docs Import" %}
+{% endblock title %}
 {% block page_title %}
     {% translate "Google Docs Import" %}
 {% endblock page_title %}

--- a/src/ludamus/templates/panel/import-review.html
+++ b/src/ludamus/templates/panel/import-review.html
@@ -2,9 +2,9 @@
 {% load i18n %}
 {% load tessera %}
 {% load django_vite %}
-{% block title_prefix %}
-    {% translate "Google Docs Import" %} -
-{% endblock title_prefix %}
+{% block title %}
+    {% translate "Google Docs Import" %}
+{% endblock title %}
 {% block page_title %}
     {% translate "Google Docs Import" %}
 {% endblock page_title %}

--- a/src/ludamus/templates/panel/import-run.html
+++ b/src/ludamus/templates/panel/import-run.html
@@ -2,9 +2,9 @@
 {% load i18n %}
 {% load tessera %}
 {% load django_vite %}
-{% block title_prefix %}
-    {% translate "Google Docs Import" %} -
-{% endblock title_prefix %}
+{% block title %}
+    {% translate "Google Docs Import" %}
+{% endblock title %}
 {% block page_title %}
     {% translate "Google Docs Import" %}
 {% endblock page_title %}

--- a/src/ludamus/templates/panel/import.html
+++ b/src/ludamus/templates/panel/import.html
@@ -1,9 +1,9 @@
 {% extends "panel/base.html" %}
 {% load i18n %}
 {% load tessera %}
-{% block title_prefix %}
-    {% translate "Google Docs Import" %} -
-{% endblock title_prefix %}
+{% block title %}
+    {% translate "Google Docs Import" %}
+{% endblock title %}
 {% block page_title %}
     {% translate "Google Docs Import" %}
 {% endblock page_title %}

--- a/src/ludamus/templates/panel/index.html
+++ b/src/ludamus/templates/panel/index.html
@@ -1,9 +1,9 @@
 {% extends "panel/base.html" %}
 {% load i18n %}
 {% load tessera %}
-{% block title_prefix %}
-    {% translate "Dashboard" %} -
-{% endblock title_prefix %}
+{% block title %}
+    {% translate "Dashboard" %}
+{% endblock title %}
 {% block page_title %}
     {% translate "Dashboard" %}
 {% endblock page_title %}

--- a/src/ludamus/templates/panel/integration-settings.html
+++ b/src/ludamus/templates/panel/integration-settings.html
@@ -1,9 +1,9 @@
 {% extends "panel/base.html" %}
 {% load i18n %}
 {% load tessera %}
-{% block title_prefix %}
-    {% translate "Integrations" %} -
-{% endblock title_prefix %}
+{% block title %}
+    {% translate "Integrations" %}
+{% endblock title %}
 {% block page_title %}
     {% translate "Event Settings" %}
 {% endblock page_title %}

--- a/src/ludamus/templates/panel/personal-data-field-create.html
+++ b/src/ludamus/templates/panel/personal-data-field-create.html
@@ -2,9 +2,9 @@
 {% load csp_tags %}
 {% load i18n %}
 {% load tessera %}
-{% block title_prefix %}
-    {% translate "New Personal Data Field" %} -
-{% endblock title_prefix %}
+{% block title %}
+    {% translate "New Personal Data Field" %}
+{% endblock title %}
 {% block page_title %}
     {% translate "New Personal Data Field" %}
 {% endblock page_title %}

--- a/src/ludamus/templates/panel/personal-data-field-edit.html
+++ b/src/ludamus/templates/panel/personal-data-field-edit.html
@@ -1,9 +1,9 @@
 {% extends "panel/base.html" %}
 {% load i18n %}
 {% load tessera %}
-{% block title_prefix %}
-    {% translate "Edit Personal Data Field" %} -
-{% endblock title_prefix %}
+{% block title %}
+    {% translate "Edit Personal Data Field" %}
+{% endblock title %}
 {% block page_title %}
     {% translate "Edit Personal Data Field" %}
 {% endblock page_title %}

--- a/src/ludamus/templates/panel/personal-data-fields.html
+++ b/src/ludamus/templates/panel/personal-data-fields.html
@@ -1,9 +1,9 @@
 {% extends "panel/base.html" %}
 {% load i18n %}
 {% load tessera %}
-{% block title_prefix %}
-    {% translate "Host Data Fields" %} -
-{% endblock title_prefix %}
+{% block title %}
+    {% translate "Host Data Fields" %}
+{% endblock title %}
 {% block page_title %}
     {% translate "CFP Fields" %}
 {% endblock page_title %}

--- a/src/ludamus/templates/panel/print-materials.html
+++ b/src/ludamus/templates/panel/print-materials.html
@@ -1,8 +1,8 @@
 {% extends "panel/base.html" %}
 {% load i18n %}
-{% block title_prefix %}
-    {% translate "Print Materials" %} —
-{% endblock title_prefix %}
+{% block title %}
+    {% translate "Print Materials" %}
+{% endblock title %}
 {% block page_title %}
     {% translate "Print Materials" %}
 {% endblock page_title %}

--- a/src/ludamus/templates/panel/print/base.html
+++ b/src/ludamus/templates/panel/print/base.html
@@ -1,10 +1,14 @@
 {% extends "base.html" %}
 {% load i18n %}
+{% comment %}Printables are organizer pages: the event takes the sphere's slot
+in the title, same as the rest of the panel.{% endcomment %}
 {% block title %}
-    {{ document.event_name }}
     {% block document_name %}
     {% endblock document_name %}
 {% endblock title %}
+{% block title_suffix %}
+    • {{ document.event_name }}
+{% endblock title_suffix %}
 {% block meta_description %}{{ document.event_description|default:document.event_name }}{% endblock meta_description %}
 {% block og_description %}{{ document.event_description|default:document.event_name }}{% endblock og_description %}
 {% block twitter_description %}{{ document.event_description|default:document.event_name }}{% endblock twitter_description %}

--- a/src/ludamus/templates/panel/print/base.html
+++ b/src/ludamus/templates/panel/print/base.html
@@ -2,6 +2,8 @@
 {% load i18n %}
 {% block title %}
     {{ document.event_name }}
+    {% block document_name %}
+    {% endblock document_name %}
 {% endblock title %}
 {% block meta_description %}{{ document.event_description|default:document.event_name }}{% endblock meta_description %}
 {% block og_description %}{{ document.event_description|default:document.event_name }}{% endblock og_description %}

--- a/src/ludamus/templates/panel/print/base.html
+++ b/src/ludamus/templates/panel/print/base.html
@@ -2,10 +2,6 @@
 {% load i18n %}
 {% comment %}Printables are organizer pages: the event takes the sphere's slot
 in the title, same as the rest of the panel.{% endcomment %}
-{% block title %}
-    {% block document_name %}
-    {% endblock document_name %}
-{% endblock title %}
 {% block title_suffix %}
     • {{ document.event_name }}
 {% endblock title_suffix %}

--- a/src/ludamus/templates/panel/print/door-cards.html
+++ b/src/ludamus/templates/panel/print/door-cards.html
@@ -1,5 +1,8 @@
 {% extends "panel/print/base.html" %}
 {% load i18n %}
+{% block document_name %}
+    • {% translate "Door cards" %}
+{% endblock document_name %}
 {% block body %}
     {% for card in document.cards %}
         {# one A4 page per room #}

--- a/src/ludamus/templates/panel/print/door-cards.html
+++ b/src/ludamus/templates/panel/print/door-cards.html
@@ -1,8 +1,8 @@
 {% extends "panel/print/base.html" %}
 {% load i18n %}
-{% block document_name %}
+{% block title %}
     {% translate "Door cards" %}
-{% endblock document_name %}
+{% endblock title %}
 {% block body %}
     {% for card in document.cards %}
         {# one A4 page per room #}

--- a/src/ludamus/templates/panel/print/door-cards.html
+++ b/src/ludamus/templates/panel/print/door-cards.html
@@ -1,7 +1,7 @@
 {% extends "panel/print/base.html" %}
 {% load i18n %}
 {% block document_name %}
-    • {% translate "Door cards" %}
+    {% translate "Door cards" %}
 {% endblock document_name %}
 {% block body %}
     {% for card in document.cards %}

--- a/src/ludamus/templates/panel/print/timetable.html
+++ b/src/ludamus/templates/panel/print/timetable.html
@@ -1,5 +1,8 @@
 {% extends "panel/print/base.html" %}
 {% load i18n %}
+{% block document_name %}
+    • {% translate "Timetable" %}
+{% endblock document_name %}
 {% block extra_style %}
     <style>
         @page {

--- a/src/ludamus/templates/panel/print/timetable.html
+++ b/src/ludamus/templates/panel/print/timetable.html
@@ -1,8 +1,8 @@
 {% extends "panel/print/base.html" %}
 {% load i18n %}
-{% block document_name %}
+{% block title %}
     {% translate "Timetable" %}
-{% endblock document_name %}
+{% endblock title %}
 {% block extra_style %}
     <style>
         @page {

--- a/src/ludamus/templates/panel/print/timetable.html
+++ b/src/ludamus/templates/panel/print/timetable.html
@@ -1,7 +1,7 @@
 {% extends "panel/print/base.html" %}
 {% load i18n %}
 {% block document_name %}
-    • {% translate "Timetable" %}
+    {% translate "Timetable" %}
 {% endblock document_name %}
 {% block extra_style %}
     <style>

--- a/src/ludamus/templates/panel/proposal-detail.html
+++ b/src/ludamus/templates/panel/proposal-detail.html
@@ -2,9 +2,9 @@
 {% load i18n %}
 {% load tessera %}
 {% load cfp_tags %}
-{% block title_prefix %}
-    {{ proposal.title }} - {% translate "Proposals" %} -
-{% endblock title_prefix %}
+{% block title %}
+    {{ proposal.title }} • {% translate "Proposals" %}
+{% endblock title %}
 {% block page_title %}
     {{ proposal.title }}
 {% endblock page_title %}

--- a/src/ludamus/templates/panel/proposal-form.html
+++ b/src/ludamus/templates/panel/proposal-form.html
@@ -1,13 +1,13 @@
 {% extends "panel/base.html" %}
 {% load i18n %}
 {% load tessera %}
-{% block title_prefix %}
+{% block title %}
     {% if proposal %}
-        {% translate "Edit Proposal" %} -
+        {% translate "Edit Proposal" %}
     {% else %}
-        {% translate "Create Session" %} -
+        {% translate "Create Session" %}
     {% endif %}
-{% endblock title_prefix %}
+{% endblock title %}
 {% block page_title %}
     {% if proposal %}
         {{ proposal.title }}

--- a/src/ludamus/templates/panel/proposal-settings.html
+++ b/src/ludamus/templates/panel/proposal-settings.html
@@ -1,9 +1,9 @@
 {% extends "panel/base.html" %}
 {% load i18n %}
 {% load tessera %}
-{% block title_prefix %}
-    {% translate "Proposal Settings" %} -
-{% endblock title_prefix %}
+{% block title %}
+    {% translate "Proposal Settings" %}
+{% endblock title %}
 {% block page_title %}
     {% translate "Event Settings" %}
 {% endblock page_title %}

--- a/src/ludamus/templates/panel/proposals.html
+++ b/src/ludamus/templates/panel/proposals.html
@@ -3,9 +3,9 @@
 {% load tessera %}
 {% load cfp_tags %}
 {% load django_vite %}
-{% block title_prefix %}
-    {% translate "Proposals" %} -
-{% endblock title_prefix %}
+{% block title %}
+    {% translate "Proposals" %}
+{% endblock title %}
 {% block page_title %}
     {% translate "Proposals" %}
 {% endblock page_title %}

--- a/src/ludamus/templates/panel/session-field-create.html
+++ b/src/ludamus/templates/panel/session-field-create.html
@@ -2,9 +2,9 @@
 {% load csp_tags %}
 {% load i18n %}
 {% load tessera %}
-{% block title_prefix %}
-    {% translate "New Session Field" %} -
-{% endblock title_prefix %}
+{% block title %}
+    {% translate "New Session Field" %}
+{% endblock title %}
 {% block page_title %}
     {% translate "New Session Field" %}
 {% endblock page_title %}

--- a/src/ludamus/templates/panel/session-field-edit.html
+++ b/src/ludamus/templates/panel/session-field-edit.html
@@ -1,9 +1,9 @@
 {% extends "panel/base.html" %}
 {% load i18n %}
 {% load tessera %}
-{% block title_prefix %}
-    {% translate "Edit Session Field" %} -
-{% endblock title_prefix %}
+{% block title %}
+    {% translate "Edit Session Field" %}
+{% endblock title %}
 {% block page_title %}
     {% translate "Edit Session Field" %}
 {% endblock page_title %}

--- a/src/ludamus/templates/panel/session-fields.html
+++ b/src/ludamus/templates/panel/session-fields.html
@@ -1,9 +1,9 @@
 {% extends "panel/base.html" %}
 {% load i18n %}
 {% load tessera %}
-{% block title_prefix %}
-    {% translate "Session Fields" %} -
-{% endblock title_prefix %}
+{% block title %}
+    {% translate "Session Fields" %}
+{% endblock title %}
 {% block page_title %}
     {% translate "CFP Fields" %}
 {% endblock page_title %}

--- a/src/ludamus/templates/panel/settings.html
+++ b/src/ludamus/templates/panel/settings.html
@@ -1,9 +1,9 @@
 {% extends "panel/base.html" %}
 {% load i18n %}
 {% load tessera django_vite %}
-{% block title_prefix %}
-    {% translate "Event Settings" %} -
-{% endblock title_prefix %}
+{% block title %}
+    {% translate "Event Settings" %}
+{% endblock title %}
 {% block page_title %}
     {% translate "Event Settings" %}
 {% endblock page_title %}

--- a/src/ludamus/templates/panel/space-copy.html
+++ b/src/ludamus/templates/panel/space-copy.html
@@ -1,9 +1,9 @@
 {% extends "panel/base.html" %}
 {% load i18n %}
 {% load tessera %}
-{% block title_prefix %}
-    {% translate "Copy space" %} -
-{% endblock title_prefix %}
+{% block title %}
+    {% translate "Copy space" %}
+{% endblock title %}
 {% block page_title %}
     {% translate "Copy space" %}
 {% endblock page_title %}

--- a/src/ludamus/templates/panel/space-form.html
+++ b/src/ludamus/templates/panel/space-form.html
@@ -1,14 +1,13 @@
 {% extends "panel/base.html" %}
 {% load i18n %}
 {% load tessera %}
-{% block title_prefix %}
+{% block title %}
     {% if node %}
         {% translate "Edit space" %}
     {% else %}
         {% translate "New space" %}
     {% endif %}
-    -
-{% endblock title_prefix %}
+{% endblock title %}
 {% block page_title %}
     {% if node %}
         {% translate "Edit space" %}

--- a/src/ludamus/templates/panel/spaces.html
+++ b/src/ludamus/templates/panel/spaces.html
@@ -2,9 +2,9 @@
 {% load i18n %}
 {% load django_vite %}
 {% load tessera %}
-{% block title_prefix %}
-    {% translate "Venues" %} -
-{% endblock title_prefix %}
+{% block title %}
+    {% translate "Venues" %}
+{% endblock title %}
 {% block page_title %}
     {% translate "Venues" %}
 {% endblock page_title %}

--- a/src/ludamus/templates/panel/time-slot-edit.html
+++ b/src/ludamus/templates/panel/time-slot-edit.html
@@ -2,9 +2,9 @@
 {% load i18n %}
 {% load tessera %}
 {% load tz %}
-{% block title_prefix %}
-    {% translate "Edit Time Slot" %} -
-{% endblock title_prefix %}
+{% block title %}
+    {% translate "Edit Time Slot" %}
+{% endblock title %}
 {% block page_title %}
     {% translate "Edit Time Slot" %}
 {% endblock page_title %}

--- a/src/ludamus/templates/panel/time-slots.html
+++ b/src/ludamus/templates/panel/time-slots.html
@@ -2,9 +2,9 @@
 {% load cfp_tags %}
 {% load i18n %}
 {% load tessera %}
-{% block title_prefix %}
-    {% translate "Time Slots" %} -
-{% endblock title_prefix %}
+{% block title %}
+    {% translate "Time Slots" %}
+{% endblock title %}
 {% block page_title %}
     {% translate "Time Slots" %}
 {% endblock page_title %}

--- a/src/ludamus/templates/panel/timetable-confirmations.html
+++ b/src/ludamus/templates/panel/timetable-confirmations.html
@@ -2,9 +2,9 @@
 {% load i18n %}
 {% load tessera %}
 {% load django_vite %}
-{% block title_prefix %}
-    {% translate "Confirmations" %} —
-{% endblock title_prefix %}
+{% block title %}
+    {% translate "Confirmations" %}
+{% endblock title %}
 {% block page_title %}
     {% translate "Confirmations" %}
 {% endblock page_title %}

--- a/src/ludamus/templates/panel/timetable-log.html
+++ b/src/ludamus/templates/panel/timetable-log.html
@@ -2,9 +2,9 @@
 {% load django_vite %}
 {% load i18n %}
 {% load tessera %}
-{% block title_prefix %}
-    {% translate "Activity Log" %} —
-{% endblock title_prefix %}
+{% block title %}
+    {% translate "Activity Log" %}
+{% endblock title %}
 {% block page_title %}
     {% translate "Schedule Activity Log" %}
 {% endblock page_title %}

--- a/src/ludamus/templates/panel/timetable-overview.html
+++ b/src/ludamus/templates/panel/timetable-overview.html
@@ -1,9 +1,9 @@
 {% extends "panel/base.html" %}
 {% load i18n %}
 {% load tessera %}
-{% block title_prefix %}
-    {% translate "Organizer Overview" %} —
-{% endblock title_prefix %}
+{% block title %}
+    {% translate "Organizer Overview" %}
+{% endblock title %}
 {% block page_title %}
     {% translate "Organizer Overview" %}
 {% endblock page_title %}

--- a/src/ludamus/templates/panel/timetable-problems.html
+++ b/src/ludamus/templates/panel/timetable-problems.html
@@ -1,9 +1,9 @@
 {% extends "panel/base.html" %}
 {% load i18n %}
 {% load tessera %}
-{% block title_prefix %}
-    {% translate "Problems" %} —
-{% endblock title_prefix %}
+{% block title %}
+    {% translate "Problems" %}
+{% endblock title %}
 {% block page_title %}
     {% translate "Problems" %}
 {% endblock page_title %}

--- a/src/ludamus/templates/panel/timetable.html
+++ b/src/ludamus/templates/panel/timetable.html
@@ -3,9 +3,9 @@
 {% load static %}
 {% load django_vite %}
 {% load tessera %}
-{% block title_prefix %}
-    {% translate "Schedule" %} —
-{% endblock title_prefix %}
+{% block title %}
+    {% translate "Schedule" %}
+{% endblock title %}
 {% block page_title %}
     {% translate "Schedule" %}
 {% endblock page_title %}

--- a/src/ludamus/templates/panel/track-create.html
+++ b/src/ludamus/templates/panel/track-create.html
@@ -1,9 +1,9 @@
 {% extends "panel/base.html" %}
 {% load i18n %}
 {% load tessera %}
-{% block title_prefix %}
-    {% translate "New Track" %} -
-{% endblock title_prefix %}
+{% block title %}
+    {% translate "New Track" %}
+{% endblock title %}
 {% block page_title %}
     {% translate "New Track" %}
 {% endblock page_title %}

--- a/src/ludamus/templates/panel/track-edit.html
+++ b/src/ludamus/templates/panel/track-edit.html
@@ -1,9 +1,9 @@
 {% extends "panel/base.html" %}
 {% load i18n %}
 {% load tessera %}
-{% block title_prefix %}
-    {% translate "Edit Track" %} -
-{% endblock title_prefix %}
+{% block title %}
+    {% translate "Edit Track" %}
+{% endblock title %}
 {% block page_title %}
     {% translate "Edit Track" %}
 {% endblock page_title %}

--- a/src/ludamus/templates/panel/tracks.html
+++ b/src/ludamus/templates/panel/tracks.html
@@ -1,9 +1,9 @@
 {% extends "panel/base.html" %}
 {% load i18n %}
 {% load tessera %}
-{% block title_prefix %}
-    {% translate "Tracks" %} -
-{% endblock title_prefix %}
+{% block title %}
+    {% translate "Tracks" %}
+{% endblock title %}
 {% block page_title %}
     {% translate "Tracks" %}
 {% endblock page_title %}

--- a/tests/e2e/tests/page-title.spec.ts
+++ b/tests/e2e/tests/page-title.spec.ts
@@ -1,0 +1,35 @@
+import { expect, test } from "./helpers/fixtures";
+
+/**
+ * The tab title is what the browser shows and what a shared link previews as.
+ * Both come from one captured value, so these assert the rendered result:
+ * "{page} • {sphere or event} • {brand}", bullets only, never a dash.
+ */
+test.describe("Page titles", () => {
+  test("names the page, then the sphere, and shares under the same title", async ({ page }) => {
+    await page.goto("/event/autumn-open/");
+
+    await expect(page).toHaveTitle(/^Autumn Open Playtest • /);
+    await expect(page).not.toHaveTitle(/[-—]/);
+
+    const ogTitle = page.locator('meta[property="og:title"]');
+    const twitterTitle = page.locator('meta[name="twitter:title"]');
+    await expect(ogTitle).toHaveAttribute("content", await page.title());
+    await expect(twitterTitle).toHaveAttribute("content", await page.title());
+  });
+
+  test("names the event an organizer manages, not their sphere", async ({ page }) => {
+    await page.goto("/admin/login/", { waitUntil: "domcontentloaded" });
+    await page.getByLabel("Username:").fill("e2e-manager");
+    await page.getByLabel("Password:").fill("e2e-manager-123");
+    await page.getByRole("button", { name: /Log in/i }).click();
+
+    await page.goto("/panel/event/frostfire-con/proposals/");
+
+    await expect(page).toHaveTitle(/^Proposals • Frostfire Game Convention/);
+
+    await page.goto("/panel/event/frostfire-con/timetable/print/door-cards/");
+
+    await expect(page).toHaveTitle(/^Door cards • Frostfire Game Convention/);
+  });
+});

--- a/tests/integration/web/test_page_metadata.py
+++ b/tests/integration/web/test_page_metadata.py
@@ -87,16 +87,34 @@ class TestPageTitle:
 
         assert _title(response) == f"Events • {non_root_sphere.name} • Zagrajmy"
 
-    def test_panel_page_title_reads_like_the_rest_of_the_site(
-        self, manager_client, sphere, event
-    ):
+    def test_panel_page_title_names_the_event_it_manages(self, manager_client, event):
         response = _get_ok(
             manager_client,
             reverse("panel:event-index", kwargs={"slug": event.slug}),
             "panel/index.html",
         )
 
-        assert _title(response) == f"Dashboard • {sphere.name}"
+        assert _title(response) == f"Dashboard • {event.name}"
+
+    def test_sphere_wide_panel_page_keeps_the_sphere(self, manager_client, sphere):
+        response = _get_ok(
+            manager_client,
+            reverse("multiverse:panel:sphere-settings"),
+            "multiverse/panel/sphere-settings.html",
+        )
+
+        assert _title(response) == f"Sphere settings • {sphere.name}"
+
+    def test_print_document_title_names_the_document_and_the_event(
+        self, manager_client, event
+    ):
+        response = _get_ok(
+            manager_client,
+            reverse("panel:timetable-print-door-cards", kwargs={"slug": event.slug}),
+            "panel/print/door-cards.html",
+        )
+
+        assert _title(response) == f"Door cards • {event.name}"
 
     # A dash in a title reads as a second kind of separator next to the bullets
     # the standard already uses, and eats more room in a tab than "•" does.
@@ -123,16 +141,14 @@ class TestLinkPreviewTitle:
 
         assert _titles(response) == [f"Kapitularz • {sphere.name}"] * 3
 
-    def test_matches_the_document_title_in_the_panel(
-        self, manager_client, sphere, event
-    ):
+    def test_matches_the_document_title_in_the_panel(self, manager_client, event):
         response = _get_ok(
             manager_client,
             reverse("panel:proposals", kwargs={"slug": event.slug}),
             "panel/proposals.html",
         )
 
-        assert _titles(response) == [f"Proposals • {sphere.name}"] * 3
+        assert _titles(response) == [f"Proposals • {event.name}"] * 3
 
 
 class TestMetaDescription:

--- a/tests/integration/web/test_page_metadata.py
+++ b/tests/integration/web/test_page_metadata.py
@@ -1,15 +1,21 @@
 import re
 from http import HTTPStatus
+from pathlib import Path
 
 from django.core.files.uploadedfile import SimpleUploadedFile
 from django.urls import reverse
 
+import ludamus
 from tests.integration.conftest import PNG_BYTES, EncounterFactory, EventFactory
 from tests.integration.utils import assert_response
 
 PRODUCT_PITCH = (
     "A convention without spreadsheet chaos. Programme proposals, a schedule of"
     " rooms and tracks, sign-ups with seat limits and a waitlist."
+)
+TEMPLATES = Path(ludamus.__file__).parent / "templates"
+TITLE_BLOCK = re.compile(
+    r"{% block title %}(?:.*?){% endblock title %}|<title>(?:.*?)</title>", re.DOTALL
 )
 
 
@@ -32,6 +38,14 @@ def _meta_raw(response, attribute, value):
 
 def _meta(response, attribute, value):
     return " ".join(_meta_raw(response, attribute, value).split())
+
+
+def _titles(response):
+    return [
+        _title(response),
+        _meta(response, "property", "og:title"),
+        _meta(response, "name", "twitter:title"),
+    ]
 
 
 def _descriptions(response):
@@ -72,6 +86,53 @@ class TestPageTitle:
         )
 
         assert _title(response) == f"Events • {non_root_sphere.name} • Zagrajmy"
+
+    def test_panel_page_title_reads_like_the_rest_of_the_site(
+        self, manager_client, sphere, event
+    ):
+        response = _get_ok(
+            manager_client,
+            reverse("panel:event-index", kwargs={"slug": event.slug}),
+            "panel/index.html",
+        )
+
+        assert _title(response) == f"Dashboard • {sphere.name}"
+
+    # A dash in a title reads as a second kind of separator next to the bullets
+    # the standard already uses, and eats more room in a tab than "•" does.
+    def test_no_title_separates_its_parts_with_a_dash(self):
+        offenders = [
+            f"{path.name}: {title}"
+            for path in TEMPLATES.rglob("*.html")
+            for title in TITLE_BLOCK.findall(path.read_text())
+            if "—" in title or " - " in title
+        ]
+
+        assert offenders == []
+
+
+class TestLinkPreviewTitle:
+    def test_matches_the_document_title(self, client, sphere):
+        event = EventFactory(sphere=sphere, name="Kapitularz")
+
+        response = _get_ok(
+            client,
+            reverse("web:chronology:event", kwargs={"slug": event.slug}),
+            ["chronology/event.html"],
+        )
+
+        assert _titles(response) == [f"Kapitularz • {sphere.name}"] * 3
+
+    def test_matches_the_document_title_in_the_panel(
+        self, manager_client, sphere, event
+    ):
+        response = _get_ok(
+            manager_client,
+            reverse("panel:proposals", kwargs={"slug": event.slug}),
+            "panel/proposals.html",
+        )
+
+        assert _titles(response) == [f"Proposals • {sphere.name}"] * 3
 
 
 class TestMetaDescription:


### PR DESCRIPTION
Three title systems were running at once, which is how
`/panel/event/2026/print/` ended up sharing as "Kapitularz" while its tab read
something else:

- the public site built `"{page} • {sphere} • Zagrajmy"`
- the panel overrode that with `"{page} - {sphere}"` — a hyphen in most files,
  an em dash in eight
- `og:title` / `twitter:title` ignored both and printed the sphere name, except
  on two pages that overrode them by hand

## One source of truth

`base.html` composes the title once, into a new `{% document_title %}` capture
tag, and `<title>`, `og:title` and `twitter:title` all print it. The
`og_title` / `twitter_title` blocks are gone, so the three can no longer drift —
the per-page overrides in `chronology/event.html` and `notice_board/detail.html`
became redundant and were deleted. A block can't hand its output to a variable,
which is exactly why they had drifted; the tag is the smallest thing that fixes
that.

## The panel joins the standard, with the event in the sphere's slot

`panel/base.html` no longer builds its own title; all 62 panel templates set
`{% block title %}` like every other page. The suffix names the **event**, not
the sphere — an organizer keeps several panel tabs open for one sphere, so the
sphere told them apart not at all. Sphere-wide pages (settings, announcements,
connections, MCP access) have no current event and keep the sphere.

| Page | Title |
| --- | --- |
| `/panel/event/2026/proposals/` | `Proposals • Kapitularz 2026 • Zagrajmy` |
| `/panel/sphere-settings/` | `Sphere settings • Kapitularz • Zagrajmy` |
| `/panel/event/2026/timetable/print/door-cards/` | `Door cards • Kapitularz 2026 • Zagrajmy` |
| `/events/kapitularz-2026/` | `Kapitularz 2026 • Kapitularz • Zagrajmy` |

## Bullets only

Every separator is a bullet now: the eight panel pages, `chronology/print.html`,
both error pages, and the enrollment / proposal / claim pages
(`Enrollment - X` → `Enrollment • X`). A dash reads as a second kind of
separator next to the bullets and costs more room in a tab.

Print documents name themselves (`Door cards`, `Timetable`) instead of leading
with the event name, so they read like the rest of the panel.

## Tests

`tests/integration/web/test_page_metadata.py` gains: title == og:title ==
twitter:title on a public and a panel page; the panel event/sphere split; the
print-document shape; and a scan asserting no template title contains `—` or
` - `.

Full suite green locally (3587 passed, 9 skipped), `mise run lint` clean,
`tingle` reports no new debt.

No screenshots: the whole change lives in `<head>`, so it only shows up in the
browser tab and in link previews, neither of which a page screenshot captures.

## Notes for review

- `document_title` is registered in djlint's `custom_blocks` and `@register.tag`
  in vulture's `ignore_decorators` — both needed for the new tag to pass the
  existing linters.
- The tag writes its name into the context it was reached with, so it has to sit
  at the top level of the page shell; nested inside a block it would be popped
  with that block. That constraint is recorded in a comment on the node.
- Third commit is review fallout: `document_name` in the print base was an
  identity wrapper around `block title`, so the two print documents override
  `title` directly and the wrapper is gone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G23WN3rj2ccMr92u6QikF4