### PR TITLE
Give each generated Site its own domain, drop SiteFactory's get-or-create

### DIFF
--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -5,7 +5,7 @@ import pytest
 from django.contrib.auth import get_user_model
 from django.contrib.auth.hashers import make_password
 from django.contrib.sites.models import Site
-from factory import Faker, LazyAttribute, LazyAttributeSequence, Sequence, SubFactory
+from factory import Faker, LazyAttribute, Sequence, SubFactory
 from factory.django import DjangoModelFactory
 from pytest_factoryboy import register
 
@@ -90,18 +90,12 @@ class UserFactory(DjangoModelFactory):
 class SiteFactory(DjangoModelFactory):
     class Meta:
         model = Site
-        django_get_or_create = ("domain",)
 
-    # Sphere.site is a OneToOneField, and this factory gets-or-creates by domain,
-    # so two Sites built from the same Faker company name collapse into one and
-    # the second Sphere hits "UNIQUE constraint failed: sphere.site_id". Faker
-    # repeats freely — and pytest-randomly reseeds per test — so whether that
-    # happens depends on how many objects a run built first. The sequence makes
-    # the domain unique per generated Site; passing an explicit domain still
-    # gets-or-creates, which is what the callers that share a Site rely on.
-    domain = LazyAttributeSequence(
-        lambda o, n: f"{o.name.lower().replace(' ', '-')}-{n}.testserver"
-    )
+    # Site.domain is unique and Sphere.site is a OneToOneField, so every
+    # generated Site needs a domain of its own. Deriving it from name would not
+    # do: Faker repeats company names, and two spheres landing on one Site fail
+    # as "UNIQUE constraint failed: sphere.site_id", pointing at the wrong table.
+    domain = Sequence(lambda n: f"site-{n}.testserver")
     name = Faker("company")
 
 

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -5,7 +5,7 @@ import pytest
 from django.contrib.auth import get_user_model
 from django.contrib.auth.hashers import make_password
 from django.contrib.sites.models import Site
-from factory import Faker, LazyAttribute, Sequence, SubFactory
+from factory import Faker, LazyAttribute, LazyAttributeSequence, Sequence, SubFactory
 from factory.django import DjangoModelFactory
 from pytest_factoryboy import register
 
@@ -92,7 +92,16 @@ class SiteFactory(DjangoModelFactory):
         model = Site
         django_get_or_create = ("domain",)
 
-    domain = LazyAttribute(lambda o: f"{o.name.lower().replace(' ', '-')}.testserver")
+    # Sphere.site is a OneToOneField, and this factory gets-or-creates by domain,
+    # so two Sites built from the same Faker company name collapse into one and
+    # the second Sphere hits "UNIQUE constraint failed: sphere.site_id". Faker
+    # repeats freely — and pytest-randomly reseeds per test — so whether that
+    # happens depends on how many objects a run built first. The sequence makes
+    # the domain unique per generated Site; passing an explicit domain still
+    # gets-or-creates, which is what the callers that share a Site rely on.
+    domain = LazyAttributeSequence(
+        lambda o, n: f"{o.name.lower().replace(' ', '-')}-{n}.testserver"
+    )
     name = Faker("company")
 
 

--- a/tests/integration/test_factories.py
+++ b/tests/integration/test_factories.py
@@ -1,10 +1,10 @@
-import pytest
-
 from tests.integration.conftest import SphereFactory
 
 
-@pytest.mark.django_db
-def test_two_spheres_do_not_collide_on_an_identical_site_name():
+# The original break: SiteFactory derived its domain from a non-unique
+# Faker("company") and got-or-created on it, so two spheres whose sites drew the
+# same name collapsed onto one Site row.
+def test_spheres_built_from_one_site_name_do_not_share_a_site():
     first = SphereFactory(site__name="Same Company")
     second = SphereFactory(site__name="Same Company")
 

--- a/tests/integration/test_factories.py
+++ b/tests/integration/test_factories.py
@@ -1,0 +1,11 @@
+import pytest
+
+from tests.integration.conftest import SphereFactory
+
+
+@pytest.mark.django_db
+def test_two_spheres_do_not_collide_on_an_identical_site_name():
+    first = SphereFactory(site__name="Same Company")
+    second = SphereFactory(site__name="Same Company")
+
+    assert first.site_id != second.site_id


### PR DESCRIPTION
## The bug

`SiteFactory` got-or-created by `domain` and derived that domain from `Faker("company")`:

```python
class Meta:
    django_get_or_create = ("domain",)

domain = LazyAttribute(lambda o: f"{o.name.lower().replace(' ', '-')}.testserver")
name = Faker("company")
```

Faker repeats company names. When two `SphereFactory()` calls drew the same one, both sites collapsed into a single `Site` row — and `Sphere.site` is a `OneToOneField` (`links/db/django/models.py:288`), so the second sphere raised:

```
django.db.utils.IntegrityError: UNIQUE constraint failed: sphere.site_id
```

Note where that points: `sphere.site_id`, not the domain that actually collided. That misdirection is why the bug took a detour to diagnose.

Nothing reseeds `factory.random` (`pytest-randomly` is not installed — I checked), so it seeds from OS entropy at import and the collision was a per-process lottery. It most recently landed on `TestEventPageView::test_query_count_constant_in_session_count`, which touches none of this.

## The fix

Drop `django_get_or_create` and give the domain a plain sequence:

```python
class Meta:
    model = Site

domain = Sequence(lambda n: f"site-{n}.testserver")
name = Faker("company")
```

The first version of this PR kept get-or-create and merely made the derived domain unique. Review found that left a hybrid: the option was dead on the default path, and on the one path where it still fired it **reproduced the very bug being fixed** — `SphereFactory(site__domain="dup.testserver")` twice still raised `UNIQUE constraint failed: sphere.site_id`.

Nothing needs it. There is exactly one explicit-domain caller in the repo (`test_notification_email_links.py:24`), invoked once, so it cannot be relying on get-or-create. The fixtures that genuinely share a Site (`sphere_fixture`, `non_root_sphere`) build it with `Site.objects.update_or_create` and never touch this factory.

Deriving from `name` doesn't survive either: `Site.name` is not unique in Django and nothing queries it, and the derived form produced hostnames like `lewis,-miller-and-barnes.testserver` — only spaces were replaced. Asking for one domain twice now fails as `UNIQUE constraint failed: django_site.domain`, which names the actual mistake.

## Test

`tests/integration/test_factories.py` — two spheres built from an identical site name must not share a Site. Deterministic: it fails against `main`'s conftest, passes here. No `@pytest.mark.django_db`, since `_django_db` is autouse for the package.

## Verification

- Full Python suite: **3582 passed, 9 skipped** — identical to baseline.
- The regression test fails against `main`'s conftest.
- `ruff`, `black`, `pylint` (10.00/10) clean on both files.