### PR TITLE
Deflake the iOS regression specs: anchors, polling, scoped snapshots

### DIFF
--- a/scripts/ios-regressions/harness.ts
+++ b/scripts/ios-regressions/harness.ts
@@ -33,22 +33,23 @@ const FALLBACK_VIEWPORT: Rect = { x: 0, y: 0, width: 402, height: 874 };
 
 // The one poll-to-deadline loop: probe until it yields a value or the window
 // closes, and only conclude "nothing" (null) once the window has actually
-// elapsed — which is what specs asserting absence rely on. Paced by a local
-// sleep rather than the runner's wait command, because the same loop must
-// serve before a device session exists (fetchReadyPage) as during one; the
-// probes themselves are the only traffic the runner needs to see. A throwing
-// probe aborts the poll.
+// elapsed — which is what specs asserting absence rely on. The window ends on
+// a probe, not a sleep, so its final interval is observed rather than slept
+// away. Paced by a local sleep rather than the runner's wait command, because
+// the same loop must serve before a device session exists (fetchReadyPage) as
+// during one; the probes themselves are the only traffic the runner needs to
+// see. A throwing probe aborts the poll.
 export const pollUntil = async <T>(
   probe: () => Promise<T | null>,
   { timeoutMs, intervalMs = 500 }: { timeoutMs: number; intervalMs?: number },
 ): Promise<T | null> => {
   const deadline = Date.now() + timeoutMs;
-  do {
+  for (;;) {
     const result = await probe();
     if (result !== null) return result;
+    if (Date.now() >= deadline) return null;
     await new Promise((resolve) => setTimeout(resolve, intervalMs));
-  } while (Date.now() < deadline);
-  return null;
+  }
 };
 
 const deviceName = env.IOS_DEVICE_NAME ?? "iPhone 17 Pro";

--- a/scripts/ios-regressions/harness.ts
+++ b/scripts/ios-regressions/harness.ts
@@ -25,10 +25,31 @@ export const hookTimeoutMs = Number(env.IOS_HOOK_TIMEOUT_MS ?? "300000");
 
 export type Rect = { x: number; y: number; width: number; height: number };
 
-// Only reached when a snapshot comes back with no nodes to read a rect from. Sized for the iPhone 17 Pro the workflow asks for first;
-// when the image lacks that device the workflow picks another, so treat this as
-// a shape that keeps arithmetic finite, not as this run's screen.
+// Only reached when a snapshot comes back with no nodes to read a rect from.
+// Sized for the iPhone 17 Pro the workflow asks for first; when the image
+// lacks that device the workflow picks another, so treat this as a shape that
+// keeps arithmetic finite, not as this run's screen.
 const FALLBACK_VIEWPORT: Rect = { x: 0, y: 0, width: 402, height: 874 };
+
+// The one poll-to-deadline loop: probe until it yields a value or the window
+// closes, and only conclude "nothing" (null) once the window has actually
+// elapsed — which is what specs asserting absence rely on. Paced by a local
+// sleep rather than the runner's wait command, because the same loop must
+// serve before a device session exists (fetchReadyPage) as during one; the
+// probes themselves are the only traffic the runner needs to see. A throwing
+// probe aborts the poll.
+export const pollUntil = async <T>(
+  probe: () => Promise<T | null>,
+  { timeoutMs, intervalMs = 500 }: { timeoutMs: number; intervalMs?: number },
+): Promise<T | null> => {
+  const deadline = Date.now() + timeoutMs;
+  do {
+    const result = await probe();
+    if (result !== null) return result;
+    await new Promise((resolve) => setTimeout(resolve, intervalMs));
+  } while (Date.now() < deadline);
+  return null;
+};
 
 const deviceName = env.IOS_DEVICE_NAME ?? "iPhone 17 Pro";
 const runtime = env.IOS_RUNTIME;
