### PR TITLE
fix(mise): pin shellcheck/hadolint by prefix so sandbox installs resolve

### DIFF
--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -105,28 +105,6 @@ if [ -n "$purged" ]; then
     || echo "WARN: 'mise install' retry failed; broken tools:$purged"
 fi
 
-# A pipx-aliased tool can survive both installs broken when its PyPI wrapper
-# appends a packaging revision to the upstream version: shellcheck-py 0.11.0.1
-# wraps shellcheck 0.11.0, hadolint-py does the same. mise passes a full X.Y.Z
-# pin to uv verbatim as ==X.Y.Z, which matches nothing on PyPI. A shorter pin
-# makes mise resolve against the registry instead (shellcheck@0.11 picks
-# 0.11.0.1) and link a 0.11.0 alias dir that satisfies the mise.toml pin, so
-# retry each still-shimless aliased tool with its pin trimmed one segment.
-# Versions stay pinned in mise.toml alone; this survives future bumps.
-for tool in $purged; do
-  [ -e "$HOME/.local/share/mise/shims/$tool" ] && continue
-  pin="$(sed -n "s/^${tool}[[:space:]]*=[[:space:]]*\"\([^\"]*\)\".*/\1/p" \
-    mise.toml)"
-  prefix="${pin%.*}"
-  case "$prefix" in
-    *.*)
-      echo "Retrying $tool@$prefix (wrapper may add a revision to $pin)"
-      mise install "$tool@$prefix" \
-        || echo "WARN: 'mise install $tool@$prefix' failed; $tool unavailable"
-      ;;
-  esac
-done
-
 mise bootstrap packages apply --yes || echo "WARN: 'mise bootstrap packages apply' failed"
 mise run bootstrap || echo "WARN: 'mise run bootstrap' failed; JS deps/build may be unavailable"
 

--- a/docs/agents/sandbox.md
+++ b/docs/agents/sandbox.md
@@ -26,14 +26,15 @@ without a shim after `mise install` gets its install purged and reinstalled
 through the alias. Pre-baked layouts that happen to satisfy the alias (hk)
 are kept as is.
 
-PyPI wrapper packages add one more failure mode: they append a packaging
-revision to the upstream version (shellcheck-py 0.11.0.1 wraps shellcheck
-0.11.0), and mise passes a full `X.Y.Z` pin to uv verbatim as `==X.Y.Z`,
-which matches nothing. The hook's last resort covers it: any aliased tool
-still shimless after the reinstall is retried with its mise.toml pin trimmed
-one segment (`shellcheck@0.11`), which mise prefix-resolves to the wrapper's
-version and links back to the pinned one. Bumping a pin in `mise.toml` needs
-no sandbox-side edit.
+PyPI wrapper packages add one more failure mode, handled in `mise.toml`
+rather than here: they append a packaging revision to the upstream version
+(shellcheck-py 0.11.0.1 wraps shellcheck 0.11.0), and mise passes an exact
+`X.Y.Z` pin to uv verbatim as `==X.Y.Z`, which matches nothing on PyPI. So
+shellcheck and hadolint are pinned as `prefix:0.11.0` / `prefix:2.14.0`:
+mise resolves a prefix against the registry, picking the wrapper in sandboxes
+and the identical exact version on the GitHub-release backends laptops use.
+Keep the `prefix:` when bumping either pin; a bare `X.Y.Z` wedges every
+sandbox `mise install`.
 
 Playwright browsers: the image's `/opt/pw-browsers` build can lag the
 `@playwright/test` pin, so the hook runs `mise run test:e2e:install`; when its

--- a/mise.sandbox.toml
+++ b/mise.sandbox.toml
@@ -15,13 +15,15 @@ disable_tools = ["python", "pipx", "github:reteps/dockerfmt"]
 [tool_alias]
 hk = "cargo:hk"
 # The pipx wrappers version as <upstream>.<wrapper-rev> (0.11.0.1 wraps
-# 0.11.0), so mise.toml's exact pins never match PyPI; session-start.sh
-# retries shimless aliased tools with the pin trimmed one segment.
+# 0.11.0), which is why mise.toml pins these two with `prefix:` — an exact pin
+# reaches uv as `==0.11.0` and matches nothing on PyPI.
 shellcheck = "pipx:shellcheck-py"
 actionlint = "go:github.com/rhysd/actionlint/cmd/actionlint"
 hadolint = "pipx:hadolint-py"
 
 # dockerfmt can't be aliased (its mise.toml key is already a full backend
