### PR TITLE
fix(flaky): timetable session-list-loads e2e test

### DIFF
--- a/tests/e2e/tests/timetable.spec.ts
+++ b/tests/e2e/tests/timetable.spec.ts
@@ -334,7 +334,17 @@ test.describe("Timetable", () => {
     await expectWidth(start);
   });
 
-  test("session list loads via HTMX and shows unscheduled sessions", async ({ page }) => {
+  // Quarantined: flagged flaky by Playwright's own retry mechanism in CI run
+  // https://github.com/zagrajmy/ludamus/actions/runs/30711558802 (2026-08-01,
+  // commit 861bf289) — failed twice on
+  // `getByRole("region", { name: "Sessions to assign" }).getByText("Storytelling Workshop")`
+  // then passed on a third attempt. 8/8 isolated local runs and an attempted
+  // concurrent-load repro (alongside panel.spec.ts, which shares the same
+  // sunhaven-festival fixture) did not reproduce it, so no verified fix is
+  // landing here — see the flaky-test report in this PR's description for
+  // what was ruled out. Re-enable once it either reproduces locally or flakes
+  // again with more evidence to go on.
+  test.skip("session list loads via HTMX and shows unscheduled sessions", async ({ page }) => {
     const sessionListLoaded = page.waitForResponse(
       (r) => r.url().includes("/parts/sessions/") && r.status() === 200,
     );


### PR DESCRIPTION
## Weekly flaky-test report (2026-07-29 → 2026-08-05)

Scanned CI workflow (`ci.yml`, id 180228480) runs on `zagrajmy/ludamus`: 39 push-to-`main` runs and 203 `pull_request` runs (242 total) in the last 7 days. Focused on the `test` and `test-postgres` jobs (pytest/e2e); `test-postgres` never failed. 18 runs had the `test` job fail.

**Strict flaky signal (same commit, both pass and fail):** none of the 242 runs re-ran a job (`run_attempt` was 1 everywhere) and no commit SHA triggered more than one workflow run, so there's no cross-run same-commit pass/fail pair in this window.

**What I did find**, using the task's definition that a same-commit pass-then-fail counts even "in a retry": Playwright's own per-test retry mechanism (2 retries in CI) caught exactly one flaky test, inside a single job run:

| Test | File | Flake evidence | Failure pattern |
|---|---|---|---|
| `session list loads via HTMX and shows unscheduled sessions` | `tests/e2e/tests/timetable.spec.ts:337` | Failed on attempt 1 and retry 1, passed on retry 2 — all same commit `861bf289`, same run [30711558802](https://github.com/zagrajmy/ludamus/actions/runs/30711558802) | `expect(locator).toBeVisible()` timeout (10s) on `getByRole("region", {name: "Sessions to assign"}).getByText("Storytelling Workshop")` |

That's the #1 (and only) flaky test found by the strict definition, so it's the target of this PR.

A looser signal worth a maintainer's separate look: `tests/e2e/tests/confirmations.spec.ts:48` failed with the *identical* error on 4 different commits of `feat/session-confirmations` this week. Code changed between those commits so it's not strict same-SHA flakiness, but 4 identical failures in a row on one WIP branch reads more like a reproducible bug the author was chasing than environment flake — flagging it here rather than acting on it, since it's out of scope for this fix.

## Root-cause attempt on the #1 flaky test

`timetable.spec.ts:337` does:
```ts
const sessionListLoaded = page.waitForResponse(r => r.url().includes("/parts/sessions/") && r.status() === 200);
await page.goto("/panel/event/sunhaven-festival/timetable/");
await sessionListLoaded;
await expect(...getByText("RPG Introduction")).toBeVisible();
await expect(...getByText("Dungeon Crawl")).toBeVisible();
await expect(...getByText("Storytelling Workshop")).toBeVisible();
```

The `#session-list` region (`timetable-browse-pane.html`) is filled via `hx-trigger="load"` — i.e. the DOM update happens asynchronously *after* the network response Playwright is waiting on, so there's a theoretical gap between "response received" and "htmx has swapped the DOM." I looked for (and ruled out) a couple of more concrete candidates:
- **Double htmx request racing the swap** — the only other trigger on that region is `timetableChanged from:body`, which only fires after a drag-and-drop session assignment (`src/timetable.ts`), not on page load. Not in play for this read-only test.
- **Shared-fixture race with another spec** — `panel.spec.ts` also loads `/panel/event/sunhaven-festival/timetable/` and could run in a different CI worker at the same time (`workers: 2`, `fullyParallel: true`, one shared DB). But it only asserts CSS on `.tab-shell`, doesn't touch session data, and the file that *does* mutate this same "Storytelling Workshop" session (`timetable.spec.ts`'s own "confirms and unconfirms a scheduled session" test) is pinned `mode: "serial"` in the same file, so it can't race the failing test.
- **`UNSCHEDULED_LIST_LIMIT`/pagination** truncating the list — it's 20, well above the 3 fixture sessions, so not a truncation issue.

I couldn't pin down a concrete, provable root cause, so I didn't want to ship a guess dressed up as a fix. I tried to reproduce it directly:
- 8/8 isolated local runs of just this test passed.
- An attempted concurrent-load repro (`timetable.spec.ts` + `panel.spec.ts` together, `--workers=2`, matching CI's shared-fixture/shared-worker setup) didn't reproduce it either (that run ended up too slow to iterate further within this pass).

Given a single occurrence in ~242 runs, no reproduction after 8 clean runs, and no reproduction under an approximation of CI's concurrency, I'm not confident enough in any specific fix to land one. Per the runbook's fallback, this PR **quarantines the test** (`test.skip` + a comment pointing at the evidence) instead of guessing.

## Test plan

- [x] `npx playwright test tests/timetable.spec.ts --project=chromium --list` shows the test still registers (as skipped), no syntax errors
- [x] `npx tsc --noEmit` in `tests/e2e` shows no *new* errors from this change (pre-existing unrelated errors in other spec files left untouched)
- [x] Pre-commit hooks (oxlint, oxfmt, varlock) pass on the changed file
- [ ] CI green

---
_Generated by [Claude Code](https://claude.ai/code/session_017opr7x9BPF6SMVvEtJMVFx)_