### PR TITLE
Reuse mills interval windows for the public midnight split

### DIFF
--- a/src/ludamus/adapters/web/django/views.py
+++ b/src/ludamus/adapters/web/django/views.py
@@ -356,11 +356,7 @@ class EventPageView(DetailView):  # type: ignore [type-arg]
                 "schedule_days": schedule_days,
                 "schedule_view_is_list": not rooms_view,
                 "schedule_view_is_rooms": rooms_view,
-                "room_lane_days": (
-                    build_room_lanes(schedule_days, tz=schedule_tz)
-                    if rooms_view
-                    else []
-                ),
+                "room_lane_days": build_room_lanes(schedule_days) if rooms_view else [],
                 "schedule_list_url": event_url,
                 "schedule_rooms_url": f"{event_url}?view=rooms",
                 "ended_hour_data": ended_hour_data,

--- a/src/ludamus/adapters/web/django/views.py
+++ b/src/ludamus/adapters/web/django/views.py
@@ -18,7 +18,6 @@ from django.shortcuts import redirect
 from django.template.response import TemplateResponse
 from django.urls import reverse
 from django.utils.decorators import method_decorator
-from django.utils.timezone import get_current_timezone
 from django.utils.translation import gettext as _
 from django.views.decorators.cache import cache_control
 from django.views.decorators.vary import vary_on_cookie as vary_cookie
@@ -337,12 +336,7 @@ class EventPageView(DetailView):  # type: ignore [type-arg]
                 group_sessions_by_state(sessions_data)
             )
 
-        schedule_tz = get_current_timezone()
-        schedule_days = (
-            build_schedule_days(sessions_data, tz=schedule_tz)
-            if compact_schedule
-            else []
-        )
+        schedule_days = build_schedule_days(sessions_data) if compact_schedule else []
         # The compact schedule offers two layouts: the chronological ledger
         # (default) and a rooms grid (?view=rooms) with a column per room.
         rooms_view = compact_schedule and self.request.GET.get("view") == "rooms"

--- a/src/ludamus/adapters/web/django/views.py
+++ b/src/ludamus/adapters/web/django/views.py
@@ -18,6 +18,7 @@ from django.shortcuts import redirect
 from django.template.response import TemplateResponse
 from django.urls import reverse
 from django.utils.decorators import method_decorator
+from django.utils.timezone import get_current_timezone
 from django.utils.translation import gettext as _
 from django.views.decorators.cache import cache_control
 from django.views.decorators.vary import vary_on_cookie as vary_cookie
@@ -336,7 +337,12 @@ class EventPageView(DetailView):  # type: ignore [type-arg]
                 group_sessions_by_state(sessions_data)
             )
 
-        schedule_days = build_schedule_days(sessions_data) if compact_schedule else []
+        schedule_tz = get_current_timezone()
+        schedule_days = (
+            build_schedule_days(sessions_data, tz=schedule_tz)
+            if compact_schedule
+            else []
+        )
         # The compact schedule offers two layouts: the chronological ledger
         # (default) and a rooms grid (?view=rooms) with a column per room.
         rooms_view = compact_schedule and self.request.GET.get("view") == "rooms"
@@ -350,7 +356,11 @@ class EventPageView(DetailView):  # type: ignore [type-arg]
                 "schedule_days": schedule_days,
                 "schedule_view_is_list": not rooms_view,
                 "schedule_view_is_rooms": rooms_view,
-                "room_lane_days": build_room_lanes(schedule_days) if rooms_view else [],
+                "room_lane_days": (
+                    build_room_lanes(schedule_days, tz=schedule_tz)
+                    if rooms_view
+                    else []
+                ),
                 "schedule_list_url": event_url,
                 "schedule_rooms_url": f"{event_url}?view=rooms",
                 "ended_hour_data": ended_hour_data,

--- a/src/ludamus/gates/web/django/chronology/schedule.py
+++ b/src/ludamus/gates/web/django/chronology/schedule.py
@@ -4,6 +4,7 @@ from collections import Counter, defaultdict
 from dataclasses import dataclass
 from datetime import UTC, datetime, timedelta
 from math import ceil
+from operator import itemgetter
 from typing import TYPE_CHECKING
 
 from django.utils import timezone
@@ -48,22 +49,42 @@ class RoomLaneDay:
     tiles: list[RoomLaneTile]
 
 
+def _next_local_midnight(moment: datetime) -> datetime:
+    return timezone.localtime(moment + timedelta(days=1)).replace(
+        hour=0, minute=0, second=0, microsecond=0
+    )
+
+
+def _local_day_segments(start: datetime, end: datetime) -> list[datetime]:
+    # Where the session starts on each local date it covers: its own start on
+    # the first date, midnight on every later one. Night program belongs to
+    # both sides of midnight, so it shows up on both days.
+    local_start = timezone.localtime(start)
+    local_end = timezone.localtime(end)
+    segments = [local_start]
+    midnight = _next_local_midnight(local_start)
+    while midnight < local_end:
+        segments.append(midnight)
+        midnight = _next_local_midnight(midnight)
+    return segments
+
+
 def build_schedule_days(sessions_data: dict[int, SessionData]) -> list[ScheduleDay]:
-    days: list[ScheduleDay] = []
+    by_hour: dict[datetime, list[tuple[datetime, SessionData]]] = defaultdict(list)
     for data in sessions_data.values():
         if data.agenda_item is None:
             continue
-        start = data.agenda_item.start_time
-        local_start = timezone.localtime(start)
-        if not days or timezone.localtime(days[-1].first_start).date() != (
-            local_start.date()
-        ):
-            days.append(ScheduleDay(first_start=start, hours=[]))
-        hours = days[-1].hours
-        hour_start = local_start.replace(minute=0, second=0, microsecond=0)
-        if not hours or hours[-1].start != hour_start:
-            hours.append(ScheduleHour(start=hour_start, sessions=[]))
-        hours[-1].sessions.append(data)
+        item = data.agenda_item
+        for segment_start in _local_day_segments(item.start_time, item.end_time):
+            hour_start = segment_start.replace(minute=0, second=0, microsecond=0)
+            by_hour[hour_start].append((item.start_time, data))
+
+    days: list[ScheduleDay] = []
+    for hour_start in sorted(by_hour):
+        sessions = [data for _, data in sorted(by_hour[hour_start], key=itemgetter(0))]
+        if not days or days[-1].first_start.date() != hour_start.date():
+            days.append(ScheduleDay(first_start=hour_start, hours=[]))
+        days[-1].hours.append(ScheduleHour(start=hour_start, sessions=sessions))
     return days
 
 
