### PR TITLE
Fix panel layout scrolling past the viewport on tall screens

### DIFF
--- a/src/ludamus/templates/panel/base.html
+++ b/src/ludamus/templates/panel/base.html
@@ -143,7 +143,7 @@ the sphere.{% endcomment %}
                 data-action="toggle-sidebar"></button>
         <!-- Sidebar -->
         <aside id="sidebar"
-               class="sidebar-panel w-64 overflow-x-hidden overflow-y-auto border-r border-border bg-bg-tertiary text-foreground dark:bg-bg-secondary flex-shrink-0 fixed inset-y-0 left-0 z-50 -translate-x-full lg:translate-x-0 lg:sticky lg:inset-auto lg:top-0 lg:z-auto lg:h-screen">
+               class="sidebar-panel w-64 overflow-x-hidden overflow-y-auto border-r border-border bg-bg-tertiary text-foreground dark:bg-bg-secondary flex-shrink-0 fixed inset-y-0 left-0 z-50 -translate-x-full lg:translate-x-0 lg:sticky lg:inset-auto lg:top-0 lg:z-auto lg:max-h-screen">
             <div class="sidebar-toggle sticky top-0 z-10 flex items-center pt-4 justify-end gap-1 bg-bg-tertiary p-2 dark:bg-bg-secondary">
                 {% if events %}
                     <div class="sidebar-fold-hide relative min-w-0 flex-1">

--- a/tests/e2e/tests/panel.spec.ts
+++ b/tests/e2e/tests/panel.spec.ts
@@ -157,6 +157,16 @@ test.describe("Backoffice Panel", () => {
     );
   });
 
+  test("shows the footer without scrolling on a tall viewport", async ({ page }) => {
+    await page.setViewportSize({ width: 1600, height: 1400 });
+    await page.goto("/panel/");
+
+    const overflow = await page
+      .locator("#app-scroll")
+      .evaluate((element) => element.scrollHeight - element.clientHeight);
+    expect(overflow).toBeLessThanOrEqual(1);
+  });
+
   test("does not scale panel category collapsibles on pointer down", async ({ page }) => {
     await page.goto("/panel/");
 


### PR DESCRIPTION
The panel sidebar was pinned to lg:h-screen, so the flex row holding it was always at least one viewport tall — plus the navbar and footer above and below it, the page overflowed by their height even with no content. Capping the sidebar with max-h-screen lets it stretch to the row instead, so a short page fits exactly.