### PR TITLE
Fall back to the initials placeholder when an avatar fails to load

### DIFF
--- a/src/ludamus/client/src/avatar.ts
+++ b/src/ludamus/client/src/avatar.ts
@@ -8,6 +8,10 @@
 
 const hide = (image: HTMLImageElement): void => {
   image.hidden = true;
+  // The placeholder makes this look intentional to the user, so the console is
+  // the only trace that a provider stopped serving avatars. No URL — that's the
+  // user's identity at their avatar host.
+  console.warn("Avatar image failed to load; falling back to the initials placeholder");
 };
 
 document.addEventListener(

--- a/src/ludamus/client/src/avatar.ts
+++ b/src/ludamus/client/src/avatar.ts
@@ -1,0 +1,37 @@
+// Avatars stack the photo on top of an initials placeholder, so an image that
+// never loads only has to get out of the way — hiding it uncovers the initials
+// instead of leaving the browser's broken-image glyph on the page.
+//
+// One capture-phase listener on the document covers every avatar: `error`
+// doesn't bubble, but capture still reaches the image on the way down, and it
+// catches avatars htmx swaps in later without re-wiring anything.
+
+const hide = (image: HTMLImageElement): void => {
+  image.hidden = true;
+};
+
+document.addEventListener(
+  "error",
+  (event) => {
+    const { target } = event;
+    if (target instanceof HTMLImageElement && target.dataset.avatarImage !== undefined) {
+      hide(target);
+    }
+  },
+  true,
+);
+
+// A cached failure (a 404 the browser still has) can fire before this module
+// runs. After the fact a failed image looks like this: done loading, no
+// intrinsic size.
+const sweepLoaded = (): void => {
+  for (const image of document.querySelectorAll<HTMLImageElement>("img[data-avatar-image]")) {
+    if (image.complete && image.naturalWidth === 0) hide(image);
+  }
+};
+
+if (document.readyState === "loading") {
+  document.addEventListener("DOMContentLoaded", sweepLoaded);
+} else {
+  sweepLoaded();
+}

--- a/src/ludamus/client/vite.config.ts
+++ b/src/ludamus/client/vite.config.ts
@@ -37,6 +37,7 @@ export default defineConfig({
       input: {
         actions: resolve(rootDir, "src/actions.ts"),
         "app-scroll": resolve(rootDir, "src/app-scroll.ts"),
+        avatar: resolve(rootDir, "src/avatar.ts"),
         "bulk-status": resolve(rootDir, "src/bulk-status.ts"),
         confirm: resolve(rootDir, "src/confirm.ts"),
         copy: resolve(rootDir, "src/copy.ts"),

--- a/src/ludamus/templates/base.html
+++ b/src/ludamus/templates/base.html
@@ -85,6 +85,7 @@
         {% vite_asset 'src/tab-scroll.ts' %}
         {% vite_asset 'src/flash.ts' %}
         {% vite_asset 'src/copy.ts' %}
+        {% vite_asset 'src/avatar.ts' %}
         {% vite_asset 'src/stepper.ts' %}
         <link rel="stylesheet" href="{% vite_asset_url 'src/index.css' %}">
         {% block extra_head %}

--- a/src/ludamus/templates/components/avatar.html
+++ b/src/ludamus/templates/components/avatar.html
@@ -11,12 +11,14 @@
                         <span class="{{ text_class }} font-semibold {{ name_value|avatar_text_class }}">{{ name_value|slice:":2"|upper }}</span>
                     </div>
                     {% if user.avatar_url %}
+                        {# data-avatar-image: avatar.ts hides the image when it fails to load, so the initials below show through instead of a broken-image glyph. #}
                         <img src="{{ user.avatar_url }}"
                              alt=""
                              width="32"
                              height="32"
                              class="absolute inset-0 h-full w-full object-cover"
-                             loading="lazy">
+                             loading="lazy"
+                             data-avatar-image>
                     {% endif %}
                 </div>
                 {% if is_danger %}

--- a/tests/e2e/tests/avatar-fallback.auth.spec.ts
+++ b/tests/e2e/tests/avatar-fallback.auth.spec.ts
@@ -1,0 +1,38 @@
+import { type Page } from "@playwright/test";
+
+import { expect, test } from "./helpers/fixtures";
+
+// The seeded e2e user's avatar_url points at an external host
+// (bootstrap_data.py), so routing it is what makes both outcomes deterministic
+// — and independent of whether the sandbox can reach that host at all.
+const AVATAR_REQUEST = /pravatar\.cc/;
+
+const PNG_BYTES = Buffer.from(
+  "89504e470d0a1a0a0000000d4948445200000001000000010802000000" +
+    "907753de0000000c49444154789c63606060000000040001f6173855" +
+    "0000000049454e44ae426082",
+  "hex",
+);
+
+const navbarAvatarImage = (page: Page) => page.locator("img[data-avatar-image]").first();
+
+test.describe("Avatar image fallback", () => {
+  test("shows the photo when it loads", async ({ page }) => {
+    await page.route(AVATAR_REQUEST, (route) =>
+      route.fulfill({ body: PNG_BYTES, contentType: "image/png" }),
+    );
+
+    await page.goto("/");
+
+    await expect(navbarAvatarImage(page)).toBeVisible();
+  });
+
+  test("uncovers the initials placeholder when the photo fails", async ({ page }) => {
+    await page.route(AVATAR_REQUEST, (route) => route.abort());
+
+    await page.goto("/");
+
+    await expect(navbarAvatarImage(page)).toBeHidden();
+    await expect(page.getByRole("img", { name: "E2E Tester" }).first()).toBeVisible();
+  });
+});

--- a/tests/e2e/tests/avatar-fallback.auth.spec.ts
+++ b/tests/e2e/tests/avatar-fallback.auth.spec.ts
@@ -14,7 +14,8 @@ const PNG_BYTES = Buffer.from(
   "hex",
 );
 
-const navbarAvatarImage = (page: Page) => page.locator("img[data-avatar-image]").first();
+const navbarAvatarImage = (page: Page) =>
+  page.getByRole("button", { name: "Account menu" }).locator("img");
 
 test.describe("Avatar image fallback", () => {
   test("shows the photo when it loads", async ({ page }) => {


### PR DESCRIPTION
The avatar component already stacks the photo on top of an initials
placeholder, so an `avatar_url` that 404s (dead Auth0/Gravatar URL, blocked
host, offline) left the browser's broken-image glyph sitting on top of the
initials.

`src/ludamus/client/src/avatar.ts` hides any `[data-avatar-image]` that fails
to load, uncovering the placeholder. One capture-phase `error` listener on the
document covers every avatar on the page — `error` doesn't bubble, but capture
still reaches the image — including the ones htmx swaps in later. An inline
`onerror=` isn't an option: `script-src` is `'self' 'nonce-…'` with no
`unsafe-inline` (`CSP_POLICY` in `edges/settings.py`). A load that already
failed before the module ran (cached 404) is caught by a one-shot sweep for
images that are `complete` with `naturalWidth === 0`.

Scope is `templates/components/avatar.html` — the navbar, party lists, session
cards, and every other place that includes it. The provider/Gravatar previews
on the profile-avatar page are untouched: they have no placeholder behind them,
so hiding a failed image there would just collapse the card.

## Verification

- `tests/e2e/tests/avatar-fallback.auth.spec.ts` — routes the seeded user's
  avatar URL two ways: fulfilled with a real PNG (image stays visible) and
  aborted (image hidden, initials placeholder visible). Both pass locally
  against `chromium-auth`.
- `mise run check` passes.
- Checked in a real browser with the avatar host blocked: before the change the
  navbar avatar shows the broken-image glyph over the "E2" initials; after it,
  just the initials circle. (Screenshots captured locally under the gitignored
  `screenshots/`, so they aren't attached here.)

No new strings, no schema change, no new logging path.

---
_Generated by [Claude Code](https://claude.ai/code/session_014HhGvEe5QdZn9CjKTfNFLx)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved avatar fallback behavior when profile images fail to load.
  * Initials placeholders now remain visible for both existing and dynamically updated avatars.

* **Tests**
  * Added coverage verifying successful avatar display and fallback behavior when image loading fails.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->