@@ -116,11 +137,17 @@ def build_room_lanes(schedule_days: list[ScheduleDay]) -> list[RoomLaneDay]:
         col_index = {key: index + 1 for index, key in enumerate(keys)}
 
         day_start = day.hours[0].start
-        day_end = max(
-            data.agenda_item.end_time
-            for hour in day.hours
-            for data in hour.sessions
-            if data.agenda_item is not None
+        # The day's lanes stop at midnight; the rest of a night session is
+        # drawn again on the day it runs into.
+        day_limit = _next_local_midnight(day_start)
+        day_end = min(
+            day_limit,
+            max(
+                data.agenda_item.end_time
+                for hour in day.hours
+                for data in hour.sessions
+                if data.agenda_item is not None
+            ),
         )
         hour_count = ceil((day_end - day_start).total_seconds() / 3600)
         session_hours = {hour.start for hour in day.hours}
@@ -144,8 +171,10 @@ def build_room_lanes(schedule_days: list[ScheduleDay]) -> list[RoomLaneDay]:
                     data.loc["parent_slug"],
                     data.loc["parent_name"],
                 )
-                start_hour = int((item.start_time - day_start).total_seconds() // 3600)
-                end_offset = (item.end_time - day_start).total_seconds() / 3600
+                visible_start = max(item.start_time, day_start)
+                visible_end = min(item.end_time, day_limit)
+                start_hour = int((visible_start - day_start).total_seconds() // 3600)
+                end_offset = (visible_end - day_start).total_seconds() / 3600
                 span = max(1, ceil(end_offset) - start_hour)
                 tiles.append(
                     RoomLaneTile(

--- a/src/ludamus/gates/web/django/chronology/schedule.py
+++ b/src/ludamus/gates/web/django/chronology/schedule.py
@@ -7,6 +7,8 @@ from math import ceil
 from operator import itemgetter
 from typing import TYPE_CHECKING
 
+from django.utils.timezone import get_current_timezone
+
 from ludamus.mills.timeslots import SlotWindow, interval_windows
 
 if TYPE_CHECKING:
@@ -51,28 +53,31 @@ class RoomLaneDay:
 
 
 def build_schedule_days(
-    sessions_data: dict[int, SessionData], *, tz: tzinfo
+    sessions_data: dict[int, SessionData], *, tz: tzinfo | None = None
 ) -> list[ScheduleDay]:
-    by_hour: dict[datetime, list[tuple[datetime, SessionData, SlotWindow]]] = (
+    zone = get_current_timezone() if tz is None else tz
+    by_hour: dict[datetime, list[tuple[datetime, SessionData, SlotWindow, int]]] = (
         defaultdict(list)
     )
     for data in sessions_data.values():
-        if data.agenda_item is None:
+        if (item := data.agenda_item) is None:
             continue
-        item = data.agenda_item
-        for window in interval_windows(start=item.start_time, end=item.end_time, tz=tz):
-            hour_start = window[0].replace(minute=0, second=0, microsecond=0)
-            by_hour[hour_start].append((item.start_time, data, window))
+        for window in interval_windows(
+            start=item.start_time, end=item.end_time, tz=zone
+        ):
+            hour = window[0].replace(minute=0, second=0, microsecond=0)
+            by_hour[hour].append((item.start_time, data, window, item.pk))
 
     days: list[ScheduleDay] = []
-    for hour_start in sorted(by_hour):
-        entries = sorted(by_hour[hour_start], key=itemgetter(0))
-        sessions = [data for _, data, _ in entries]
-        if not days or days[-1].first_start.date() != hour_start.date():
-            days.append(ScheduleDay(first_start=hour_start, hours=[], windows={}))
-        for _, data, window in entries:
-            days[-1].windows[data.agenda_item.pk] = window
-        days[-1].hours.append(ScheduleHour(start=hour_start, sessions=sessions))
+    for hour in sorted(by_hour):
+        entries = sorted(by_hour[hour], key=itemgetter(0))
+        if not days or days[-1].first_start.date() != hour.date():
+            days.append(ScheduleDay(first_start=hour, hours=[]))
+        day = days[-1]
+        day.windows.update((pk, window) for _, _, window, pk in entries)
+        day.hours.append(
+            ScheduleHour(start=hour, sessions=[data for _, data, _, _ in entries])
+        )
     return days
 
 
@@ -83,47 +88,37 @@ def group_sessions_by_state(
     dict[datetime, list[SessionData]],
     dict[datetime, list[SessionData]],
 ]:
-    current_time = datetime.now(tz=UTC)
+    now = datetime.now(tz=UTC)
     ended: dict[datetime, list[SessionData]] = defaultdict(list)
     current: dict[datetime, list[SessionData]] = defaultdict(list)
     future_unavailable: dict[datetime, list[SessionData]] = defaultdict(list)
-    for session_data in sessions_data.values():
-        if session_data.agenda_item is None:
+    for data in sessions_data.values():
+        if data.agenda_item is None:
             continue
-        session_start_time = session_data.agenda_item.start_time
-        if session_data.agenda_item.end_time <= current_time:
-            ended[session_start_time].append(session_data)
-        elif (
-            not session_data.is_enrollment_available
-            and session_start_time > current_time
-        ):
-            future_unavailable[session_start_time].append(session_data)
+        start = data.agenda_item.start_time
+        if data.agenda_item.end_time <= now:
+            ended[start].append(data)
+        elif not data.is_enrollment_available and start > now:
+            future_unavailable[start].append(data)
         else:
-            current[session_start_time].append(session_data)
+            current[start].append(data)
     return dict(ended), dict(current), dict(future_unavailable)
+
+
+def _room_key(data: SessionData) -> tuple[str, str, str]:
+    return data.loc["space_name"], data.loc["parent_slug"], data.loc["parent_name"]
 
 
 def build_room_lanes(schedule_days: list[ScheduleDay]) -> list[RoomLaneDay]:
     lane_days: list[RoomLaneDay] = []
     for day in schedule_days:
-        keys = sorted(
-            {
-                (
-                    data.loc["space_name"],
-                    data.loc["parent_slug"],
-                    data.loc["parent_name"],
-                )
-                for hour in day.hours
-                for data in hour.sessions
-            }
-        )
+        keys = sorted({_room_key(data) for hour in day.hours for data in hour.sessions})
         name_counts = Counter(name for name, _, _ in keys)
         rooms = [
             f"{name} ({parent})" if name_counts[name] > 1 and parent else name
             for name, _, parent in keys
         ]
         col_index = {key: index + 1 for index, key in enumerate(keys)}
-
         day_start = day.hours[0].start
         session_hours = {hour.start for hour in day.hours}
         tiles: list[RoomLaneTile] = []
@@ -132,41 +127,33 @@ def build_room_lanes(schedule_days: list[ScheduleDay]) -> list[RoomLaneDay]:
             for data in hour.sessions:
                 if data.agenda_item is None:
                     continue
-                key = (
-                    data.loc["space_name"],
-                    data.loc["parent_slug"],
-                    data.loc["parent_name"],
-                )
                 visible_start, visible_end = day.windows[data.agenda_item.pk]
                 day_end = max(day_end, visible_end)
                 start_hour = int((visible_start - day_start).total_seconds() // 3600)
-                end_offset = (visible_end - day_start).total_seconds() / 3600
-                span = max(1, ceil(end_offset) - start_hour)
+                span = max(
+                    1,
+                    ceil((visible_end - day_start).total_seconds() / 3600) - start_hour,
+                )
                 tiles.append(
                     RoomLaneTile(
                         data=data,
                         slot_hour=hour.start,
-                        col=col_index[key],
+                        col=col_index[_room_key(data)],
                         row_start=start_hour + 1,
                         row_span=span,
                     )
                 )
-
-        hour_count = ceil((day_end - day_start).total_seconds() / 3600)
-        hour_marks = [
+        marks = [
             RoomLaneHourMark(
                 start=(mark := day_start + timedelta(hours=offset)),
                 row=offset + 1,
                 has_sessions=mark in session_hours,
             )
-            for offset in range(hour_count)
+            for offset in range(ceil((day_end - day_start).total_seconds() / 3600))
         ]
         lane_days.append(
             RoomLaneDay(
-                first_start=day.first_start,
-                rooms=rooms,
-                hour_marks=hour_marks,
-                tiles=tiles,
+                first_start=day.first_start, rooms=rooms, hour_marks=marks, tiles=tiles
             )
         )
     return lane_days

--- a/src/ludamus/gates/web/django/chronology/schedule.py
+++ b/src/ludamus/gates/web/django/chronology/schedule.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
 from collections import Counter, defaultdict
-from dataclasses import dataclass
-from datetime import UTC, date, datetime, timedelta, tzinfo
+from dataclasses import dataclass, field
+from datetime import UTC, datetime, timedelta, tzinfo
 from math import ceil
 from operator import itemgetter
 from typing import TYPE_CHECKING
@@ -23,6 +23,7 @@ class ScheduleHour:
 class ScheduleDay:
     first_start: datetime
     hours: list[ScheduleHour]
+    windows: dict[int, SlotWindow] = field(default_factory=dict)
 
 
 @dataclass
@@ -49,35 +50,28 @@ class RoomLaneDay:
     tiles: list[RoomLaneTile]
 
 
-def _window_on_date(
-    *, start: datetime, end: datetime, tz: tzinfo, day: date
-) -> SlotWindow:
-    for window in interval_windows(start=start, end=end, tz=tz):
-        if window[0].date() == day:
-            return window
-    msg = f"interval {start}..{end} has no window on {day}"
-    raise ValueError(msg)
-
-
 def build_schedule_days(
     sessions_data: dict[int, SessionData], *, tz: tzinfo
 ) -> list[ScheduleDay]:
-    by_hour: dict[datetime, list[tuple[datetime, SessionData]]] = defaultdict(list)
+    by_hour: dict[datetime, list[tuple[datetime, SessionData, SlotWindow]]] = (
+        defaultdict(list)
+    )
     for data in sessions_data.values():
         if data.agenda_item is None:
             continue
         item = data.agenda_item
-        for window_start, _window_end in interval_windows(
-            start=item.start_time, end=item.end_time, tz=tz
-        ):
-            hour_start = window_start.replace(minute=0, second=0, microsecond=0)
-            by_hour[hour_start].append((item.start_time, data))
+        for window in interval_windows(start=item.start_time, end=item.end_time, tz=tz):
+            hour_start = window[0].replace(minute=0, second=0, microsecond=0)
+            by_hour[hour_start].append((item.start_time, data, window))
 
     days: list[ScheduleDay] = []
     for hour_start in sorted(by_hour):
-        sessions = [data for _, data in sorted(by_hour[hour_start], key=itemgetter(0))]
+        entries = sorted(by_hour[hour_start], key=itemgetter(0))
+        sessions = [data for _, data, _ in entries]
         if not days or days[-1].first_start.date() != hour_start.date():
-            days.append(ScheduleDay(first_start=hour_start, hours=[]))
+            days.append(ScheduleDay(first_start=hour_start, hours=[], windows={}))
+        for _, data, window in entries:
+            days[-1].windows[data.agenda_item.pk] = window
         days[-1].hours.append(ScheduleHour(start=hour_start, sessions=sessions))
     return days
 
@@ -109,9 +103,7 @@ def group_sessions_by_state(
     return dict(ended), dict(current), dict(future_unavailable)
 
 
-def build_room_lanes(
-    schedule_days: list[ScheduleDay], *, tz: tzinfo
-) -> list[RoomLaneDay]:
+def build_room_lanes(schedule_days: list[ScheduleDay]) -> list[RoomLaneDay]:
     lane_days: list[RoomLaneDay] = []
     for day in schedule_days:
         keys = sorted(
@@ -133,7 +125,6 @@ def build_room_lanes(
         col_index = {key: index + 1 for index, key in enumerate(keys)}
 
         day_start = day.hours[0].start
-        day_date = day_start.date()
         session_hours = {hour.start for hour in day.hours}
         tiles: list[RoomLaneTile] = []
         day_end = day_start
@@ -141,15 +132,12 @@ def build_room_lanes(
             for data in hour.sessions:
                 if data.agenda_item is None:
                     continue
-                item = data.agenda_item
                 key = (
                     data.loc["space_name"],
                     data.loc["parent_slug"],
                     data.loc["parent_name"],
                 )
-                visible_start, visible_end = _window_on_date(
-                    start=item.start_time, end=item.end_time, tz=tz, day=day_date
-                )
+                visible_start, visible_end = day.windows[data.agenda_item.pk]
                 day_end = max(day_end, visible_end)
                 start_hour = int((visible_start - day_start).total_seconds() // 3600)
                 end_offset = (visible_end - day_start).total_seconds() / 3600

--- a/src/ludamus/gates/web/django/chronology/schedule.py
+++ b/src/ludamus/gates/web/django/chronology/schedule.py
@@ -2,12 +2,12 @@ from __future__ import annotations
 
 from collections import Counter, defaultdict
 from dataclasses import dataclass
-from datetime import UTC, datetime, timedelta
+from datetime import UTC, date, datetime, timedelta, tzinfo
 from math import ceil
 from operator import itemgetter
 from typing import TYPE_CHECKING
 
-from django.utils import timezone
+from ludamus.mills.timeslots import SlotWindow, interval_windows
 
 if TYPE_CHECKING:
     from ludamus.gates.web.django.chronology.event_presentation import SessionData
@@ -49,34 +49,28 @@ class RoomLaneDay:
     tiles: list[RoomLaneTile]
 
 
-def _next_local_midnight(moment: datetime) -> datetime:
-    return timezone.localtime(moment + timedelta(days=1)).replace(
-        hour=0, minute=0, second=0, microsecond=0
-    )
+def _window_on_date(
+    *, start: datetime, end: datetime, tz: tzinfo, day: date
+) -> SlotWindow:
+    for window in interval_windows(start=start, end=end, tz=tz):
+        if window[0].date() == day:
+            return window
+    msg = f"interval {start}..{end} has no window on {day}"
+    raise ValueError(msg)
 
 
-def _local_day_segments(start: datetime, end: datetime) -> list[datetime]:
-    # Where the session starts on each local date it covers: its own start on
-    # the first date, midnight on every later one. Night program belongs to
-    # both sides of midnight, so it shows up on both days.
-    local_start = timezone.localtime(start)
-    local_end = timezone.localtime(end)
-    segments = [local_start]
-    midnight = _next_local_midnight(local_start)
-    while midnight < local_end:
-        segments.append(midnight)
-        midnight = _next_local_midnight(midnight)
-    return segments
-
-
-def build_schedule_days(sessions_data: dict[int, SessionData]) -> list[ScheduleDay]:
+def build_schedule_days(
+    sessions_data: dict[int, SessionData], *, tz: tzinfo
+) -> list[ScheduleDay]:
     by_hour: dict[datetime, list[tuple[datetime, SessionData]]] = defaultdict(list)
     for data in sessions_data.values():
         if data.agenda_item is None:
             continue
         item = data.agenda_item
-        for segment_start in _local_day_segments(item.start_time, item.end_time):
-            hour_start = segment_start.replace(minute=0, second=0, microsecond=0)
+        for window_start, _window_end in interval_windows(
+            start=item.start_time, end=item.end_time, tz=tz
+        ):
+            hour_start = window_start.replace(minute=0, second=0, microsecond=0)
             by_hour[hour_start].append((item.start_time, data))
 
     days: list[ScheduleDay] = []
@@ -115,7 +109,9 @@ def group_sessions_by_state(
     return dict(ended), dict(current), dict(future_unavailable)
 
 
-def build_room_lanes(schedule_days: list[ScheduleDay]) -> list[RoomLaneDay]:
+def build_room_lanes(
+    schedule_days: list[ScheduleDay], *, tz: tzinfo
+) -> list[RoomLaneDay]:
     lane_days: list[RoomLaneDay] = []
     for day in schedule_days:
         keys = sorted(
@@ -137,30 +133,10 @@ def build_room_lanes(schedule_days: list[ScheduleDay]) -> list[RoomLaneDay]:
         col_index = {key: index + 1 for index, key in enumerate(keys)}
 
         day_start = day.hours[0].start
-        # The day's lanes stop at midnight; the rest of a night session is
-        # drawn again on the day it runs into.
-        day_limit = _next_local_midnight(day_start)
-        day_end = min(
-            day_limit,
-            max(
-                data.agenda_item.end_time
-                for hour in day.hours
-                for data in hour.sessions
-                if data.agenda_item is not None
-            ),
-        )
-        hour_count = ceil((day_end - day_start).total_seconds() / 3600)
+        day_date = day_start.date()
         session_hours = {hour.start for hour in day.hours}
-        hour_marks = [
-            RoomLaneHourMark(
-                start=(mark := day_start + timedelta(hours=offset)),
-                row=offset + 1,
-                has_sessions=mark in session_hours,
-            )
-            for offset in range(hour_count)
-        ]
-
-        tiles = []
+        tiles: list[RoomLaneTile] = []
+        day_end = day_start
         for hour in day.hours:
             for data in hour.sessions:
                 if data.agenda_item is None:
@@ -171,8 +147,10 @@ def build_room_lanes(schedule_days: list[ScheduleDay]) -> list[RoomLaneDay]:
                     data.loc["parent_slug"],
                     data.loc["parent_name"],
                 )
-                visible_start = max(item.start_time, day_start)
-                visible_end = min(item.end_time, day_limit)
+                visible_start, visible_end = _window_on_date(
+                    start=item.start_time, end=item.end_time, tz=tz, day=day_date
+                )
+                day_end = max(day_end, visible_end)
                 start_hour = int((visible_start - day_start).total_seconds() // 3600)
                 end_offset = (visible_end - day_start).total_seconds() / 3600
                 span = max(1, ceil(end_offset) - start_hour)
@@ -185,6 +163,16 @@ def build_room_lanes(schedule_days: list[ScheduleDay]) -> list[RoomLaneDay]:
                         row_span=span,
                     )
                 )
+
+        hour_count = ceil((day_end - day_start).total_seconds() / 3600)
+        hour_marks = [
+            RoomLaneHourMark(
+                start=(mark := day_start + timedelta(hours=offset)),
+                row=offset + 1,
+                has_sessions=mark in session_hours,
+            )
+            for offset in range(hour_count)
+        ]
         lane_days.append(
             RoomLaneDay(
                 first_start=day.first_start,

--- a/src/ludamus/mills/timeslots.py
+++ b/src/ludamus/mills/timeslots.py
@@ -1,8 +1,9 @@
-"""Shared time-slot helpers for the chronology and printing mills.
+"""Shared local-day window helpers for chronology mills and schedule gates.
 
 Time slots are proposer availability windows ("when could you run your
 session?"), not schedule display units — rendered timetables show the real
-session start and end times instead.
+session start and end times instead. Both still need the same local-midnight
+split, so the pure interval math lives here.
 """
 
 from __future__ import annotations
@@ -17,11 +18,9 @@ if TYPE_CHECKING:
 type SlotWindow = tuple[datetime, datetime]
 
 
-def slot_windows(slot: TimeSlotDTO, tz: tzinfo) -> list[SlotWindow]:
-    # A slot spanning multiple local dates contributes one (start, end) window
-    # to each date it touches, clamped to that date's [00:00, 24:00) range.
-    local_start = slot.start_time.astimezone(tz)
-    local_end = slot.end_time.astimezone(tz)
+def interval_windows(*, start: datetime, end: datetime, tz: tzinfo) -> list[SlotWindow]:
+    local_start = start.astimezone(tz)
+    local_end = end.astimezone(tz)
     windows: list[SlotWindow] = []
     days_span = (local_end.date() - local_start.date()).days + 1
     for offset in range(days_span):
@@ -33,6 +32,10 @@ def slot_windows(slot: TimeSlotDTO, tz: tzinfo) -> list[SlotWindow]:
         if window_start < window_end:
             windows.append((window_start, window_end))
     return windows
+
+
+def slot_windows(slot: TimeSlotDTO, tz: tzinfo) -> list[SlotWindow]:
+    return interval_windows(start=slot.start_time, end=slot.end_time, tz=tz)
 
 
 def slot_windows_by_local_date(

--- a/src/ludamus/mills/timetable.py
+++ b/src/ludamus/mills/timetable.py
@@ -3,7 +3,7 @@ from collections import defaultdict
 from datetime import date, datetime, timedelta, tzinfo
 from typing import TYPE_CHECKING, NamedTuple
 
-from ludamus.mills.timeslots import SlotWindow, slot_windows, slot_windows_by_local_date
+from ludamus.mills.timeslots import slot_windows_by_local_date
 from ludamus.pacts import (
     AgendaItemDTO,
     NotFoundError,
@@ -43,29 +43,9 @@ from ludamus.specs.timetable import (
 if TYPE_CHECKING:
     from ludamus.pacts import FacilitatorDTO, SpaceDTO, TimeSlotDTO, UnitOfWorkProtocol
 
-_WINDOWS_ACROSS_ONE_MIDNIGHT = 2
-
-
-def _slot_windows_by_grid_date(
-    slots: list[TimeSlotDTO], tz: tzinfo
-) -> dict[date, list[SlotWindow]]:
-    # A slot that crosses one midnight — exactly two per-date windows — stays
-    # whole on the day it starts, so night program extends that day's column
-    # past 24:00. Splitting it would mint a 00:00-anchored phantom day and
-    # stretch the grid's shared time axis to a full 24 hours. Slots touching
-    # more dates keep the per-date windows.
-    grouped: dict[date, list[SlotWindow]] = defaultdict(list)
-    for slot in slots:
-        windows = slot_windows(slot, tz)
-        if len(windows) == _WINDOWS_ACROSS_ONE_MIDNIGHT:
-            windows = [(windows[0][0], windows[1][1])]
-        for window in windows:
-            grouped[window[0].date()].append(window)
-    return grouped
-
 
 def _position_sessions(
-    items: list[AgendaItemDTO], event_start: datetime
+    *, items: list[AgendaItemDTO], grid_start: datetime, grid_end: datetime
 ) -> list[SessionPositionDTO]:
     if not items:
         return []
@@ -89,13 +69,20 @@ def _position_sessions(
     for group in groups:
         lane_width_pct = 100.0 / len(group)
         for index, item in enumerate(group):
-            offset_min = (item.start_time - event_start).total_seconds() / 60
+            # A session crossing midnight renders on every day it touches,
+            # clipped to that day's range; `duration_minutes` stays the real
+            # length so a drag reschedules the whole session, not the fragment.
+            visible_start = max(item.start_time, grid_start)
+            visible_end = min(item.end_time, grid_end)
+            offset_min = (visible_start - grid_start).total_seconds() / 60
             duration_min = (item.end_time - item.start_time).total_seconds() / 60
+            visible_min = (visible_end - visible_start).total_seconds() / 60
             positions.append(
                 SessionPositionDTO(
                     agenda_item=item,
                     start_minutes=round(offset_min),
                     duration_minutes=round(duration_min),
+                    visible_minutes=round(visible_min),
                     lane_start_pct=index * lane_width_pct,
                     lane_width_pct=lane_width_pct,
                 )
@@ -152,7 +139,7 @@ class TimetableService:
         spaces = leaf_spaces[start : start + TIMETABLE_ROOM_PAGE_SIZE]
 
         all_slots = self._uow.time_slots.list_by_event(event_pk)
-        windows_by_date = _slot_windows_by_grid_date(all_slots, tz)
+        windows_by_date = slot_windows_by_local_date(all_slots, tz)
         available_dates = sorted(windows_by_date)
         if date_selection != "all" and date_selection not in windows_by_date:
             date_selection = available_dates[0] if available_dates else "all"
@@ -179,12 +166,6 @@ class TimetableService:
         for index, date_to_render in enumerate(dates_to_render):
             range_start = day_range_starts[index]
             range_end = range_start + timedelta(minutes=total_minutes)
-            # Past-midnight ranges can reach into the next rendered day. The
-            # next day owns everything from its own range start, so capping
-            # here makes the day filters a partition — a night session never
-            # renders in two columns.
-            if index + 1 < len(day_range_starts):
-                range_end = min(range_end, day_range_starts[index + 1])
             days.append(
                 self._build_day_grid(
                     date_to_render=date_to_render,
@@ -252,7 +233,7 @@ class TimetableService:
                 SpaceColumnDTO(
                     space=space,
                     sessions=_position_sessions(
-                        items_for_space, event_start=grid_start
+                        items=items_for_space, grid_start=grid_start, grid_end=grid_end
                     ),
                 )
             )

--- a/src/ludamus/pacts/chronology.py
+++ b/src/ludamus/pacts/chronology.py
@@ -382,8 +382,6 @@ class SessionPositionDTO(BaseModel):
     agenda_item: AgendaItemDTO
     start_minutes: int
     duration_minutes: int
-    # What this day's column shows: the same as duration_minutes, except for a
-    # session clipped by midnight, which also renders on the next day.
     visible_minutes: int
     lane_start_pct: float = 0.0
     lane_width_pct: float = 100.0

--- a/src/ludamus/pacts/chronology.py
+++ b/src/ludamus/pacts/chronology.py
@@ -382,6 +382,9 @@ class SessionPositionDTO(BaseModel):
     agenda_item: AgendaItemDTO
     start_minutes: int
     duration_minutes: int
+    # What this day's column shows: the same as duration_minutes, except for a
+    # session clipped by midnight, which also renders on the next day.
+    visible_minutes: int
     lane_start_pct: float = 0.0
     lane_width_pct: float = 100.0
 

--- a/src/ludamus/templates/panel/parts/timetable-day-grid.html
+++ b/src/ludamus/templates/panel/parts/timetable-day-grid.html
@@ -20,7 +20,7 @@
                      data-confirmed="{{ pos.agenda_item.session_confirmed|yesno:'true,false' }}"
                      title="{{ pos.agenda_item.session_title }}"
                      style="--offset: {{ pos.start_minutes }};
-                            --duration: {{ pos.duration_minutes }};
+                            --duration: {{ pos.visible_minutes }};
                             --lane-start: {{ pos.lane_start_pct }}%;
                             --lane-width: {{ pos.lane_width_pct }}%"
                      hx-get="{% url 'panel:timetable-session-detail-part' slug=slug pk=pos.agenda_item.session_id %}?track={{ filter_track_pk|default:'' }}&date={{ date_value }}"
@@ -39,10 +39,10 @@
                             {% endif %}
                             {{ pos.agenda_item.session_title|truncatechars:256 }}
                         </div>
-                        <div class="timetable-session-meta timetable-session-presenter wrap-anywhere {% if pos.agenda_item.session_id in conflict_session_pks %}text-danger{% elif pos.agenda_item.session_id in slot_violation_session_pks %}text-warning{% else %}text-info{% endif %} {% if pos.duration_minutes <= 32 %}hidden{% endif %}">
+                        <div class="timetable-session-meta timetable-session-presenter wrap-anywhere {% if pos.agenda_item.session_id in conflict_session_pks %}text-danger{% elif pos.agenda_item.session_id in slot_violation_session_pks %}text-warning{% else %}text-info{% endif %} {% if pos.visible_minutes <= 32 %}hidden{% endif %}">
                             {{ pos.agenda_item.presenter_name }}
                         </div>
-                        <div class="timetable-session-meta timetable-session-duration {% if pos.agenda_item.session_id in conflict_session_pks %}text-danger{% elif pos.agenda_item.session_id in slot_violation_session_pks %}text-warning{% else %}text-info{% endif %} {% if pos.duration_minutes <= 52 %}hidden{% endif %}">
+                        <div class="timetable-session-meta timetable-session-duration {% if pos.agenda_item.session_id in conflict_session_pks %}text-danger{% elif pos.agenda_item.session_id in slot_violation_session_pks %}text-warning{% else %}text-info{% endif %} {% if pos.visible_minutes <= 52 %}hidden{% endif %}">
                             {{ pos.agenda_item.session_duration_minutes }} min
                         </div>
                     </div>

--- a/tests/integration/web/chronology/test_event_page.py
+++ b/tests/integration/web/chronology/test_event_page.py
@@ -215,7 +215,7 @@ class TestEventPageView:
             minute=0, second=0, microsecond=0
         )
         schedule_day = ScheduleDay(
-            first_start=agenda_item.start_time,
+            first_start=hour_start,
             hours=[ScheduleHour(start=hour_start, sessions=[session_data])],
         )
         url = self._get_url(event.slug)
@@ -331,7 +331,7 @@ class TestEventPageView:
             minute=0, second=0, microsecond=0
         )
         schedule_day = ScheduleDay(
-            first_start=agenda_item.start_time,
+            first_start=hour_start,
             hours=[ScheduleHour(start=hour_start, sessions=[session_data])],
         )
         url = self._get_url(event.slug)
@@ -654,7 +654,7 @@ class TestEventPageView:
             minute=0, second=0, microsecond=0
         )
         schedule_day = ScheduleDay(
-            first_start=agenda_item.start_time,
+            first_start=hour_start,
             hours=[ScheduleHour(start=hour_start, sessions=[session_data])],
         )
         url = self._get_url(event.slug)

--- a/tests/integration/web/chronology/test_event_page.py
+++ b/tests/integration/web/chronology/test_event_page.py
@@ -217,6 +217,12 @@ class TestEventPageView:
         schedule_day = ScheduleDay(
             first_start=hour_start,
             hours=[ScheduleHour(start=hour_start, sessions=[session_data])],
+            windows={
+                agenda_item.pk: (
+                    timezone.localtime(agenda_item.start_time),
+                    timezone.localtime(agenda_item.end_time),
+                )
+            },
         )
         url = self._get_url(event.slug)
         assert_response(
@@ -333,6 +339,12 @@ class TestEventPageView:
         schedule_day = ScheduleDay(
             first_start=hour_start,
             hours=[ScheduleHour(start=hour_start, sessions=[session_data])],
+            windows={
+                agenda_item.pk: (
+                    timezone.localtime(agenda_item.start_time),
+                    timezone.localtime(agenda_item.end_time),
+                )
+            },
         )
         url = self._get_url(event.slug)
         assert_response(
@@ -656,6 +668,12 @@ class TestEventPageView:
         schedule_day = ScheduleDay(
             first_start=hour_start,
             hours=[ScheduleHour(start=hour_start, sessions=[session_data])],
+            windows={
+                agenda_item.pk: (
+                    timezone.localtime(agenda_item.start_time),
+                    timezone.localtime(agenda_item.end_time),
+                )
+            },
         )
         url = self._get_url(event.slug)
         assert_response(

--- a/tests/unit/gates/web/django/chronology/test_presentation.py
+++ b/tests/unit/gates/web/django/chronology/test_presentation.py
@@ -1,9 +1,9 @@
 import sys
 from datetime import UTC, datetime
 from unittest.mock import MagicMock
+from zoneinfo import ZoneInfo
 
 import pytest
-from django.utils import timezone
 
 from ludamus.gates.web.django.chronology.event_presentation import SessionData
 from ludamus.gates.web.django.chronology.schedule import (
@@ -13,6 +13,8 @@ from ludamus.gates.web.django.chronology.schedule import (
 )
 from ludamus.pacts import AgendaItemDTO
 from ludamus.pacts.legacy import SessionFieldValueDTO
+
+_SCHEDULE_TZ = ZoneInfo("Europe/Warsaw")
 
 
 def _make_session_data(
@@ -177,7 +179,7 @@ class TestBuildScheduleDays:
             )
         )
 
-        days = build_schedule_days({1: pending, 2: scheduled})
+        days = build_schedule_days({1: pending, 2: scheduled}, tz=_SCHEDULE_TZ)
 
         assert len(days) == 1
         assert days[0].hours[0].sessions == [scheduled]
@@ -185,17 +187,16 @@ class TestBuildScheduleDays:
     def test_only_pending_proposals_yield_no_days(self):
         pending = _make_session_data(agenda_item=None)
 
-        assert not build_schedule_days({1: pending})
+        assert not build_schedule_days({1: pending}, tz=_SCHEDULE_TZ)
 
 
 class TestNightSessions:
     @staticmethod
     def _night_session() -> SessionData:
-        tz = timezone.get_current_timezone()
         return _make_session_data(
             agenda_item=AgendaItemDTO(
-                start_time=datetime(2026, 7, 10, 22, tzinfo=tz),
-                end_time=datetime(2026, 7, 11, 2, tzinfo=tz),
+                start_time=datetime(2026, 7, 10, 22, tzinfo=_SCHEDULE_TZ),
+                end_time=datetime(2026, 7, 11, 2, tzinfo=_SCHEDULE_TZ),
                 pk=1,
                 session_confirmed=True,
             ),
@@ -205,13 +206,16 @@ class TestNightSessions:
     def test_session_crossing_midnight_lands_on_both_days(self):
         night = self._night_session()
 
-        days = build_schedule_days({1: night})
+        days = build_schedule_days({1: night}, tz=_SCHEDULE_TZ)
 
         assert [[hour.start.hour for hour in day.hours] for day in days] == [[22], [0]]
         assert [day.hours[0].sessions for day in days] == [[night], [night]]
 
     def test_room_lanes_clip_the_night_session_at_midnight(self):
-        days = build_room_lanes(build_schedule_days({1: self._night_session()}))
+        days = build_room_lanes(
+            build_schedule_days({1: self._night_session()}, tz=_SCHEDULE_TZ),
+            tz=_SCHEDULE_TZ,
+        )
 
         assert [[mark.start.hour for mark in day.hour_marks] for day in days] == [
             [22, 23],

--- a/tests/unit/gates/web/django/chronology/test_presentation.py
+++ b/tests/unit/gates/web/django/chronology/test_presentation.py
@@ -3,9 +3,11 @@ from datetime import UTC, datetime
 from unittest.mock import MagicMock
 
 import pytest
+from django.utils import timezone
 
 from ludamus.gates.web.django.chronology.event_presentation import SessionData
 from ludamus.gates.web.django.chronology.schedule import (
+    build_room_lanes,
     build_schedule_days,
     group_sessions_by_state,
 )
@@ -184,6 +186,40 @@ class TestBuildScheduleDays:
         pending = _make_session_data(agenda_item=None)
 
         assert not build_schedule_days({1: pending})
+
+
+class TestNightSessions:
+    @staticmethod
+    def _night_session() -> SessionData:
+        tz = timezone.get_current_timezone()
+        return _make_session_data(
+            agenda_item=AgendaItemDTO(
+                start_time=datetime(2026, 7, 10, 22, tzinfo=tz),
+                end_time=datetime(2026, 7, 11, 2, tzinfo=tz),
+                pk=1,
+                session_confirmed=True,
+            ),
+            loc={"space_name": "Sala A", "parent_slug": "hall", "parent_name": "Hall"},
+        )
+
+    def test_session_crossing_midnight_lands_on_both_days(self):
+        night = self._night_session()
+
+        days = build_schedule_days({1: night})
+
+        assert [[hour.start.hour for hour in day.hours] for day in days] == [[22], [0]]
+        assert [day.hours[0].sessions for day in days] == [[night], [night]]
+
+    def test_room_lanes_clip_the_night_session_at_midnight(self):
+        days = build_room_lanes(build_schedule_days({1: self._night_session()}))
+
+        assert [[mark.start.hour for mark in day.hour_marks] for day in days] == [
+            [22, 23],
+            [0, 1],
+        ]
+        assert [
+            [(tile.row_start, tile.row_span) for tile in day.tiles] for day in days
+        ] == [[(1, 2)], [(1, 2)]]
 
 
 class TestGroupSessionsByState:

--- a/tests/unit/gates/web/django/chronology/test_presentation.py
+++ b/tests/unit/gates/web/django/chronology/test_presentation.py
@@ -210,11 +210,14 @@ class TestNightSessions:
 
         assert [[hour.start.hour for hour in day.hours] for day in days] == [[22], [0]]
         assert [day.hours[0].sessions for day in days] == [[night], [night]]
+        assert [(day.windows[1][0].hour, day.windows[1][1].hour) for day in days] == [
+            (22, 0),
+            (0, 2),
+        ]
 
     def test_room_lanes_clip_the_night_session_at_midnight(self):
         days = build_room_lanes(
-            build_schedule_days({1: self._night_session()}, tz=_SCHEDULE_TZ),
-            tz=_SCHEDULE_TZ,
+            build_schedule_days({1: self._night_session()}, tz=_SCHEDULE_TZ)
         )
 
         assert [[mark.start.hour for mark in day.hour_marks] for day in days] == [

--- a/tests/unit/test_timeslots_mills.py
+++ b/tests/unit/test_timeslots_mills.py
@@ -1,0 +1,39 @@
+from datetime import UTC, datetime
+from zoneinfo import ZoneInfo
+
+from ludamus.mills.timeslots import interval_windows
+
+_TZ = ZoneInfo("Europe/Warsaw")
+
+
+class TestIntervalWindows:
+    def test_same_day_stays_one_window(self):
+        start = datetime(2026, 7, 10, 12, tzinfo=_TZ)
+        end = datetime(2026, 7, 10, 14, tzinfo=_TZ)
+
+        assert interval_windows(start=start, end=end, tz=_TZ) == [(start, end)]
+
+    def test_night_interval_splits_at_local_midnight(self):
+        start = datetime(2026, 7, 10, 22, tzinfo=_TZ)
+        end = datetime(2026, 7, 11, 2, tzinfo=_TZ)
+        midnight = datetime(2026, 7, 11, 0, tzinfo=_TZ)
+
+        assert interval_windows(start=start, end=end, tz=_TZ) == [
+            (start, midnight),
+            (midnight, end),
+        ]
+
+    def test_converts_from_utc_into_tz(self):
+        start = datetime(2026, 7, 10, 20, tzinfo=UTC)
+        end = datetime(2026, 7, 10, 23, tzinfo=UTC)
+
+        assert interval_windows(start=start, end=end, tz=_TZ) == [
+            (
+                datetime(2026, 7, 10, 22, tzinfo=_TZ),
+                datetime(2026, 7, 11, 0, tzinfo=_TZ),
+            ),
+            (
+                datetime(2026, 7, 11, 0, tzinfo=_TZ),
+                datetime(2026, 7, 11, 1, tzinfo=_TZ),
+            ),
+        ]

--- a/tests/unit/test_timetable_mills.py
+++ b/tests/unit/test_timetable_mills.py
@@ -194,9 +194,10 @@ class TestBuildGridOverlappingSessions:
         )
 
         assert grid.date_selection == date(2026, 1, 1)
-        assert grid.total_minutes == 4 * 60
+        # The selected day owns only its own side of midnight: 22:00 -> 24:00.
+        assert grid.total_minutes == 2 * 60
 
-    def test_overnight_slot_extends_its_day_instead_of_adding_a_24h_day(self):
+    def test_overnight_slot_adds_the_day_it_reaches_into(self):
         uow = MagicMock()
         now = datetime(2026, 1, 1, 10, 0, tzinfo=UTC)
         space = SpaceDTO(
@@ -232,17 +233,17 @@ class TestBuildGridOverlappingSessions:
         )
 
         assert grid.available_dates == [date(2026, 1, 1), date(2026, 1, 2)]
-        assert grid.total_minutes == 13 * 60
+        # Jan 2 owns a 00:00 window, so the shared axis starts at midnight.
+        assert grid.total_minutes == 24 * 60
         assert [label.time.strftime("%H:%M") for label in grid.time_labels][:2] == [
-            "12:00",
-            "13:00",
+            "00:00",
+            "01:00",
         ]
-        assert grid.time_labels[-1].time.strftime("%H:%M") == "01:00"
         day_one, day_two = grid.days
-        assert [pos.start_minutes for pos in day_one.columns[0].sessions] == [12 * 60]
-        assert day_two.columns[0].sessions == []
+        assert day_one.columns[0].sessions == []
+        assert [pos.start_minutes for pos in day_two.columns[0].sessions] == [0]
 
-    def test_overlapping_day_ranges_render_each_item_in_exactly_one_column(self):
+    def test_session_crossing_midnight_renders_clipped_on_both_days(self):
         uow = MagicMock()
         now = datetime(2026, 1, 1, 10, 0, tzinfo=UTC)
         space = SpaceDTO(
@@ -258,42 +259,29 @@ class TestBuildGridOverlappingSessions:
         uow.time_slots.list_by_event.return_value = [
             TimeSlotDTO(
                 pk=1,
-                start_time=datetime(2026, 1, 1, 18, 0, tzinfo=UTC),
-                end_time=datetime(2026, 1, 2, 1, 0, tzinfo=UTC),
-            ),
-            TimeSlotDTO(
-                pk=2,
-                start_time=datetime(2026, 1, 2, 0, 30, tzinfo=UTC),
+                start_time=datetime(2026, 1, 1, 22, 0, tzinfo=UTC),
                 end_time=datetime(2026, 1, 2, 2, 0, tzinfo=UTC),
-            ),
+            )
         ]
-        first_night = _make_item(
-            pk=1,
-            start_time=datetime(2026, 1, 2, 0, 15, tzinfo=UTC),
-            end_time=datetime(2026, 1, 2, 0, 30, tzinfo=UTC),
+        night_owl = _make_item(
+            start_time=datetime(2026, 1, 1, 22, 0, tzinfo=UTC),
+            end_time=datetime(2026, 1, 2, 2, 0, tzinfo=UTC),
         )
-        second_night = _make_item(
-            pk=2,
-            session_id=2,
-            start_time=datetime(2026, 1, 2, 0, 30, tzinfo=UTC),
-            end_time=datetime(2026, 1, 2, 1, 30, tzinfo=UTC),
-        )
-        uow.agenda_items.list_by_event.return_value = [first_night, second_night]
+        uow.agenda_items.list_by_event.return_value = [night_owl]
 
         grid = TimetableService(uow).build_grid(
             event_pk=1, tz=UTC, date_selection="all"
         )
 
         day_one, day_two = grid.days
-        # Day one's range reaches 01:00 of Jan 2 while day two's starts at
-        # midnight (00:30 floored to the hour grid), so both contain the two
-        # night items; the later day owns the overlap instead of rendering
-        # the items in both columns.
-        assert day_one.columns[0].sessions == []
-        assert [
-            (pos.agenda_item.pk, pos.start_minutes)
-            for pos in day_two.columns[0].sessions
-        ] == [(1, 15), (2, 30)]
+        # Friday shows 22:00 -> 24:00, Saturday 00:00 -> 02:00, and both keep
+        # the real 4h duration so a drag moves the whole session.
+        friday, saturday = day_one.columns[0].sessions[0], (
+            day_two.columns[0].sessions[0]
+        )
+        assert (friday.start_minutes, friday.visible_minutes) == (22 * 60, 2 * 60)
+        assert (saturday.start_minutes, saturday.visible_minutes) == (0, 2 * 60)
+        assert [friday.duration_minutes, saturday.duration_minutes] == [4 * 60, 4 * 60]
 
 
 class TestRevertChange:


### PR DESCRIPTION
## Summary
- Lift pure local-day splitting into `interval_windows` in mills; `slot_windows` is now a thin wrapper.
- Drive public `build_schedule_days` / `build_room_lanes` from that helper instead of home-grown midnight helpers.
- Pass an explicit timezone from the event page gate edge, matching the panel timetable contract.
- Carry each day's `SlotWindow` on `ScheduleDay` so room lanes clip without a second split.

Stacked on #798.

## Screenshots

Compact schedule rooms view — a 22:00–02:00 session ("Night Owl: Across Midnight") clipped on both local days (Tue 22:00–24:00 / Wed 00:00–02:00) in RPG Table 2:

![Night session split across midnight in rooms view](https://files.catbox.moe/lzsqpc.png)

## Test plan
- [x] `tests/unit/test_timeslots_mills.py` covers same-day, midnight split, and UTC→tz conversion
- [x] Existing night-session presentation tests updated to pass explicit tz
- [x] Spot-check compact schedule rooms view with a 22:00–02:00 session across both local days