### PR TITLE
Add an individual CLA and the bot that collects it

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -1,0 +1,48 @@
+---
+name: CLA
+
+# pull_request_target, not pull_request: the action needs write access to store
+# the signature, and a pull_request run from a fork does not get it. This
+# workflow checks out no contributor code, so running in the base context is
+# safe here.
+on:
+  issue_comment:
+    types: [ created ]
+  pull_request_target:
+    types: [ opened, synchronize, closed ]
+
+permissions:
+  actions: write
+  contents: write
+  pull-requests: write
+  statuses: write
+
+jobs:
+  cla:
+    runs-on: ubuntu-latest
+    # Only the signing phrase, never every comment on every issue.
+    if: >
+      github.event_name == 'pull_request_target' ||
+      contains(github.event.comment.body, 'I have read the CLA Document')
+    steps:
+      - uses: contributor-assistant/github-action@v2.6.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Needs a classic PAT with repo scope, or a fine-grained token with
+          # contents write. See CLA.md and CONTRIBUTING.md for the one-time setup.
+          PERSONAL_ACCESS_TOKEN: ${{ secrets.CLA_SIGNATURES_TOKEN }}
+        with:
+          path-to-document: https://github.com/zagrajmy/ludamus/blob/main/CLA.md
+          # Signatures live on their own branch so they never appear in a diff
+          # under review.
+          branch: cla-signatures
+          path-to-signatures: signatures/v1/cla.json
+          # Maintainers hold the copyright already; bots cannot agree to
+          # anything.
+          allowlist: fancysnake,hasparus,lprasol,*[bot]
+          custom-notsigned-prcomment: >
+            Thanks for the pull request. Before it can be merged, please read
+            our [Contributor License Agreement](https://github.com/zagrajmy/ludamus/blob/main/CLA.md)
+            and accept it by posting exactly this comment:
+          custom-pr-sign-comment: I have read the CLA Document and I hereby sign the CLA
+          custom-allsigned-prcomment: All contributors have signed the CLA.

--- a/CLA.md
+++ b/CLA.md
@@ -1,0 +1,103 @@
+# Ludamus Individual Contributor License Agreement
+
+Version 1.0
+
+Thank you for contributing to Ludamus. This agreement sets out the terms under
+which your contributions are accepted. It protects you as much as the project:
+it records that you meant to contribute your work, and it gives the project the
+rights it needs to keep distributing that work.
+
+**You keep the copyright in everything you contribute.** This is a licence, not
+a transfer of ownership. You remain free to use, sell, license and distribute
+your own contributions however you like.
+
+You accept this agreement by signing the comment the CLA bot posts on your first
+pull request. Signing applies to all your past and future contributions to this
+project.
+
+## 1. Definitions
+
+**"You"** means the individual who accepts this agreement, or the legal entity
+on whose behalf it is accepted. For a legal entity, all entities that control,
+are controlled by, or are under common control with it are treated as a single
+contributor.
+
+**"Owners"** means Radosław Ganczarek and Piotr Monwid-Olechnowicz, jointly, as
+the holders of copyright in the project.
+
+**"Project"** means Ludamus, the software published at
+<https://github.com/zagrajmy/ludamus>.
+
+**"Contribution"** means any original work of authorship, including any changes
+or additions to existing work, that you intentionally submit to the Project. For
+this definition, "submit" means any form of electronic, verbal or written
+communication sent to the Owners or their representatives, including but not
+limited to pull requests, issues, and messages on communication channels the
+Project uses, but excluding communication that you conspicuously mark, or
+otherwise designate in writing, as "Not a Contribution".
+
+## 2. Copyright licence
+
+You grant the Owners, and to recipients of software distributed by the Owners, a
+perpetual, worldwide, non-exclusive, no-charge, royalty-free and irrevocable
+copyright licence to reproduce, prepare derivative works of, publicly display,
+publicly perform, sublicense and distribute your Contributions and such
+derivative works.
+
+The right to sublicense is what lets the Owners distribute the Project under a
+licence other than its current one — for example to offer it under commercial
+terms alongside the AGPL, or to move the Project to a different licence in
+future without having to ask every contributor again. The Owners may exercise
+that right without further permission from you and without payment to you.
+
+## 3. Patent licence
+
+You grant the Owners, and to recipients of software distributed by the Owners, a
+perpetual, worldwide, non-exclusive, no-charge, royalty-free and irrevocable
+patent licence to make, have made, use, offer to sell, sell, import and
+otherwise transfer the Project. This licence applies only to those patent claims
+you can license that are necessarily infringed by your Contribution alone, or by
+the combination of your Contribution with the Project to which it was submitted.
+
+If any entity institutes patent litigation alleging that your Contribution, or
+the Project it was submitted to, constitutes direct or contributory patent
+infringement, then any patent licences granted to that entity under this
+agreement terminate as of the date such litigation is filed.
+
+## 4. Your representations
+
+You represent that:
+
+1. You are legally entitled to grant the above licences.
+2. Each Contribution is your original creation, or you have the right to submit
+   it under this agreement.
+3. If your employer has rights to intellectual property you create, you have
+   received permission to make Contributions on behalf of that employer, your
+   employer has waived those rights, or your employer has executed a separate
+   corporate agreement with the Owners.
+4. Any third-party material you include is identified as such in your
+   submission, together with its licence and any restrictions it carries.
+
+You are not expected to provide support for your Contributions, and you provide
+them without warranty of any kind, express or implied, except as required by
+law.
+
+You agree to tell the Owners if you become aware that any of these
+representations has become inaccurate.
+
+## 5. Assignment
+
+The Owners may assign this agreement, and the rights granted under it, to a
+legal entity they establish to hold and steward the Project. No further consent
+from you is required, and this agreement then applies as though that entity were
+the Owners.
+
+## 6. Governing law
+
+This agreement is governed by Polish law. Nothing in it limits any rights you
+have under mandatory provisions of the law that applies to you.
+
+---
+
+Adapted from the Apache Software Foundation Individual Contributor License
+Agreement v2.0.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,14 +6,15 @@ rules are in [CLAUDE.md](CLAUDE.md). `mise tasks` lists every command.
 ## Licensing
 
 Ludamus is [AGPL-3.0-only](LICENSE), and contributions come in under the same
-license. By opening a pull request you confirm you wrote the code or have the
-right to submit it, and that you license it under AGPL-3.0-only.
+license. First-time contributors sign our [CLA](CLA.md); a bot posts the link on
+your pull request and you accept in a comment. It takes a minute and covers
+everything you contribute from then on.
 
-You keep your copyright. There is no CLA.
-
-This is written down because relicensing needs every copyright holder's
-agreement, and a project that never recorded who those are has to work it out
-from the commit log afterwards. We did that once already.
+**You keep your copyright.** The CLA is a licence, not a transfer. What it adds
+beyond the AGPL is the right to sublicense, which is what lets the project be
+relicensed or offered on commercial terms later without tracking down every
+contributor. Without it, one unreachable person can freeze the licence forever.
+We reconstructed the holder list from the commit log once; that doesn't scale.
 
 Vendoring or adapting third-party code is fine, say so in the pull request. MIT,
 BSD and Apache-2.0 are compatible; copyleft outside the GPL family usually


### PR DESCRIPTION
Stacked on #787, which adds `CONTRIBUTING.md`. Base retargets to `main` once that merges.

## Why

Without a CLA the project can only ever be AGPL. Selling a non-AGPL licence, or moving off AGPL at all, needs the right to sublicense every contribution, and the AGPL grant alone doesn't give it. Everything else stays possible without one — hosting it, support contracts, sponsorship — so this buys exactly one thing: the option to license the code on terms other than the AGPL.

Adding it later means chasing signatures retroactively or deleting code. It is cheapest right now, while the holder set is two people and nobody outside has contributed.

## What contributors give up

Nothing they own. This is a licence, not a transfer: contributors keep copyright in their work and remain free to use, sell and relicense it themselves. What the project gains over the plain AGPL grant is the right to sublicense.

The cost is friction, and it's real: a bot comments on every first-time pull request, and the project reads as steward-controlled rather than purely communal. That's the trade being made deliberately.

## The grantee problem

A CLA needs someone to grant *to*, and "Zagrajmy" is not a legal entity, so it cannot receive one. The agreement names Radosław Ganczarek and Piotr Monwid-Olechnowicz jointly, as the actual copyright holders.

Clause 5 covers the obvious next step: the Owners may assign the agreement and its rights to a legal entity they establish to steward the project, with no further consent from signatories. Without that clause, incorporating later would mean asking everyone to sign again.

## How it works

`contributor-assistant/github-action` posts a comment on a pull request from anyone who hasn't signed, and the contributor accepts by replying with the phrase. Signatures are stored as JSON on a dedicated `cla-signatures` branch, so they never show up in a diff under review. Maintainers and bots are allowlisted.

Text adapted from the Apache ICLA v2.0, which is the usual starting point and is widely reused. It covers copyright grant, patent grant with a litigation-termination clause, contributor representations including the employer case, and Polish governing law.

## Before this can work

**Add a `CLA_SIGNATURES_TOKEN` repository secret** — a classic PAT with `repo` scope, or a fine-grained token with contents write. The action needs it to commit signatures. Until it exists the workflow will fail on every pull request, so either add the secret when merging or hold the merge until it's there.

## Worth a lawyer

I'm not one. The structure is conventional and the clauses are standard, but this is the document that decides whether you can sell a licence in three years. If real money is ever going to depend on it, half an hour of review is cheap insurance — particularly on clause 5 and the Polish governing-law choice.

---
_Generated by [Claude Code](https://claude.ai/code/session_01RfGafwYHAdfsnYFzeMrmiq)_