### PR TITLE
test(flaky): quarantine test_print_document_title_names_the_document_and_the_event

### DIFF
--- a/PAPERCUTS.md
+++ b/PAPERCUTS.md
@@ -316,3 +316,10 @@ If you fix a papercut, remove it.
   permissions on /etc/ssh/ssh_config.d/20-systemd-ssh-proxy.conf'. Committing
   works, pushing needs the user to run it (or the file's mode fixed to 0644
   root:root).
+- 2026-08-08: Weekly flaky-test scan found
+  test_print_document_title_names_the_document_and_the_event
+  (test_page_metadata.py) failed twice on unrelated main commits (0f90b147f6,
+  3a2f9f5c5a) this week with AttributeError: 'HttpResponseRedirect' object has
+  no attribute 'context_data', then passed again with no related fix; could
+  not reproduce in 3 local full-suite pytest -n auto runs. Quarantined with a
+  skip pending root-cause.

--- a/tests/integration/web/test_page_metadata.py
+++ b/tests/integration/web/test_page_metadata.py
@@ -2,6 +2,7 @@ import re
 from http import HTTPStatus
 from pathlib import Path
 
+import pytest
 from django.core.files.uploadedfile import SimpleUploadedFile
 from django.urls import reverse
 
@@ -105,6 +106,16 @@ class TestPageTitle:
 
         assert _title(response) == f"Sphere settings • {sphere.name}"
 
+    @pytest.mark.skip(
+        reason=(
+            "Flaky under pytest-xdist: fails ~1/15 CI runs with "
+            "AttributeError: 'HttpResponseRedirect' object has no attribute "
+            "'context_data', i.e. the print view redirects instead of "
+            "rendering. Root cause not yet pinned down — see the flaky-test "
+            "report for the investigation. Quarantined rather than deleted "
+            "so the coverage gap stays visible."
+        )
+    )
     def test_print_document_title_names_the_document_and_the_event(
         self, manager_client, event, sphere
     ):


### PR DESCRIPTION
## Summary

Weekly flaky-test scan of the last 7 days of `CI` runs on `main` (30 runs,
30 full `pytest -n auto` executions of the ~3,600-test suite) found exactly
one flaky test:

- `tests/integration/web/test_page_metadata.py:108` —
  `TestPageTitle::test_print_document_title_names_the_document_and_the_event`

It failed on two consecutive, otherwise-unrelated commits this week
(`0f90b147f6`, `3a2f9f5c5a` — neither touches the print view or its
templates) with:

```
AttributeError: 'HttpResponseRedirect' object has no attribute 'context_data'
```

...then passed again on the very next commit with no related fix landing in
between. That error means the view actually returned a redirect instead of
a 200 — `_get_ok()`'s helper evaluates `response.context_data` eagerly as a
kwarg, so a redirect surfaces as an unhelpful `AttributeError` rather than a
clean "expected 200, got 302".

- Failing run 1: https://github.com/zagrajmy/ludamus/actions/runs/30764661987/job/91541125631 (commit `0f90b147f6`)
- Failing run 2: https://github.com/zagrajmy/ludamus/actions/runs/30767152317/job/91547789297 (commit `3a2f9f5c5a`)
- Passing run (surrounding commit, same test): https://github.com/zagrajmy/ludamus/actions/runs/30772048099/job/91560762838 (commit `c943f61787`)

## Root-cause investigation

`PublicEventPrintView` never redirects on its own. The only redirect in the
request path is `RequestContextMiddleware`, which redirects to the root
domain when it can't resolve a `Sphere` for `request.get_host()` — normally
unreachable here since `ROOT_DOMAIN=testserver` matches Django's test
client's default host exactly.

This matches a pattern already logged in `PAPERCUTS.md` for other tests in
this suite: sphere/site fixture collisions under `pytest-xdist` parallel
contention (e.g. `test_query_count_constant_in_session_count` flaking with
`UNIQUE constraint failed: sphere.site_id`, and another `test:py` run
flaking with `VariableDoesNotExist`). The `sphere` fixture's own docstring
already accounts for a stale row surviving a prior transactional test's
flush, which is consistent with cross-test contamination under `-n auto`.

I could not pin the exact trigger down further: 3 local full-suite
`pytest -n auto tests/integration` runs (mirroring CI exactly) all passed
(2743 passed / 9 skipped each time), consistent with the ~1-in-15 CI flake
rate observed. Rather than ship a guess at a fix, I'm quarantining the test
per the report's fallback instructions, with the investigation notes kept
in the skip reason and in `PAPERCUTS.md` so the next person has a head
start.

## Changes

- Added `@pytest.mark.skip(...)` to the flaky test with a reason explaining
  the failure mode and pointing back to this investigation.
- Logged the scan + quarantine in `PAPERCUTS.md`.

## tingle

`tingle check` reports `pytest-skip +1` for the new skip marker. This is a
deliberate, justified addition — quarantining a confirmed-flaky test rather
than deleting it, so the coverage gap stays visible until someone roots out
the cause.

## Test plan

- [x] `pytest tests/integration/web/test_page_metadata.py -v` — 16 passed, 1
      skipped
- [x] `mise run lint --jobs "$(nproc)"` — all green (oxlint, mypy, pylint,
      djlint, black, markdownlint, etc.)
- [x] `tingle check` — net +1 (justified above)

## No other flaky tests found

Every other failure in this week's 30 CI runs was deterministic: two runs
failed `checks` on a real pylint too-complexity violation in
`src/ludamus/gates/web/django/event/print.py` (McCabe 12, fixed by a later
commit), and one run failed `checks` on an `oxlint` binary download HTTP
error (CI infra flake, not a test).


---
_Generated by [Claude Code](https://claude.ai/code/session_01WdofXrc6AxhLHqfVXuXpB6)_