@@ -215,7 +236,6 @@ export const createIosHarness = (session: string): IosHarness => {
   // with gestures, which are the slowest thing either spec can do.
   const fetchReadyPage = async (url: URL, contains: string): Promise<string> => {
     console.log(`Checking local event page at ${url.toString()}...`);
-    const deadline = Date.now() + 60000;
     let lastError = "no response";
 
     // Pin the language both halves of a spec see. Bun's fetch sends no
@@ -227,24 +247,34 @@ export const createIosHarness = (session: string): IosHarness => {
     // the spec fails loudly rather than passing vacuously.
     const headers = { "Accept-Language": "en" };
 
-    while (Date.now() < deadline) {
-      try {
-        const response = await fetch(url, { headers });
-        const text = await response.text();
-        if (response.ok && text.includes(contains)) return text;
+    const unusable = (): Error =>
+      new Error(
+        `Local event page is not usable at ${url.toString()} (${lastError}). ` +
+          "Make sure the e2e server is running and serving the seeded event.",
+      );
 
-        lastError = `HTTP ${response.status}; body starts with ${JSON.stringify(text.slice(0, 160))}`;
-        if (response.status >= 400 && response.status < 500) break;
-      } catch (error) {
-        lastError = error instanceof Error ? error.message : String(error);
-      }
-      await new Promise((resolve) => setTimeout(resolve, 1000));
-    }
+    const page = await pollUntil<string>(
+      async () => {
+        let status: number | null = null;
+        try {
+          const response = await fetch(url, { headers });
+          const text = await response.text();
+          if (response.ok && text.includes(contains)) return text;
 
-    throw new Error(
-      `Local event page is not usable at ${url.toString()} (${lastError}). ` +
-        "Make sure the e2e server is running and serving the seeded event.",
+          status = response.status;
+          lastError = `HTTP ${status}; body starts with ${JSON.stringify(text.slice(0, 160))}`;
+        } catch (error) {
+          lastError = error instanceof Error ? error.message : String(error);
+        }
+        // A 4xx is a wrong URL or a missing seed, not a server still starting;
+        // no amount of polling fixes it.
+        if (status !== null && status >= 400 && status < 500) throw unusable();
+        return null;
+      },
+      { timeoutMs: 60000, intervalMs: 1000 },
     );
+    if (page === null) throw unusable();
+    return page;
   };
 
   return {

--- a/scripts/ios-regressions/harness.ts
+++ b/scripts/ios-regressions/harness.ts
@@ -25,28 +25,51 @@ export const hookTimeoutMs = Number(env.IOS_HOOK_TIMEOUT_MS ?? "300000");
 
 export type Rect = { x: number; y: number; width: number; height: number };
 
-// Only reached when a snapshot comes back without a root rect. Sized for the
-// iPhone 17 Pro the macOS runner image actually provides -- CI ignores
-// `deviceName` below, because the workflow picks a UDID and passes it in.
+// Only reached when a snapshot comes back with no nodes to read a rect from. Sized for the iPhone 17 Pro the workflow asks for first;
+// when the image lacks that device the workflow picks another, so treat this as
+// a shape that keeps arithmetic finite, not as this run's screen.
 const FALLBACK_VIEWPORT: Rect = { x: 0, y: 0, width: 402, height: 874 };
 
 const deviceName = env.IOS_DEVICE_NAME ?? "iPhone 17 Pro";
 const runtime = env.IOS_RUNTIME;
 const providedUdid = env.UDID;
 
+// One convention for "is this on screen": rect centre inside the viewport,
+// clear of a band for Safari's top and bottom chrome. The band's exact size is
+// unknowable from this sandbox; being conservative only narrows what counts as
+// visible, which specs must treat as "press/check something else", never as a
+// pass. The runner's `hittable` is NOT this check — it reads false inside
+// Safari's web content (device-falsified on this branch).
+const CHROME_INSET = 120;
+
+export const centreOnScreen = (rect: Rect, viewport: Rect): boolean => {
+  const centreY = rect.y + rect.height / 2;
+  return (
+    centreY >= viewport.y + CHROME_INSET && centreY <= viewport.y + viewport.height - CHROME_INSET
+  );
+};
+
+export const describeNode = (node: SnapshotNode): string => {
+  const rect = node.rect
+    ? ` x=${Math.round(node.rect.x)} y=${Math.round(node.rect.y)} w=${Math.round(node.rect.width)} h=${Math.round(node.rect.height)}`
+    : "";
+  return `${node.type ?? "node"} ref=@${node.ref}${rect} hittable=${String(node.hittable)} label=${JSON.stringify(
+    node.label ?? node.value ?? "",
+  )}`;
+};
+
 export type IosHarness = {
   client: AgentDeviceClient;
   deviceOptions: IosDeviceOptions;
-  takeSnapshot: () => Promise<CaptureSnapshotResult>;
+  takeSnapshot: (scope?: string) => Promise<CaptureSnapshotResult>;
   viewportOf: (snapshot: CaptureSnapshotResult) => Rect;
-  viewportRect: () => Promise<Rect>;
   close: () => Promise<void>;
-  snapshotLabels: () => Promise<string[]>;
+  snapshotLabels: (scope?: string) => Promise<string[]>;
   findNodeByLabel: (label: string) => Promise<SnapshotNode | null>;
   wait: (durationMs: number) => Promise<void>;
   openUrl: (url: string, udid: string) => Promise<void>;
   prepareDevice: () => Promise<string>;
-  assertPageReady: (url: URL, contains: string) => Promise<void>;
+  fetchReadyPage: (url: URL, contains: string) => Promise<string>;
 };
 
 export const createIosHarness = (session: string): IosHarness => {
@@ -56,18 +79,27 @@ export const createIosHarness = (session: string): IosHarness => {
     ? { platform: "ios", udid: providedUdid }
     : { platform: "ios", device: deviceName };
 
-  const takeSnapshot = (): Promise<CaptureSnapshotResult> =>
-    client.capture.snapshot({ ...deviceOptions, interactiveOnly: true });
+  // The runner walks at most 300 nodes per snapshot and silently drops the
+  // rest (`fastSnapshotLimit`, surfaced as `truncated`), so on a large page
+  // anything late in document order never appears. `scope` narrows the walk to
+  // the subtree of the first element whose accessible label or identifier
+  // contains the given text — resolved by a live element query, which has no
+  // such cap. A scope that matches nothing falls back to the full, possibly
+  // truncated, tree.
+  const takeSnapshot = (scope?: string): Promise<CaptureSnapshotResult> =>
+    client.capture.snapshot({
+      ...deviceOptions,
+      interactiveOnly: true,
+      ...(scope ? { scope } : {}),
+    });
 
-  const snapshotLabels = async (): Promise<string[]> => {
-    const snapshot = await takeSnapshot();
+  const snapshotLabels = async (scope?: string): Promise<string[]> => {
+    const snapshot = await takeSnapshot(scope);
     return snapshot.nodes.map((node) => node.label ?? node.value ?? "").filter(Boolean);
   };
 
   const viewportOf = (snapshot: CaptureSnapshotResult): Rect =>
     snapshot.nodes[0]?.rect ?? FALLBACK_VIEWPORT;
-
-  const viewportRect = async (): Promise<Rect> => viewportOf(await takeSnapshot());
 
   const close = async (): Promise<void> => {
     try {
@@ -177,16 +209,29 @@ export const createIosHarness = (session: string): IosHarness => {
     return udid;
   };
 
-  const assertPageReady = async (url: URL, contains: string): Promise<void> => {
+  // Waits for the page to serve `contains`, then hands back the body. A caller
+  // that needs a landmark from the markup -- a scrubber slot anchor, the
+  // accessible name of a control -- reads it here instead of hunting for it
+  // with gestures, which are the slowest thing either spec can do.
+  const fetchReadyPage = async (url: URL, contains: string): Promise<string> => {
     console.log(`Checking local event page at ${url.toString()}...`);
     const deadline = Date.now() + 60000;
     let lastError = "no response";
 
+    // Pin the language both halves of a spec see. Bun's fetch sends no
+    // Accept-Language, so Django falls back to LANGUAGE_CODE ("pl") and dates
+    // render from Django's own compiled catalogue — "Sobota" — while the
+    // en-US simulator's Safari asks for and gets "Saturday". Names read from
+    // this HTML then never match device labels. Pinning "en" aligns the two;
+    // if the simulator is ever not English, set-membership finds nothing and
+    // the spec fails loudly rather than passing vacuously.
+    const headers = { "Accept-Language": "en" };
+
     while (Date.now() < deadline) {
       try {
-        const response = await fetch(url);
+        const response = await fetch(url, { headers });
         const text = await response.text();
-        if (response.ok && text.includes(contains)) return;
+        if (response.ok && text.includes(contains)) return text;
 
         lastError = `HTTP ${response.status}; body starts with ${JSON.stringify(text.slice(0, 160))}`;
         if (response.status >= 400 && response.status < 500) break;
@@ -207,13 +252,12 @@ export const createIosHarness = (session: string): IosHarness => {
     deviceOptions,
     takeSnapshot,
     viewportOf,
-    viewportRect,
     close,
     snapshotLabels,
     findNodeByLabel,
     wait,
     openUrl,
     prepareDevice,
-    assertPageReady,
+    fetchReadyPage,
   };
 };

--- a/scripts/ios-regressions/harness.ts
+++ b/scripts/ios-regressions/harness.ts
@@ -65,9 +65,13 @@ const providedUdid = env.UDID;
 const CHROME_INSET = 120;
 
 export const centreOnScreen = (rect: Rect, viewport: Rect): boolean => {
+  const centreX = rect.x + rect.width / 2;
   const centreY = rect.y + rect.height / 2;
   return (
-    centreY >= viewport.y + CHROME_INSET && centreY <= viewport.y + viewport.height - CHROME_INSET
+    centreX >= viewport.x &&
+    centreX <= viewport.x + viewport.width &&
+    centreY >= viewport.y + CHROME_INSET &&
+    centreY <= viewport.y + viewport.height - CHROME_INSET
   );
 };
 
@@ -258,7 +262,9 @@ export const createIosHarness = (session: string): IosHarness => {
       async () => {
         let status: number | null = null;
         try {
-          const response = await fetch(url, { headers });
+          // Bounded per request: pollUntil cannot interrupt a pending fetch,
+          // so a stalled server would otherwise hold the hook past the window.
+          const response = await fetch(url, { headers, signal: AbortSignal.timeout(5000) });
           const text = await response.text();
           if (response.ok && text.includes(contains)) return text;
 

--- a/scripts/ios-regressions/modal.test.ts
+++ b/scripts/ios-regressions/modal.test.ts
@@ -8,6 +8,7 @@ import {
   createIosHarness,
   describeNode,
   hookTimeoutMs,
+  pollUntil,
   sessionName,
 } from "./harness";
 
@@ -27,6 +28,7 @@ const {
   findNodeByLabel,
   viewportOf,
   close,
+  wait,
   openUrl,
   prepareDevice,
   fetchReadyPage,
@@ -48,15 +50,14 @@ const showingLabels = async (): Promise<string[]> => {
 
 // Polling, not sleeping: the modal animates in, and a single snapshot taken
 // mid-animation reports content that is about to be there as missing.
-const waitUntilShowing = async (texts: string[], timeoutMs: number): Promise<boolean> => {
-  const deadline = Date.now() + timeoutMs;
-  do {
-    const labels = await showingLabels();
-    if (texts.every((text) => labels.some((label) => label.includes(text)))) return true;
-    await client.command.wait({ ...deviceOptions, durationMs: 400 });
-  } while (Date.now() < deadline);
-  return false;
-};
+const waitUntilShowing = async (texts: string[], timeoutMs: number): Promise<boolean> =>
+  (await pollUntil(
+    async () => {
+      const labels = await showingLabels();
+      return texts.every((text) => labels.some((label) => label.includes(text))) || null;
+    },
+    { timeoutMs, intervalMs: 400 },
+  )) ?? false;
 
 const clickNodeCenter = async (node: SnapshotNode): Promise<void> => {
   if (node.rect) {
@@ -122,7 +123,7 @@ const scrollUntilTriggerInViewport = async (): Promise<SnapshotNode> => {
       direction: centerY > viewportHeight - 120 ? "down" : "up",
       pixels: 450,
     });
-    await client.command.wait({ ...deviceOptions, durationMs: 200 });
+    await wait(200);
   }
 
   throw new Error(`Could not bring ${targetTriggerLabel} into the viewport`);
@@ -131,19 +132,12 @@ const scrollUntilTriggerInViewport = async (): Promise<SnapshotNode> => {
 const forcePreOpenScroll = async (): Promise<void> => {
   for (let step = 0; step < preOpenScrollSteps; step += 1) {
     await client.interactions.scroll({ ...deviceOptions, direction: "down", pixels: 450 });
-    await client.command.wait({ ...deviceOptions, durationMs: 150 });
+    await wait(150);
   }
 };
 
-const waitForLabel = async (label: string, timeoutMs: number): Promise<SnapshotNode | null> => {
-  const deadline = Date.now() + timeoutMs;
-  while (Date.now() < deadline) {
-    const node = await findNodeByLabel(label);
-    if (node) return node;
-    await client.command.wait({ ...deviceOptions, durationMs: 500 });
-  }
-  return null;
-};
+const waitForLabel = (label: string, timeoutMs: number): Promise<SnapshotNode | null> =>
+  pollUntil(() => findNodeByLabel(label), { timeoutMs });
 
 const eventUrl = new URL(eventPath, baseUrl);
 const modalUrl = new URL(eventUrl);
@@ -164,7 +158,7 @@ beforeAll(async () => {
   const initialUrl = openViaScrolledPage ? eventUrl : modalUrl;
   console.log(`Opening Safari at ${initialUrl.toString()}...`);
   await openUrl(initialUrl.toString(), udid);
-  await client.command.wait({ ...deviceOptions, durationMs: 3000 });
+  await wait(3000);
 
   let preOpenTriggerLabel: string | null = null;
   let preOpenTriggerY: number | null = null;
@@ -210,7 +204,7 @@ beforeAll(async () => {
     throw new Error("Could not find visible target: Close");
   }
   await clickNodeCenter(closeButton);
-  await client.command.wait({ ...deviceOptions, durationMs: 1000 });
+  await wait(1000);
 
   // Closed means gone from the tree, not merely outside the visibility band —
   // the rect filter here would let a stuck-but-scrolled modal read as closed.
@@ -219,7 +213,7 @@ beforeAll(async () => {
   }
 
   if (openViaScrolledPage && preOpenTriggerLabel && preOpenTriggerY !== null) {
-    await client.command.wait({ ...deviceOptions, durationMs: 600 });
+    await wait(600);
     const settledSnapshot = await takeSnapshot();
     const settledTrigger = settledSnapshot.nodes.find(
       (node) => node.label === preOpenTriggerLabel && !isHiddenDialogLabel(node),

--- a/scripts/ios-regressions/modal.test.ts
+++ b/scripts/ios-regressions/modal.test.ts
@@ -2,7 +2,14 @@ import type { CaptureSnapshotResult, SnapshotNode } from "agent-device";
 
 import { afterAll, beforeAll, expect, test } from "bun:test";
 
-import { baseUrl, createIosHarness, hookTimeoutMs, sessionName } from "./harness";
+import {
+  baseUrl,
+  centreOnScreen,
+  createIosHarness,
+  describeNode,
+  hookTimeoutMs,
+  sessionName,
+} from "./harness";
 
 const env = process.env;
 const session = sessionName("modal");
@@ -22,12 +29,33 @@ const {
   close,
   openUrl,
   prepareDevice,
-  assertPageReady,
+  fetchReadyPage,
 } = createIosHarness(session);
 
-const hasVisibleText = async (text: string): Promise<boolean> => {
-  const labels = await snapshotLabels();
-  return labels.some((label) => label.includes(text));
+// `snapshotLabels` reports every label in the tree, including nodes scrolled
+// out of view, so it cannot answer "is this on screen". The runner's `hittable`
+// cannot either — the device run at 69a819a judged the open modal's own
+// heading not hittable while the very next step tapped it; the field reads
+// false inside Safari's web content. A rect centred in the viewport is the
+// check that both survives the device and still fails for content parked
+// below the fold of a modal that no longer sizes itself.
+const showingLabels = async (): Promise<string[]> => {
+  const snapshot = await takeSnapshot();
+  return snapshot.nodes.flatMap((node) =>
+    node.label && node.rect && isNodeInViewport(snapshot, node) ? [node.label] : [],
+  );
+};
+
+// Polling, not sleeping: the modal animates in, and a single snapshot taken
+// mid-animation reports content that is about to be there as missing.
+const waitUntilShowing = async (texts: string[], timeoutMs: number): Promise<boolean> => {
+  const deadline = Date.now() + timeoutMs;
+  do {
+    const labels = await showingLabels();
+    if (texts.every((text) => labels.some((label) => label.includes(text)))) return true;
+    await client.command.wait({ ...deviceOptions, durationMs: 400 });
+  } while (Date.now() < deadline);
+  return false;
 };
 
 const clickNodeCenter = async (node: SnapshotNode): Promise<void> => {
@@ -46,21 +74,8 @@ const clickNodeReference = async (node: SnapshotNode): Promise<void> => {
   await client.interactions.click({ ...deviceOptions, ref: `@${node.ref}` });
 };
 
-const describeNode = (node: SnapshotNode): string => {
-  const rect = node.rect
-    ? ` x=${Math.round(node.rect.x)} y=${Math.round(node.rect.y)} w=${Math.round(node.rect.width)} h=${Math.round(node.rect.height)}`
-    : "";
-  return `${node.type ?? "node"} ref=@${node.ref}${rect} label=${JSON.stringify(
-    node.label ?? node.value ?? "",
-  )}`;
-};
-
-const isNodeInViewport = (snapshot: CaptureSnapshotResult, node: SnapshotNode): boolean => {
-  if (!node.rect) return false;
-  const viewportHeight = viewportOf(snapshot).height;
-  const centerY = node.rect.y + node.rect.height / 2;
-  return centerY >= 80 && centerY <= viewportHeight - 120;
-};
+const isNodeInViewport = (snapshot: CaptureSnapshotResult, node: SnapshotNode): boolean =>
+  Boolean(node.rect && centreOnScreen(node.rect, viewportOf(snapshot)));
 
 const isHiddenDialogLabel = (node: SnapshotNode): boolean =>
   (node.label ?? "").includes("web dialog");
@@ -143,7 +158,7 @@ let closeIssue: string | null = null;
 let scrollIssue: string | null = null;
 
 beforeAll(async () => {
-  await assertPageReady(eventUrl, targetTitle);
+  await fetchReadyPage(eventUrl, targetTitle);
   const udid = await prepareDevice();
 
   const initialUrl = openViaScrolledPage ? eventUrl : modalUrl;
@@ -180,9 +195,10 @@ beforeAll(async () => {
   }
 
   console.log("Checking whether modal content is initially visible...");
-  const contentInitiallyVisible =
-    (await hasVisibleText("About this session")) &&
-    (await hasVisibleText("Przygoda w stylu filmu"));
+  const contentInitiallyVisible = await waitUntilShowing(
+    ["About this session", "Przygoda w stylu filmu"],
+    5000,
+  );
   if (!contentInitiallyVisible) {
     contentIssue =
       'Modal content headed by "About this session" / "Przygoda w stylu filmu" is not initially visible.';
@@ -196,7 +212,9 @@ beforeAll(async () => {
   await clickNodeCenter(closeButton);
   await client.command.wait({ ...deviceOptions, durationMs: 1000 });
 
-  if (await hasVisibleText("Close")) {
+  // Closed means gone from the tree, not merely outside the visibility band —
+  // the rect filter here would let a stuck-but-scrolled modal read as closed.
+  if ((await snapshotLabels()).includes("Close")) {
     closeIssue = "The modal X / Close button did not close the modal.";
   }
 

--- a/scripts/ios-regressions/scrubber-longpress.test.ts
+++ b/scripts/ios-regressions/scrubber-longpress.test.ts
@@ -131,9 +131,6 @@ const waitForRailMarkers = async (
 ): Promise<RailHour[]> => {
   let screen: Rect | null = null;
   let lastSnapshotError: unknown = null;
-  // A slot, not a plain `let`: the assignment happens inside the probe
-  // closure, which TypeScript's flow analysis cannot see from out here.
-  const last: { scoped: CaptureSnapshotResult | null } = { scoped: null };
   const markers = await pollUntil<RailHour[]>(
     async () => {
       // A snapshot taken while Safari is still launching throws; that is a
@@ -142,23 +139,27 @@ const waitForRailMarkers = async (
       // cannot touch — and holds still for the rest of the run.
       try {
         screen ??= viewportOf(await takeSnapshot());
-        last.scoped = await takeSnapshot(navName);
+        const scoped = await takeSnapshot(navName);
+        const found = railMarkersFrom(scoped, markerNames, screen);
+        return found.length > 0 ? found : null;
       } catch (error) {
         lastSnapshotError = error;
         console.warn("Snapshot failed while the page was settling; retrying.", error);
         return null;
       }
-      const found = railMarkersFrom(last.scoped, markerNames, screen);
-      return found.length > 0 ? found : null;
     },
     { timeoutMs },
   );
   if (markers) return markers;
 
-  const scoped = last.scoped;
-  if (!scoped) {
+  // One fresh scoped snapshot so the dump describes the tree at failure time —
+  // this path has already spent the full window, so the roundtrip is free.
+  let scoped: CaptureSnapshotResult;
+  try {
+    scoped = await takeSnapshot(navName);
+  } catch (error) {
     throw new Error(
-      `No snapshot succeeded in ${timeoutMs}ms; last error: ${String(lastSnapshotError)}`,
+      `No snapshot succeeded in ${timeoutMs}ms; last error: ${String(lastSnapshotError ?? error)}`,
     );
   }
   // The scoped tree is small, so the dump can afford to show all of it. A

--- a/scripts/ios-regressions/scrubber-longpress.test.ts
+++ b/scripts/ios-regressions/scrubber-longpress.test.ts
@@ -1,10 +1,21 @@
+import type { CaptureSnapshotResult } from "agent-device";
+
 import { afterAll, beforeAll, expect, test } from "bun:test";
 
-import { baseUrl, createIosHarness, hookTimeoutMs, sessionName } from "./harness";
+import type { Rect } from "./harness";
+
+import {
+  baseUrl,
+  centreOnScreen,
+  createIosHarness,
+  describeNode,
+  hookTimeoutMs,
+  sessionName,
+} from "./harness";
 
 const env = process.env;
 const session = sessionName("scrubber");
-const eventPath = env.EVENT_PATH ?? "/chronology/event/kapitularz-2025-anonymized/";
+const eventPath = env.EVENT_PATH ?? "/event/kapitularz-2025-anonymized/";
 const eventUrl = new URL(eventPath, baseUrl);
 
 const calloutSignals = [
@@ -21,55 +32,201 @@ const {
   takeSnapshot,
   snapshotLabels,
   viewportOf,
-  viewportRect,
   close,
   wait,
   openUrl,
   prepareDevice,
-  assertPageReady,
+  fetchReadyPage,
 } = createIosHarness(session);
 
-const scrollScheduleIntoView = async (): Promise<void> => {
-  for (let attempt = 0; attempt < 14; attempt += 1) {
-    const snapshot = await takeSnapshot();
-    const viewportHeight = viewportOf(snapshot).height;
-    const sessionOnScreen = snapshot.nodes.some(
-      (node) =>
-        (node.label ?? "").startsWith("Open details for") &&
-        node.rect !== undefined &&
-        node.rect.y > 80 &&
-        node.rect.y < viewportHeight - 120,
+// The rail's own hour links are anchors (#slot-YYYYMMDD-HH), so Safari can land
+// mid-schedule on load. Reaching the same place with scroll gestures cost up to
+// 14 of them, and a single gesture on this page — 110 sessions, ~400 KB — runs
+// past the runner's 180s per-command ceiling, which is what made this spec
+// flaky. The ids are derived from the seed's start date, so read one from the
+// markup rather than hardcoding it.
+const railSlotAnchor = (html: string): string => {
+  const slots = [...html.matchAll(/data-rail-hour="([\w-]+)"/g)].map((match) => match[1]);
+  if (slots.length === 0) throw new Error("The schedule rail rendered no hour anchors.");
+  // A few hours in, so sessions fill the viewport above and below the rail.
+  return slots[Math.min(3, slots.length - 1)];
+};
+
+type RailHour = { label: string; rect: Rect };
+
+// Attribute values arrive escaped; the rail's labels carry event and day names.
+// `&amp;` goes last: unescaping it first would turn a served `&amp;lt;` (the
+// literal text "&lt;") into "<" — CodeQL's double-unescape, and a name that
+// would never match its device label.
+const decodeEntities = (value: string): string =>
+  value
+    .replaceAll("&lt;", "<")
+    .replaceAll("&gt;", ">")
+    .replaceAll("&quot;", '"')
+    .replaceAll("&#x27;", "'")
+    .replaceAll("&#39;", "'")
+    .replaceAll("&amp;", "&");
+
+// Accessibility engines collapse runs of whitespace in a name; markup keeps its
+// indentation. Collapse both sides the same way before comparing.
+const collapse = (value: string): string => value.replace(/\s+/g, " ").trim();
+
+const namesFrom = (html: string, pattern: RegExp): Set<string> =>
+  new Set(
+    [...html.matchAll(pattern)].flatMap((m) => (m[1] ? [collapse(decodeEntities(m[1]))] : [])),
+  );
+
+// This page overflows the runner's 300-node snapshot budget, and the rail nav
+// is the last element in the document — an unscoped snapshot truncates before
+// ever reaching it (seven device runs of "no rail names appeared" traced back
+// to exactly this). Scoping the snapshot to the nav's accessible name walks
+// only its subtree — a few dozen nodes — so every rendered marker surfaces.
+// Both marker name sets come from the served, already-translated markup: the
+// links' bare hour text ("10") and their aria-labels, whichever the engine
+// reports.
+const RAIL_NAV_NAME = /<nav class="schedule-rail[^"]*"\s+aria-label="([^"]+)"/;
+const RAIL_HOUR_NAMES = /class="schedule-rail-hour[^"]*"[^>]*aria-label="([^"]+)"/g;
+const RAIL_HOUR_TEXTS = /class="schedule-rail-hour[^"]*"[^>]*>([^<]+)<\/a>/g;
+
+const railNavName = (html: string): string => {
+  const name = RAIL_NAV_NAME.exec(html)?.[1];
+  if (!name) throw new Error("The schedule rail nav rendered no aria-label to scope by.");
+  return collapse(decodeEntities(name));
+};
+
+// A marker link and its own text node both match the name sets at the same
+// spot; one press per spot is enough. The screen band drops markers that are
+// rendered but not yet scrolled into view — before fitRail (event-timeline.ts)
+// thins the rail, or before Safari applies the fragment scroll — so a press
+// never lands on a clipped or off-screen target.
+const railMarkersFrom = (
+  snapshot: CaptureSnapshotResult,
+  names: Set<string>,
+  screen: Rect,
+): RailHour[] => {
+  const seen = new Set<number>();
+  return snapshot.nodes.flatMap((node) => {
+    const label = node.label ? collapse(node.label) : "";
+    if (!label || !node.rect || !names.has(label)) return [];
+    if (node.rect.width <= 0 || node.rect.height <= 0) return [];
+    if (!centreOnScreen(node.rect, screen)) return [];
+    const spot = Math.round((node.rect.y + node.rect.height / 2) / 4);
+    if (seen.has(spot)) return [];
+    seen.add(spot);
+    return [{ label, rect: node.rect }];
+  });
+};
+
+// Polled, not slept: Safari applies the fragment scroll somewhere after load,
+// and a fixed wait is either too short on a slow runner or wasted on a fast
+// one. Without the check the long-press would land on empty page and the spec
+// would pass by finding no callout, which is not the same as the callout being
+// suppressed.
+const waitForRailMarkers = async (
+  timeoutMs: number,
+  navName: string,
+  markerNames: Set<string>,
+): Promise<RailHour[]> => {
+  const deadline = Date.now() + timeoutMs;
+  let screen: Rect | null = null;
+  let scoped: CaptureSnapshotResult | null = null;
+  let lastSnapshotError: unknown = null;
+  do {
+    // A snapshot taken while Safari is still launching throws; that is a state
+    // to wait out, not to end the run on. The screen rect comes from an
+    // unscoped snapshot's root node — the window frame, which truncation
+    // cannot touch — and holds still for the rest of the run.
+    try {
+      screen ??= viewportOf(await takeSnapshot());
+      scoped = await takeSnapshot(navName);
+    } catch (error) {
+      lastSnapshotError = error;
+      console.warn("Snapshot failed while the page was settling; retrying.", error);
+    }
+    if (screen && scoped) {
+      const markers = railMarkersFrom(scoped, markerNames, screen);
+      if (markers.length > 0) return markers;
+    }
+    await wait(500);
+  } while (Date.now() < deadline);
+
+  if (!scoped) {
+    throw new Error(
+      `No snapshot succeeded in ${timeoutMs}ms; last error: ${String(lastSnapshotError)}`,
     );
-    if (sessionOnScreen) return;
-    await client.interactions.scroll({ ...deviceOptions, direction: "down", pixels: 450 });
-    await wait(300);
   }
+  // The scoped tree is small, so the dump can afford to show all of it. A
+  // truncated or screen-sized root means the scope query missed the nav and
+  // the runner fell back to the full tree.
+  const sample = scoped.nodes.slice(0, 15).map(describeNode).join(" | ");
+  throw new Error(
+    `No on-screen rail markers in the ${JSON.stringify(navName)}-scoped snapshot: ` +
+      `${scoped.nodes.length} nodes, truncated=${String(scoped.truncated)}, ` +
+      `screen=${JSON.stringify(screen)}. ` +
+      `Expected labels like ${JSON.stringify([...markerNames][0])}. Nodes: ${sample || "none"}.`,
+  );
+};
+
+// A handful spread down the rail: the callout is a per-element behaviour, so
+// one hour passing says little about the rest. Dedup keeps a short rail from
+// pressing the same marker four times.
+const pressTargets = (markers: RailHour[]): RailHour[] =>
+  [...new Set([0.1, 0.35, 0.6, 0.85].map((f) => Math.floor(f * markers.length)))].map(
+    (index) => markers[index],
+  );
+
+// Absence is the pass here, so both false-negative paths need closing. One: a
+// snapshot taken before the callout has had time to appear reads as success —
+// poll instead, and only conclude "nothing" once the window has elapsed. Two:
+// the callout sheet joins a page that already overflows the snapshot's node
+// budget, so ask for the sheet directly — the scope resolves via a live
+// element query with no such cap. When no callout is up the scope misses and
+// the runner falls back to the full tree, which then contains no signal.
+const surfacedCallout = async (timeoutMs: number): Promise<string[]> => {
+  const deadline = Date.now() + timeoutMs;
+  do {
+    await wait(500);
+    const labels = await snapshotLabels("Open in");
+    const surfaced = calloutSignals.filter((signal) =>
+      labels.some((label) => label.includes(signal)),
+    );
+    if (surfaced.length > 0) return surfaced;
+  } while (Date.now() < deadline);
+  return [];
 };
 
 let surfacedCalloutSignals: string[] = [];
 
 beforeAll(async () => {
-  await assertPageReady(eventUrl, "schedule-rail");
+  const html = await fetchReadyPage(eventUrl, "schedule-rail");
   const udid = await prepareDevice();
 
-  console.log(`Opening Safari at ${eventUrl.toString()}...`);
-  await openUrl(eventUrl.toString(), udid);
-  await wait(3000);
-
-  await scrollScheduleIntoView();
-
-  const viewport = await viewportRect();
-  const x = viewport.x + viewport.width - 4;
-  const fractions = [0.3, 0.45, 0.6, 0.75];
-  for (const fraction of fractions) {
-    const y = viewport.y + viewport.height * fraction;
-    console.log(`Long-pressing the rail at x=${Math.round(x)} y=${Math.round(y)}...`);
-    await client.interactions.longPress({ ...deviceOptions, x, y, durationMs: 800 });
-    await wait(900);
-    const labels = await snapshotLabels();
-    const surfaced = calloutSignals.filter((signal) =>
-      labels.some((label) => label.includes(signal)),
+  const navName = railNavName(html);
+  const markerNames = new Set([
+    ...namesFrom(html, RAIL_HOUR_NAMES),
+    ...namesFrom(html, RAIL_HOUR_TEXTS),
+  ]);
+  if (markerNames.size === 0) {
+    throw new Error(
+      "The page rendered no rail markers; the spec needs them to know what to press.",
     );
+  }
+
+  const scheduleUrl = new URL(eventUrl);
+  scheduleUrl.hash = `slot-${railSlotAnchor(html)}`;
+  console.log(`Opening Safari at ${scheduleUrl.toString()}...`);
+  await openUrl(scheduleUrl.toString(), udid);
+
+  const markers = await waitForRailMarkers(90_000, navName, markerNames);
+
+  for (const hour of pressTargets(markers)) {
+    const x = hour.rect.x + hour.rect.width / 2;
+    const y = hour.rect.y + hour.rect.height / 2;
+    console.log(
+      `Long-pressing ${JSON.stringify(hour.label)} at x=${Math.round(x)} y=${Math.round(y)}...`,
+    );
+    await client.interactions.longPress({ ...deviceOptions, x, y, durationMs: 800 });
+    const surfaced = await surfacedCallout(2500);
     if (surfaced.length > 0) {
       surfacedCalloutSignals = surfaced;
       break;

--- a/scripts/ios-regressions/scrubber-longpress.test.ts
+++ b/scripts/ios-regressions/scrubber-longpress.test.ts
@@ -10,6 +10,7 @@ import {
   createIosHarness,
   describeNode,
   hookTimeoutMs,
+  pollUntil,
   sessionName,
 } from "./harness";
 
@@ -33,7 +34,6 @@ const {
   snapshotLabels,
   viewportOf,
   close,
-  wait,
   openUrl,
   prepareDevice,
   fetchReadyPage,
@@ -83,7 +83,9 @@ const namesFrom = (html: string, pattern: RegExp): Set<string> =>
 // only its subtree — a few dozen nodes — so every rendered marker surfaces.
 // Both marker name sets come from the served, already-translated markup: the
 // links' bare hour text ("10") and their aria-labels, whichever the engine
-// reports.
+// reports. The patterns are wed to the attribute order that
+// templates/chronology/_compact_schedule.html renders; a reorder there fails
+// the loud railNavName / markerNames guards below, never a device run.
 const RAIL_NAV_NAME = /<nav class="schedule-rail[^"]*"\s+aria-label="([^"]+)"/;
 const RAIL_HOUR_NAMES = /class="schedule-rail-hour[^"]*"[^>]*aria-label="([^"]+)"/g;
 const RAIL_HOUR_TEXTS = /class="schedule-rail-hour[^"]*"[^>]*>([^<]+)<\/a>/g;
@@ -127,29 +129,33 @@ const waitForRailMarkers = async (
   navName: string,
   markerNames: Set<string>,
 ): Promise<RailHour[]> => {
-  const deadline = Date.now() + timeoutMs;
   let screen: Rect | null = null;
-  let scoped: CaptureSnapshotResult | null = null;
   let lastSnapshotError: unknown = null;
-  do {
-    // A snapshot taken while Safari is still launching throws; that is a state
-    // to wait out, not to end the run on. The screen rect comes from an
-    // unscoped snapshot's root node — the window frame, which truncation
-    // cannot touch — and holds still for the rest of the run.
-    try {
-      screen ??= viewportOf(await takeSnapshot());
-      scoped = await takeSnapshot(navName);
-    } catch (error) {
-      lastSnapshotError = error;
-      console.warn("Snapshot failed while the page was settling; retrying.", error);
-    }
-    if (screen && scoped) {
-      const markers = railMarkersFrom(scoped, markerNames, screen);
-      if (markers.length > 0) return markers;
-    }
-    await wait(500);
-  } while (Date.now() < deadline);
+  // A slot, not a plain `let`: the assignment happens inside the probe
+  // closure, which TypeScript's flow analysis cannot see from out here.
+  const last: { scoped: CaptureSnapshotResult | null } = { scoped: null };
+  const markers = await pollUntil<RailHour[]>(
+    async () => {
+      // A snapshot taken while Safari is still launching throws; that is a
+      // state to wait out, not to end the run on. The screen rect comes from
+      // an unscoped snapshot's root node — the window frame, which truncation
+      // cannot touch — and holds still for the rest of the run.
+      try {
+        screen ??= viewportOf(await takeSnapshot());
+        last.scoped = await takeSnapshot(navName);
+      } catch (error) {
+        lastSnapshotError = error;
+        console.warn("Snapshot failed while the page was settling; retrying.", error);
+        return null;
+      }
+      const found = railMarkersFrom(last.scoped, markerNames, screen);
+      return found.length > 0 ? found : null;
+    },
+    { timeoutMs },
+  );
+  if (markers) return markers;
 
+  const scoped = last.scoped;
   if (!scoped) {
     throw new Error(
       `No snapshot succeeded in ${timeoutMs}ms; last error: ${String(lastSnapshotError)}`,
@@ -182,18 +188,17 @@ const pressTargets = (markers: RailHour[]): RailHour[] =>
 // budget, so ask for the sheet directly — the scope resolves via a live
 // element query with no such cap. When no callout is up the scope misses and
 // the runner falls back to the full tree, which then contains no signal.
-const surfacedCallout = async (timeoutMs: number): Promise<string[]> => {
-  const deadline = Date.now() + timeoutMs;
-  do {
-    await wait(500);
-    const labels = await snapshotLabels("Open in");
-    const surfaced = calloutSignals.filter((signal) =>
-      labels.some((label) => label.includes(signal)),
-    );
-    if (surfaced.length > 0) return surfaced;
-  } while (Date.now() < deadline);
-  return [];
-};
+const surfacedCallout = async (timeoutMs: number): Promise<string[]> =>
+  (await pollUntil<string[]>(
+    async () => {
+      const labels = await snapshotLabels("Open in");
+      const surfaced = calloutSignals.filter((signal) =>
+        labels.some((label) => label.includes(signal)),
+      );
+      return surfaced.length > 0 ? surfaced : null;
+    },
+    { timeoutMs },
+  )) ?? [];
 
 let surfacedCalloutSignals: string[] = [];
 


### PR DESCRIPTION
Split out of #789 — the `ios-regressions` job&#39;s flakiness had nothing to do with the participants limit, and fixing it turned into its own investigation.

## What was wrong

Three independent problems, each fixed at its root:

1. **Scroll gestures outran the runner.** Reaching mid-schedule cost up to 14 gestures, and one gesture on the 110-session seed page can exceed the runner&#39;s 180 s per-command ceiling. The rail&#39;s own `#slot-YYYYMMDD-HH` anchors land Safari there on load instead; the slot id is read from the served markup.

2. **Fixed waits raced the UI.** A snapshot taken before Safari applies the fragment scroll, or before a callout has had time to appear, reads as success. Every async check now polls to a deadline through one harness `pollUntil`; &#34;nothing surfaced&#34; is only concluded once the window has elapsed, and each window ends on a probe, not a sleep.

3. **The snapshot silently truncates at 300 nodes.** `fastSnapshotLimit` in the runner&#39;s `RunnerTests+Snapshot.swift` caps the walk and reports the rest only as `truncated: true`, which nothing read. The rail nav is the *last* element in the document, so it never appeared in any snapshot — every failed rail hunt across seven device runs, including the &#34;aria-labels never surface&#34; conclusion, was this cap, not label semantics. Snapshots are now **scoped** to the rail nav&#39;s own `aria-label` — the scope resolves via a live element query with no node cap, and only the rail subtree is walked. The callout check gets the same treatment (scoped to &#34;Open in&#34;), so the sheet can never be truncated away into a vacuous pass either.

The modal spec shares the harness changes: accessible names come from the served, language-pinned markup (Bun&#39;s `fetch` sends no `Accept-Language`, so Django would otherwise serve Polish while the simulator renders English), and visibility checks share one conservative screen-band convention instead of trusting `hittable`, which reads false inside Safari web content.

## Validation

Four consecutive on-device green runs (327ee7a, 32faeb7, 3195cbe, 35055d7). Mutation-tested in #803: with `[-webkit-touch-callout:none]`, the `contextmenu` preventDefault, and the modal description stripped, the scrubber failed with `surfacedCalloutSignals = ["Open in New Tab"]` and the modal failed its content check — on both retry attempts each — while the untouched behaviors kept passing. The specs fail on exactly the regressions they guard, and only on those.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AT39sjmMjfTKLVwLXmG6pB