-# spec), so it keeps the one duplicated pin in this file.
+# spec), so it keeps the one duplicated pin in this file. Bump it together with
+# mise.toml's — nothing checks that they agree, and they had already drifted
+# (sandboxes ran 0.5.2 against laptops' 0.5.4).
 [tools]
-"go:github.com/reteps/dockerfmt" = "v0.5.2"
+"go:github.com/reteps/dockerfmt" = "v0.5.4"

--- a/mise.toml
+++ b/mise.toml
@@ -30,8 +30,14 @@ markdownlint-cli2 = "0.23.1"
 "npm:@endevco/aube" = { version = "1.31.0", npm_args = "--ignore-scripts=false" }
 hk = "1.51.0"
 actionlint = "1.7.12"
-shellcheck = "0.11.0"
-hadolint = "2.14.0"
+# `prefix:` (not a bare "0.11.0"): in sandboxes these two resolve to PyPI
+# wrappers that append a packaging revision to the upstream version
+# (shellcheck-py 0.11.0.1 wraps shellcheck 0.11.0). mise hands an exact pin to
+# uv verbatim as `==0.11.0`, which matches nothing there; a prefix pin resolves
+# against the registry and picks the wrapper. On GitHub-release backends the
+# prefix matches the exact version, so laptops keep installing 0.11.0/2.14.0.
+shellcheck = "prefix:0.11.0"
+hadolint = "prefix:2.14.0"
 "github:reteps/dockerfmt" = "0.5.4"
 pipx = "1.16.0"
 


### PR DESCRIPTION
## What

`mise install` failed on `shellcheck` and `hadolint` in Claude Code web sandboxes:

```
mise shellcheck@0.11.0  [1/3] uv tool install shellcheck-py==0.11.0
  × No solution found when resolving dependencies:
  ╰─▶ Because there is no version of shellcheck-py==0.11.0 ...
```

The PyPI wrappers `mise.sandbox.toml` aliases these two to version as
`<upstream>.<wrapper-rev>` — `shellcheck-py 0.11.0.1` wraps shellcheck `0.11.0`,
`hadolint-py 2.14.0.1` wraps hadolint `2.14.0`, and neither publishes a bare
`0.11.0` / `2.14.0`. mise handed the exact `mise.toml` pin to uv verbatim as
`==0.11.0`, which matches nothing, so every `mise install` — and every
`mise run <task>` that triggers one — failed on both tools.

`session-start.sh` repaired this after the fact by retrying with the pin trimmed
one segment, so sessions ended up working; anything running *before* the async
hook got that far (`mise run lint` early in a session) still hit the failure.

## How

Pin both with `prefix:` in `mise.toml`, which makes mise resolve the version
against the registry instead of passing it through:

```toml
shellcheck = "prefix:0.11.0"
hadolint = "prefix:2.14.0"
```

Prefix resolution happens in mise's core, before backend dispatch, so it picks
the wrapper revision on the pipx backend and the identical exact version on the
GitHub-release backends laptops and CI use. Versions stay pinned in `mise.toml`
alone, and the hook's pin-trimming retry loop becomes dead code — removed. The
missing-shim purge loop above it is untouched; it covers a different failure
(pre-baked GitHub-layout installs clashing with the alias backend).

Also bumps the sandbox `dockerfmt` pin to `v0.5.4` to match `mise.toml`. That
pin is duplicated because dockerfmt's `mise.toml` key is already a full backend
spec and can't be aliased — and it had drifted, so sandboxes were formatting
with 0.5.2 while everyone else ran 0.5.4.

## Verification

In this sandbox, after purging both installs and their shims:

- `mise install` — succeeds directly, no repair pass:
  `uv tool install shellcheck-py==0.11.0.1` / `hadolint-py==2.14.0.1`, shims regenerated
- `shellcheck --version` → `0.11.0`, `hadolint --version` → `2.14.0` — the pinned upstream versions
- `mise run lint` — green (exit 0), including `shellcheck` and `hadolint` via hk
- `shellcheck .claude/hooks/session-start.sh` — clean after the removal

The GitHub-release backends can't be exercised from a sandbox (the egress proxy
403s GitHub), so this PR's own CI run is the check on that path: `ci.yml` does
`mise install` on plain ubuntu runners with the default backends.

---
_Generated by [Claude Code](https://claude.ai/code/session_01RfGafwYHAdfsnYFzeMrmiq)_