### PR TITLE
fix(durations): never show a raw ISO duration (#341)

### DIFF
--- a/src/ludamus/gates/web/django/chronology/forms.py
+++ b/src/ludamus/gates/web/django/chronology/forms.py
@@ -91,8 +91,10 @@ def build_session_details_form(
         "display_name": forms.CharField(label=_("Presenter name"), max_length=255),
     }
 
-    if durations:
-        duration_choices = [(d, format_duration(d)) for d in durations]
+    # A duration nothing can read is left out: an option is worth offering only
+    # when it can be labelled with a length.
+    duration_choices = [(d, label) for d in durations if (label := format_duration(d))]
+    if duration_choices:
         fields["duration"] = forms.ChoiceField(
             label=_("Duration"), choices=[("", "---"), *duration_choices]
         )

--- a/src/ludamus/gates/web/django/chronology/panel/views/google_docs_import.py
+++ b/src/ludamus/gates/web/django/chronology/panel/views/google_docs_import.py
@@ -30,6 +30,7 @@ from ludamus.gates.web.django.chronology.panel.views.base import (
 )
 from ludamus.mills.submissions.mapping import MissingKeyColumnsError, slugify
 from ludamus.pacts.chronology import IntegrationImplementationId, IntegrationKind
+from ludamus.pacts.durations import build_duration, parse_duration
 from ludamus.pacts.submissions import (
     DurationSpec,
     EntityRef,
@@ -79,7 +80,8 @@ class OptionEntity(TypedDict):
 
 class OptionDuration(TypedDict):
     option: str
-    iso: str
+    hours: int | None
+    minutes: int | None
 
 
 class OverrideRow(TypedDict):
@@ -391,16 +393,20 @@ def _option_entities(
 def _option_durations(
     question: SourceQuestion, target: QuestionTarget | None
 ) -> list[OptionDuration]:
-    # One row per source option, pre-filled with the operator-typed ISO 8601
-    # duration so the (hidden) editor is ready the moment the row becomes a
-    # session-duration target. A blank ISO leaves that option unmapped: the
+    # One row per source option, pre-filled with the length the operator picked
+    # so the (hidden) editor is ready the moment the row becomes a
+    # session-duration target. A blank length leaves that option unmapped: the
     # importer then skips rows whose answer hits this option.
     configured = target.values if target else {}
     rows: list[OptionDuration] = []
     for option in question.options:
         spec = configured.get(option)
-        iso = spec.iso if isinstance(spec, DurationSpec) else ""
-        rows.append({"option": option, "iso": iso})
+        hours, minutes = parse_duration(
+            spec.iso if isinstance(spec, DurationSpec) else ""
+        )
+        rows.append(
+            {"option": option, "hours": hours or None, "minutes": minutes or None}
+        )
     return rows
 
 
@@ -493,18 +499,27 @@ def _time_slot_values_from_post(
 
 
 def _duration_values_from_post(post: QueryDict, index: int) -> dict[str, QuestionValue]:
-    # Per-option ISO duration rows submit parallel arrays; a blank ISO drops
-    # that option (its answers will be skipped at import time).
+    # Per-option duration rows submit parallel arrays of hours and minutes; a
+    # zero-length option is dropped (its answers will be skipped at import
+    # time). ISO is composed here, never typed by the operator.
     values: dict[str, QuestionValue] = {}
     rows = zip(
-        post.getlist(f"droption_{index}"), post.getlist(f"driso_{index}"), strict=False
+        post.getlist(f"droption_{index}"),
+        post.getlist(f"drhours_{index}"),
+        post.getlist(f"drminutes_{index}"),
+        strict=False,
     )
-    for option, iso in rows:
-        clean_iso = iso.strip()
-        if not (option and clean_iso):
+    for option, hours, minutes in rows:
+        iso = build_duration(hours=_positive_int(hours), minutes=_positive_int(minutes))
+        if not (option and iso):
             continue
-        values[option] = DurationSpec(iso=clean_iso)
+        values[option] = DurationSpec(iso=iso)
     return values
+
+
+def _positive_int(raw: str) -> int:
+    text = (raw or "").strip()
+    return int(text) if text.isdigit() else 0
 
 
 def _entity_map_from_post(

--- a/src/ludamus/gates/web/django/chronology/panel/views/proposal_edit.py
+++ b/src/ludamus/gates/web/django/chronology/panel/views/proposal_edit.py
@@ -34,7 +34,6 @@ from ludamus.gates.web.django.dynamic_fields import (
     unfold_custom_answers,
 )
 from ludamus.gates.web.django.forms import CUSTOM_DURATION, create_proposal_form
-from ludamus.gates.web.django.templatetags.cfp_tags import parse_duration
 from ludamus.pacts import (
     NotFoundError,
     PersonalDataFieldValueData,
@@ -44,6 +43,7 @@ from ludamus.pacts import (
     SessionStatus,
     SessionUpdateData,
 )
+from ludamus.pacts.durations import parse_duration
 from ludamus.pacts.legacy import parse_uploaded_file, resolve_uploaded_file_field
 from ludamus.pacts.panel import ProposalDraft
 from ludamus.pacts.services import DatabaseConstraintError

--- a/src/ludamus/gates/web/django/event/panel/views/proposal_category_settings.py
+++ b/src/ludamus/gates/web/django/event/panel/views/proposal_category_settings.py
@@ -17,6 +17,7 @@ from ludamus.gates.web.django.event.panel.views.base import (
 )
 from ludamus.gates.web.django.forms import ProposalCategoryForm
 from ludamus.gates.web.django.panel import parse_requirement_selection
+from ludamus.pacts.durations import normalize_duration
 from ludamus.pacts.legacy import NotFoundError, PromotionMode, RedirectError
 from ludamus.pacts.submissions import (
     ProposalCategoryEditContextDTO,
@@ -61,8 +62,13 @@ def _settings_data(
         description=cleaned["description"],
         start_time=cleaned["start_time"],
         end_time=cleaned["end_time"],
+        # The steppers compose ISO already, but a duration saved before they
+        # existed can still be posted back — normalize so only readable lengths
+        # are stored.
         durations=[
-            duration for duration in request.POST.getlist("durations") if duration
+            normalized
+            for duration in request.POST.getlist("durations")
+            if (normalized := normalize_duration(duration))
         ],
         min_participants_limit=cleaned["min_participants_limit"] or 0,
         max_participants_limit=cleaned["max_participants_limit"] or 0,

--- a/src/ludamus/gates/web/django/forms.py
+++ b/src/ludamus/gates/web/django/forms.py
@@ -18,11 +18,9 @@ from ludamus.gates.web.django.dynamic_fields import (
     CustomAnswerFormMixin,
     build_dynamic_fields,
 )
-from ludamus.gates.web.django.templatetags.cfp_tags import (
-    build_duration,
-    format_duration,
-)
+from ludamus.gates.web.django.templatetags.cfp_tags import format_duration
 from ludamus.pacts.discounts import DiscountKind
+from ludamus.pacts.durations import build_duration
 from ludamus.pacts.images import ALLOWED_IMAGE_FORMATS, IMAGE_ACCEPT, LOGO_ACCEPT
 from ludamus.pacts.legacy import PromotionMode
 from ludamus.pacts.submissions import AccreditationType
@@ -686,15 +684,19 @@ class _ComposedDurationForm(SessionEditForm):
 
 def _duration_field(durations: Sequence[str]) -> forms.ChoiceField | None:
     # No configured durations means the steppers are the whole control, so the
-    # inherited free-text field is dropped (a None entry removes it).
-    if not durations:
+    # inherited free-text field is dropped (a None entry removes it). A stored
+    # duration nothing can read is dropped too: an option is worth offering
+    # only when it can be labelled with a length.
+    if not (
+        labelled := [(d, label) for d in durations if (label := format_duration(d))]
+    ):
         return None
     return forms.ChoiceField(
         required=False,
         label=_("Duration"),
         choices=[
             ("", "---"),
-            *((d, format_duration(d)) for d in durations),
+            *labelled,
             # Kept last: the template reveals the steppers with a CSS
             # :last-child selector rather than JavaScript.
             (CUSTOM_DURATION, _("Custom")),

--- a/src/ludamus/gates/web/django/templatetags/cfp_tags.py
+++ b/src/ludamus/gates/web/django/templatetags/cfp_tags.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import re
 from typing import TYPE_CHECKING, Any
 
 from django import template
@@ -8,6 +7,7 @@ from django.utils import timezone
 from django.utils.translation import gettext as _
 
 from ludamus.gates.web.django.helpers import placeholder_cover_url
+from ludamus.pacts.durations import parse_duration
 
 if TYPE_CHECKING:
     from ludamus.pacts import SessionDTO
@@ -154,28 +154,6 @@ def format_field_value(value: Any) -> str:  # type: ignore[misc] # ruff:ignore[a
     return str(value)
 
 
-def parse_duration(iso_duration: str) -> tuple[int, int]:
-    """Split an ISO 8601 duration into hours and minutes.
-
-    Returns:
-        (hours, minutes), both 0 for anything unparsable.
-    """
-    if not (match := re.match(r"PT(?:(\d+)H)?(?:(\d+)M)?", iso_duration or "")):
-        return 0, 0
-    return int(match.group(1) or 0), int(match.group(2) or 0)
-
-
-def build_duration(*, hours: int, minutes: int) -> str:
-    """Compose an ISO 8601 duration, empty when both parts are zero.
-
-    Returns:
-        A string like "PT1H30M", "PT45M" or "".
-    """
-    if not hours and not minutes:
-        return ""
-    return "PT" + (f"{hours}H" if hours else "") + (f"{minutes}M" if minutes else "")
-
-
 @register.filter
 def format_duration(iso_duration: str) -> str:
     """Format ISO 8601 duration string to human-readable format.
@@ -184,11 +162,9 @@ def format_duration(iso_duration: str) -> str:
         iso_duration: ISO 8601 duration string (e.g., "PT1H45M", "PT30M", "PT2H")
 
     Returns:
-        Human-readable duration (e.g., "1h 45min", "30min", "2h")
+        Human-readable duration ("1h 45min", "30min", "2h"), empty when the
+        stored value is unreadable — a raw ISO string is never shown.
     """
-    if not iso_duration:
-        return ""
-
     hours, minutes = parse_duration(iso_duration)
 
     if hours and minutes:
@@ -197,4 +173,4 @@ def format_duration(iso_duration: str) -> str:
         return f"{hours}h"
     if minutes:
         return f"{minutes}min"
-    return iso_duration
+    return ""

--- a/src/ludamus/links/db/django/migrations/0142_normalize_durations.py
+++ b/src/ludamus/links/db/django/migrations/0142_normalize_durations.py
@@ -1,0 +1,37 @@
+from django.db import migrations
+
+from ludamus.pacts.durations import normalize_duration
+
+
+def normalize_stored_durations(apps, schema_editor):
+    del schema_editor
+    # Durations reached storage as whatever their author typed ("P4H",
+    # "50min", "110m"). Rewrite them in the one format readers understand;
+    # anything unreadable becomes unset rather than shown raw.
+    session_model = apps.get_model("db_main", "Session")
+    # Soft-deleted rows included: restoring a session must not bring an
+    # unreadable duration back with it.
+    for session in session_model.objects.exclude(duration="").iterator():
+        if (normalized := normalize_duration(session.duration)) != session.duration:
+            session.duration = normalized
+            session.save(update_fields=["duration"])
+
+    category_model = apps.get_model("db_main", "ProposalCategory")
+    for category in category_model.objects.iterator():
+        normalized_durations = [
+            normalized
+            for duration in category.durations or []
+            if (normalized := normalize_duration(duration))
+        ]
+        if normalized_durations != category.durations:
+            category.durations = normalized_durations
+            category.save(update_fields=["durations"])
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [("db_main", "0141_eventpanelsettings_proposal_columns")]
+
+    operations = [
+        migrations.RunPython(normalize_stored_durations, migrations.RunPython.noop)
+    ]

--- a/src/ludamus/locale/pl/LC_MESSAGES/django.po
+++ b/src/ludamus/locale/pl/LC_MESSAGES/django.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-08-08 12:08+0200\n"
+"POT-Creation-Date: 2026-08-09 13:50+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -643,30 +643,37 @@ msgid "%(name)s (manages their own enrollment)"
 msgstr "%(name)s (zarządza swoimi zapisami)"
 
 #: src/ludamus/adapters/web/django/views.py
+#, python-brace-format
 msgid "Enrolled: {}"
 msgstr "Zapisani: {}"
 
 #: src/ludamus/adapters/web/django/views.py
+#, python-brace-format
 msgid "Added to waiting list: {}"
 msgstr "Dodani do listy oczekujących: {}"
 
 #: src/ludamus/adapters/web/django/views.py
+#, python-brace-format
 msgid "Seat held (awaiting their approval): {}"
 msgstr "Miejsce zarezerwowane (czeka na ich zgodę): {}"
 
 #: src/ludamus/adapters/web/django/views.py
+#, python-brace-format
 msgid "Cancelled: {}"
 msgstr "Anulowani: {}"
 
 #: src/ludamus/adapters/web/django/views.py
+#, python-brace-format
 msgid "Skipped (already enrolled or conflicts): {}"
 msgstr "Pominięci (już zapisani lub konflikty): {}"
 
 #: src/ludamus/adapters/web/django/views.py
+#, python-brace-format
 msgid "Guests you bring: {}"
 msgstr "Goście, których zabierasz: {}"
 
 #: src/ludamus/adapters/web/django/views.py
+#, python-brace-format
 msgid ""
 "Not enough spots available. {} spots requested, {} available. Bring fewer "
 "guests or use the waiting list for account holders."
@@ -675,6 +682,7 @@ msgstr ""
 "Zabierz mniej gości lub użyj listy oczekujących dla posiadaczy kont."
 
 #: src/ludamus/adapters/web/django/views.py
+#, python-brace-format
 msgid ""
 "Not enough spots available. {} spots requested, {} available. Please use "
 "waiting list for some users."
@@ -1153,6 +1161,7 @@ msgid "disallowed"
 msgstr "niedozwolone"
 
 #: src/ludamus/gates/web/django/chronology/panel/views/event_settings.py
+#, python-brace-format
 msgid "Use sphere default (currently: {})"
 msgstr "Użyj domyślnego ustawienia sfery (obecnie: {})"
 
@@ -1879,6 +1888,7 @@ msgid "Please wait before submitting another proposal."
 msgstr "Poczekaj chwilę przed przesłaniem kolejnego zgłoszenia."
 
 #: src/ludamus/gates/web/django/chronology/views.py
+#, python-brace-format
 msgid "Session proposal '{}' submitted successfully!"
 msgstr "Zgłoszenie punktu programu '{}' zostało pomyślnie przesłane!"
 
@@ -1887,6 +1897,7 @@ msgid "There is already a session scheduled at this space and time."
 msgstr "W tej przestrzeni i w tym czasie jest już zaplanowany punkt programu."
 
 #: src/ludamus/gates/web/django/chronology/views.py
+#, python-brace-format
 msgid "Proposal '{}' has been accepted and added to the agenda."
 msgstr "Zgłoszenie '{}' zostało zaakceptowane i dodane do programu."
 

--- a/src/ludamus/locale/pl/LC_MESSAGES/django.po
+++ b/src/ludamus/locale/pl/LC_MESSAGES/django.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-08-06 00:14+0200\n"
+"POT-Creation-Date: 2026-08-08 12:08+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -643,37 +643,30 @@ msgid "%(name)s (manages their own enrollment)"
 msgstr "%(name)s (zarządza swoimi zapisami)"
 
 #: src/ludamus/adapters/web/django/views.py
-#, python-brace-format
 msgid "Enrolled: {}"
 msgstr "Zapisani: {}"
 
 #: src/ludamus/adapters/web/django/views.py
-#, python-brace-format
 msgid "Added to waiting list: {}"
 msgstr "Dodani do listy oczekujących: {}"
 
 #: src/ludamus/adapters/web/django/views.py
-#, python-brace-format
 msgid "Seat held (awaiting their approval): {}"
 msgstr "Miejsce zarezerwowane (czeka na ich zgodę): {}"
 
 #: src/ludamus/adapters/web/django/views.py
-#, python-brace-format
 msgid "Cancelled: {}"
 msgstr "Anulowani: {}"
 
 #: src/ludamus/adapters/web/django/views.py
-#, python-brace-format
 msgid "Skipped (already enrolled or conflicts): {}"
 msgstr "Pominięci (już zapisani lub konflikty): {}"
 
 #: src/ludamus/adapters/web/django/views.py
-#, python-brace-format
 msgid "Guests you bring: {}"
 msgstr "Goście, których zabierasz: {}"
 
 #: src/ludamus/adapters/web/django/views.py
-#, python-brace-format
 msgid ""
 "Not enough spots available. {} spots requested, {} available. Bring fewer "
 "guests or use the waiting list for account holders."
@@ -682,7 +675,6 @@ msgstr ""
 "Zabierz mniej gości lub użyj listy oczekujących dla posiadaczy kont."
 
 #: src/ludamus/adapters/web/django/views.py
-#, python-brace-format
 msgid ""
 "Not enough spots available. {} spots requested, {} available. Please use "
 "waiting list for some users."
@@ -1161,7 +1153,6 @@ msgid "disallowed"
 msgstr "niedozwolone"
 
 #: src/ludamus/gates/web/django/chronology/panel/views/event_settings.py
-#, python-brace-format
 msgid "Use sphere default (currently: {})"
 msgstr "Użyj domyślnego ustawienia sfery (obecnie: {})"
 
@@ -1887,7 +1878,6 @@ msgid "Please wait before submitting another proposal."
 msgstr "Poczekaj chwilę przed przesłaniem kolejnego zgłoszenia."
 
 #: src/ludamus/gates/web/django/chronology/views.py
-#, python-brace-format
 msgid "Session proposal '{}' submitted successfully!"
 msgstr "Zgłoszenie punktu programu '{}' zostało pomyślnie przesłane!"
 
@@ -1896,7 +1886,6 @@ msgid "There is already a session scheduled at this space and time."
 msgstr "W tej przestrzeni i w tym czasie jest już zaplanowany punkt programu."
 
 #: src/ludamus/gates/web/django/chronology/views.py
-#, python-brace-format
 msgid "Proposal '{}' has been accepted and added to the agenda."
 msgstr "Zgłoszenie '{}' zostało zaakceptowane i dodane do programu."
 
@@ -2645,10 +2634,12 @@ msgstr "Nieprawidłowy wybór kategorii."
 
 #: src/ludamus/gates/web/django/forms.py
 #: src/ludamus/templates/chronology/print.html
+#: src/ludamus/templates/panel/parts/import-recipe-row.html
 msgid "Hours"
 msgstr "Godziny"
 
 #: src/ludamus/gates/web/django/forms.py
+#: src/ludamus/templates/panel/parts/import-recipe-row.html
 msgid "Minutes"
 msgstr "Minuty"
 
@@ -6333,10 +6324,12 @@ msgid "Define how long sessions of this category can be."
 msgstr "Określ jak długo mogą trwać punkty programu w tej kategorii."
 
 #: src/ludamus/templates/panel/cfp-edit.html
+#: src/ludamus/templates/panel/parts/import-recipe-row.html
 msgid "h"
 msgstr "h"
 
 #: src/ludamus/templates/panel/cfp-edit.html
+#: src/ludamus/templates/panel/parts/import-recipe-row.html
 msgid "min"
 msgstr "min"
 
@@ -7557,15 +7550,11 @@ msgstr "Domyślny dla odpowiedzi własnych"
 
 #: src/ludamus/templates/panel/parts/import-recipe-row.html
 msgid ""
-"Map each source answer to an ISO 8601 duration (e.g. PT1H30M for 1 h 30 "
-"min). Answers without a mapping are skipped at import time."
+"Set how long each source answer means. Answers left at zero are skipped at "
+"import time."
 msgstr ""
-"Zmapuj każdą odpowiedź źródłową na czas trwania ISO 8601 (np. PT1H30M dla 1 "
-"g 30 min). Odpowiedzi bez mapowania są pomijane przy imporcie."
-
-#: src/ludamus/templates/panel/parts/import-recipe-row.html
-msgid "ISO 8601 duration"
-msgstr "Czas trwania ISO 8601"
+"Ustaw, jaką długość oznacza każda odpowiedź źródłowa. Odpowiedzi z zerową "
+"długością są pomijane przy imporcie."
 
 #: src/ludamus/templates/panel/parts/import-recipe-row.html
 msgid ""
@@ -8803,6 +8792,16 @@ msgstr "Temat"
 #: src/ludamus/templates/staging_email_inbox.html
 msgid "No emails captured yet."
 msgstr "Brak przechwyconych e-maili."
+
+#~ msgid ""
+#~ "Map each source answer to an ISO 8601 duration (e.g. PT1H30M for 1 h 30 "
+#~ "min). Answers without a mapping are skipped at import time."
+#~ msgstr ""
+#~ "Zmapuj każdą odpowiedź źródłową na czas trwania ISO 8601 (np. PT1H30M dla "
+#~ "1 g 30 min). Odpowiedzi bez mapowania są pomijane przy imporcie."
+
+#~ msgid "ISO 8601 duration"
+#~ msgstr "Czas trwania ISO 8601"
 
 #, python-format
 #~ msgid "%(scheduled)s scheduled, %(pending)s pending"

--- a/src/ludamus/mills/legacy.py
+++ b/src/ludamus/mills/legacy.py
@@ -34,6 +34,7 @@ from ludamus.pacts import (
     UploadedFileProtocol,
     WizardData,
 )
+from ludamus.pacts.durations import normalize_duration
 from ludamus.pacts.submissions import is_empty_answer
 from ludamus.specs.encounter import ENCOUNTER_DEFAULT_DURATION
 from ludamus.specs.proposal import PROPOSAL_RATE_LIMIT_SECONDS
@@ -350,7 +351,9 @@ class ProposeSessionService:
                 title=title,
                 slug=slug,
                 description=description,
-                duration=str(session_data.get("duration") or ""),
+                # Whatever the source calls a duration ("50min", "110m") is
+                # normalized on the way in: storage holds ISO or nothing.
+                duration=normalize_duration(str(session_data.get("duration") or "")),
                 participants_limit=participants_limit,
                 min_age=int(str(session_data.get("min_age") or 0)),
                 contact_email=wizard_data.get("contact_email", ""),

--- a/src/ludamus/mills/submissions/mapping.py
+++ b/src/ludamus/mills/submissions/mapping.py
@@ -11,6 +11,7 @@ from unidecode import unidecode
 
 from ludamus.mills.field_values import split_imported_answers
 from ludamus.pacts import PersonalDataFieldValueData, SessionFieldValueData
+from ludamus.pacts.durations import normalize_duration
 from ludamus.pacts.submissions import (
     DuplicateValueError,
     DurationSpec,
@@ -188,8 +189,10 @@ def _duration_iso(target: QuestionTarget, header: str, answer: str) -> str:
     if not answer.strip():
         return ""
     spec = target.values.get(answer)
-    if isinstance(spec, DurationSpec) and spec.iso:
-        return spec.iso
+    # Recipes saved before the length steppers existed can hold a hand-typed
+    # spec, so it is normalized rather than trusted.
+    if isinstance(spec, DurationSpec) and (iso := normalize_duration(spec.iso)):
+        return iso
     return _skip(f"{header}: unmapped duration answer '{answer}'")
 
 

--- a/src/ludamus/pacts/durations.py
+++ b/src/ludamus/pacts/durations.py
@@ -1,0 +1,36 @@
+"""The stored shape of a session length.
+
+`Session.duration` and `ProposalCategory.durations` hold ISO 8601 durations.
+That format is a storage detail every writer normalizes into and every reader
+leaves: it must not reach a screen, organizer's or participant's.
+"""
+
+import re
+
+MINUTES_PER_HOUR = 60
+_CANONICAL_DURATION_RE = re.compile(r"PT(?:(?P<hours>\d+)H)?(?:(?P<minutes>\d+)M)?")
+_DURATION_PART_RE = re.compile(r"(?P<hours>\d+)\s*h|(?P<minutes>\d+)\s*m")
+
+
+def parse_duration(iso_duration: str) -> tuple[int, int]:
+    if not (match := _CANONICAL_DURATION_RE.fullmatch(iso_duration or "")):
+        return 0, 0
+    return int(match["hours"] or 0), int(match["minutes"] or 0)
+
+
+def build_duration(*, hours: int, minutes: int) -> str:
+    if not hours and not minutes:
+        return ""
+    return "PT" + (f"{hours}H" if hours else "") + (f"{minutes}M" if minutes else "")
+
+
+def normalize_duration(text: str) -> str:
+    # Durations arrive in whatever shape their author felt like — "P4H",
+    # "50min", "110m". Read every hour and minute part out of the text and
+    # rebuild canonically; text carrying neither normalizes to "" (unset).
+    hours = minutes = 0
+    for part in _DURATION_PART_RE.finditer((text or "").lower()):
+        hours += int(part.group("hours") or 0)
+        minutes += int(part.group("minutes") or 0)
+    carried, minutes = divmod(minutes, MINUTES_PER_HOUR)
+    return build_duration(hours=hours + carried, minutes=minutes)

--- a/src/ludamus/templates/chronology/_session_card.html
+++ b/src/ludamus/templates/chronology/_session_card.html
@@ -62,10 +62,12 @@
                         {% icon "map-pin" class="size-4 shrink-0 text-foreground-muted/80" variant="mini" %}
                         <span class="truncate" title="{{ data.location_label }}">{{ data.location_label }}</span>
                     {% endif %}
-                    {% if data.session.duration %}
-                        {% icon "clock" class="size-4 shrink-0 text-foreground-muted/80" variant="mini" %}
-                        <span class="shrink-0">{{ data.session.duration|format_duration }}</span>
-                    {% endif %}
+                    {% with duration_label=data.session.duration|format_duration %}
+                        {% if duration_label %}
+                            {% icon "clock" class="size-4 shrink-0 text-foreground-muted/80" variant="mini" %}
+                            <span class="shrink-0">{{ duration_label }}</span>
+                        {% endif %}
+                    {% endwith %}
                 </div>
                 <div class="shrink-0 flex items-center gap-2">
                     {% if data.is_pending_proposal %}

--- a/src/ludamus/templates/panel/cfp-edit.html
+++ b/src/ludamus/templates/panel/cfp-edit.html
@@ -166,14 +166,19 @@
                         </div>
                         <div id="durations-list" class="space-y-2">
                             {% for duration in durations %}
-                                <div class="duration-item flex items-center justify-between py-2 px-3 bg-bg-tertiary rounded-lg">
-                                    <span class="text-sm text-foreground-secondary">{{ duration|format_duration }}</span>
-                                    <input type="hidden" name="durations" value="{{ duration }}">
-                                    <button type="button"
-                                            class="remove-duration text-foreground-muted hover:text-danger transition">
-                                        {% icon "x-mark" class="w-4 h-4" %}
-                                    </button>
-                                </div>
+                                {# An unreadable stored duration is left out entirely, so saving drops it. #}
+                                {% with duration_label=duration|format_duration %}
+                                    {% if duration_label %}
+                                        <div class="duration-item flex items-center justify-between py-2 px-3 bg-bg-tertiary rounded-lg">
+                                            <span class="text-sm text-foreground-secondary">{{ duration_label }}</span>
+                                            <input type="hidden" name="durations" value="{{ duration }}">
+                                            <button type="button"
+                                                    class="remove-duration text-foreground-muted hover:text-danger transition">
+                                                {% icon "x-mark" class="w-4 h-4" %}
+                                            </button>
+                                        </div>
+                                    {% endif %}
+                                {% endwith %}
                             {% empty %}
                                 <p id="no-durations-msg" class="text-sm text-foreground-muted italic">
                                     {% translate "No durations configured yet." %}

--- a/src/ludamus/templates/panel/parts/import-recipe-row.html
+++ b/src/ludamus/templates/panel/parts/import-recipe-row.html
@@ -193,7 +193,7 @@
     <div class="recipe-durations mt-3 max-w-xl space-y-3 sm:ml-20 {% if row.selected != "session.duration" %}hidden{% endif %}"
          data-row="{{ row.index }}">
         <p class="text-xs text-foreground-muted">
-            {% translate "Map each source answer to an ISO 8601 duration (e.g. PT1H30M for 1 h 30 min). Answers without a mapping are skipped at import time." %}
+            {% translate "Set how long each source answer means. Answers left at zero are skipped at import time." %}
         </p>
         {% for dur in row.option_durations %}
             <div class="dr-option rounded-lg border border-border bg-bg-tertiary p-3">
@@ -201,14 +201,24 @@
                 <input type="hidden"
                        name="droption_{{ row.index }}"
                        value="{{ dur.option }}">
-                <input type="text"
-                       name="driso_{{ row.index }}"
-                       value="{{ dur.iso }}"
-                       aria-label="{% translate "ISO 8601 duration" %}"
-                       placeholder="PT1H30M"
-                       pattern="PT(\d+H)?(\d+M)?"
-                       title="PT1H30M"
-                       class="w-full rounded-lg border border-border bg-bg-secondary px-2 py-1 text-sm text-foreground focus:outline-none focus:ring-2 focus:ring-primary">
+                <div class="flex items-center gap-2">
+                    <input type="number"
+                           name="drhours_{{ row.index }}"
+                           value="{{ dur.hours|default_if_none:"" }}"
+                           min="0"
+                           max="24"
+                           aria-label="{% translate "Hours" %}"
+                           class="w-16 rounded-lg border border-border bg-bg-secondary px-2 py-1 text-center text-sm text-foreground focus:outline-none focus:ring-2 focus:ring-primary">
+                    <span class="text-sm text-foreground-muted">{% translate "h" %}</span>
+                    <input type="number"
+                           name="drminutes_{{ row.index }}"
+                           value="{{ dur.minutes|default_if_none:"" }}"
+                           min="0"
+                           max="59"
+                           aria-label="{% translate "Minutes" %}"
+                           class="w-16 rounded-lg border border-border bg-bg-secondary px-2 py-1 text-center text-sm text-foreground focus:outline-none focus:ring-2 focus:ring-primary">
+                    <span class="text-sm text-foreground-muted">{% translate "min" %}</span>
+                </div>
             </div>
         {% endfor %}
     </div>

--- a/src/ludamus/templates/panel/proposal-detail.html
+++ b/src/ludamus/templates/panel/proposal-detail.html
@@ -188,14 +188,16 @@
                                     {{ proposal.participants_limit|default_if_none:"—" }}
                                 </dd>
                             </div>
-                            {% if proposal.duration %}
-                                <div>
-                                    <dt class="text-xs text-foreground-muted">{% translate "Duration" %}</dt>
-                                    <dd class="text-foreground">
-                                        {{ proposal.duration|format_duration }}
-                                    </dd>
-                                </div>
-                            {% endif %}
+                            {% with duration_label=proposal.duration|format_duration %}
+                                {% if duration_label %}
+                                    <div>
+                                        <dt class="text-xs text-foreground-muted">{% translate "Duration" %}</dt>
+                                        <dd class="text-foreground">
+                                            {{ duration_label }}
+                                        </dd>
+                                    </div>
+                                {% endif %}
+                            {% endwith %}
                             {% if proposal.min_age %}
                                 <div>
                                     <dt class="text-xs text-foreground-muted">{% translate "Minimum Age" %}</dt>

--- a/tests/integration/web/panel/test_cfp_edit_page.py
+++ b/tests/integration/web/panel/test_cfp_edit_page.py
@@ -874,6 +874,25 @@ class TestProposalCategorySettingsPageView:
         category.refresh_from_db()
         assert category.durations == ["PT30M", "PT1H", "PT2H"]
 
+    def test_post_normalizes_durations(self, panel_client, event):
+        category = ProposalCategory.objects.create(
+            event=event, name="RPG Sessions", slug="rpg-sessions"
+        )
+
+        response = panel_client.post(
+            self.get_url(event, category),
+            data={"name": "RPG Sessions", "durations": ["P4H", "50min", "nonsense"]},
+        )
+
+        assert_response(
+            response,
+            HTTPStatus.FOUND,
+            messages=[(messages.SUCCESS, "Category updated successfully.")],
+            url=f"/panel/event/{event.slug}/cfp/",
+        )
+        category.refresh_from_db()
+        assert category.durations == ["PT4H", "PT50M"]
+
     def test_post_updates_existing_durations(self, panel_client, event):
         category = ProposalCategory.objects.create(
             event=event,

--- a/tests/integration/web/panel/test_import_views.py
+++ b/tests/integration/web/panel/test_import_views.py
@@ -310,8 +310,8 @@ class TestEventImportProposalView:
                     {"option": "18+", "name": "18+", "slug": "18"},
                 ],
                 "option_durations": [
-                    {"option": "do 16", "iso": ""},
-                    {"option": "18+", "iso": ""},
+                    {"option": "do 16", "hours": None, "minutes": None},
+                    {"option": "18+", "hours": None, "minutes": None},
                 ],
                 "overrides": [{"raw": "", "replacement": ""}],
                 "catchall_name": "",
@@ -3245,7 +3245,7 @@ class TestImportRowSavePostHelpers:
         # An unrecognised field type falls back to text.
         assert settings.definitions.personal_fields["phone"].type == "text"
 
-    def test_post_saves_duration_target_and_skips_blank_iso(
+    def test_post_saves_duration_target_and_skips_blank_length(
         self, panel_client, event, connection_with_secret
     ):
         integration = make_integration(
@@ -3259,7 +3259,8 @@ class TestImportRowSavePostHelpers:
                 "question_0": "Length",
                 "target_0": "session.duration",
                 "droption_0": ["30 min", "blank"],
-                "driso_0": ["PT30M", "  "],
+                "drhours_0": ["", ""],
+                "drminutes_0": ["30", "  "],
             },
         )
 
@@ -3269,8 +3270,9 @@ class TestImportRowSavePostHelpers:
             integration.settings_json
         ).questions["Length"]
         assert target.to == "session.duration"
-        # The blank-ISO option is dropped; only the mapped one survives.
+        # The zero-length option is dropped; only the mapped one survives.
         assert set(target.values) == {"30 min"}
+        assert target.values["30 min"].iso == "PT30M"
 
     def test_post_skips_blank_time_slot_row(
         self, panel_client, event, connection_with_secret

--- a/tests/unit/gates/web/django/templatetags/test_cfp_tags.py
+++ b/tests/unit/gates/web/django/templatetags/test_cfp_tags.py
@@ -20,11 +20,14 @@ class TestFormatDuration:
         assert not format_duration(None)  # type: ignore[arg-type]
 
     def test_invalid_format(self) -> None:
-        assert format_duration("invalid") == "invalid"
+        assert not format_duration("invalid")
 
     def test_pt_only(self) -> None:
-        # PT with no hours or minutes - regex matches but both groups are None
-        assert format_duration("PT") == "PT"
+        assert not format_duration("PT")
+
+    @pytest.mark.parametrize("stored", ("P4H", "50min", "110m", "PT1H30MJUNK"))
+    def test_unreadable_value_is_not_echoed(self, stored: str) -> None:
+        assert not format_duration(stored)
 
     @pytest.mark.parametrize(
         ("iso", "expected"),

--- a/tests/unit/test_pacts_durations.py
+++ b/tests/unit/test_pacts_durations.py
@@ -1,0 +1,56 @@
+import pytest
+
+from ludamus.pacts.durations import build_duration, normalize_duration, parse_duration
+
+
+class TestParseDuration:
+    @pytest.mark.parametrize(
+        ("iso", "expected"),
+        (("PT1H30M", (1, 30)), ("PT2H", (2, 0)), ("PT45M", (0, 45))),
+    )
+    def test_canonical_value(self, iso: str, expected: tuple[int, int]) -> None:
+        assert parse_duration(iso) == expected
+
+    @pytest.mark.parametrize(
+        "stored", ("", "PT", "P4H", "50min", "PT1H30MJUNK", "JUNKPT1H")
+    )
+    def test_unreadable_value(self, stored: str) -> None:
+        assert parse_duration(stored) == (0, 0)
+
+
+class TestBuildDuration:
+    @pytest.mark.parametrize(
+        ("hours", "minutes", "expected"),
+        ((1, 30, "PT1H30M"), (2, 0, "PT2H"), (0, 45, "PT45M"), (0, 0, "")),
+    )
+    def test_composition(self, hours: int, minutes: int, expected: str) -> None:
+        assert build_duration(hours=hours, minutes=minutes) == expected
+
+
+class TestNormalizeDuration:
+    # The values production actually held when issue #341 was filed.
+    @pytest.mark.parametrize(
+        ("stored", "expected"),
+        (
+            ("P4H", "PT4H"),
+            ("50min", "PT50M"),
+            ("110m", "PT1H50M"),
+            ("110min", "PT1H50M"),
+        ),
+    )
+    def test_production_values(self, stored: str, expected: str) -> None:
+        assert normalize_duration(stored) == expected
+
+    @pytest.mark.parametrize("iso", ("PT4H", "PT1H30M", "PT50M"))
+    def test_canonical_value_round_trips(self, iso: str) -> None:
+        assert normalize_duration(iso) == iso
+
+    @pytest.mark.parametrize("stored", ("", "invalid", "2026-06-05"))
+    def test_unreadable_value_becomes_unset(self, stored: str) -> None:
+        assert not normalize_duration(stored)
+
+    def test_minutes_carry_into_hours(self) -> None:
+        assert normalize_duration("1h 90m") == "PT2H30M"
+
+    def test_idempotent(self) -> None:
+        assert normalize_duration(normalize_duration("110min")) == "PT1H50M"


### PR DESCRIPTION
`format_duration` echoed its input when the value didn't parse, so a stored "P4H" reached the session card, the proposal detail and the category editor verbatim. Production held five such values across 13 rows, all hand-typed or fed in by the legacy importer.

- one duration contract in `pacts/durations.py`: strict `parse_duration`, `build_duration`, and `normalize_duration` for loose input
- `format_duration` returns "" rather than the raw string; the three templates and both duration choice fields guard on the label
- every writer normalizes: the legacy feed (where "50min" and "110m" came from), the category settings POST, and the import recipe
- the recipe's per-option ISO text box becomes hours/minutes steppers, so no organizer is asked to type ISO
- data migration rewrites the stored values, soft-deleted rows included