### PR TITLE
perf(rituals): hand agents the tail of a gate log, not the transcript

### DIFF
--- a/src/ludamus/edges/rituals/pr_check.py
+++ b/src/ludamus/edges/rituals/pr_check.py
@@ -68,6 +68,7 @@ from .shell import (
     WAIT_LABEL,
     ahead,
     commit,
+    coverage_report,
     label,
     quoted,
     release,
@@ -248,11 +249,13 @@ async def finish_merge(work: Work) -> Transition:
 @step
 async def cover(work: Work) -> Transition:
     measured = await shell(COVERAGE)
-    output = said(measured)
-    # The report's own word for a line no test reached. Read from the output
+    output = coverage_report(measured)
+    # The report's own words for a line no test reached. Read from the output
     # rather than the exit code, which is also non-zero for a threshold this
-    # ritual has no business moving.
-    if "Missing" in output:
+    # ritual has no business moving. Both words and not just "Missing": the
+    # summary block below the listing says "Missing: 0 lines" on a clean report
+    # too, so the bare word matches every run there is.
+    if "Missing lines" in output:
         if exhausted(work, cover.name):
             return goto(
                 set_aside,

--- a/src/ludamus/edges/rituals/shell.py
+++ b/src/ludamus/edges/rituals/shell.py
@@ -38,31 +38,68 @@ WAIT_LABEL = "pr::wait"
 
 STASHED = "stashed"
 
-# How much of a gate's output is worth paying for. A mise task list stops at the
-# first failure, and every tool in it puts its verdict last — pytest's short
-# summary, diff-cover's missing lines — so the tail is the part that says what
-# is wrong. What sits above it is a suite naming three and a half thousand tests
-# that passed, and an agent told to re-run one failing test by name does not
-# need to read them.
-TAIL = 20
+# How much of a gate's output is worth paying for, counted in characters rather
+# than lines: what is being spent is tokens, and a line has no fixed price —
+# twenty lines of ruff is a couple of hundred bytes, and twenty carrying a
+# pytest assertion repr or a mypy note about a long generic type is orders of
+# magnitude more. A mise task list stops at the first failure, and every tool in
+# it puts its verdict last — pytest's short summary, ruff's count — so what fits
+# at the end is the part that says what is wrong. What sits above it is a suite
+# naming three and a half thousand tests that passed, and an agent told to
+# re-run one failing test by name does not need to read them.
+BUDGET = 4000
+
+# diff-cover's report is self-delimiting — its own banner, then everything to
+# the end of the run — so the one caller that reads the report needs no budget
+# at all. See `coverage_report`.
+BANNER = "Diff Coverage"
 
 
 def quoted(value: str) -> str:
     return shlex.quote(value)
 
 
+# The budget buys whole lines, and the last line is bought whether it fits or
+# not: a tool that pretty-prints a value onto one long line would otherwise
+# spend the budget and hand back nothing.
+def _tail(text: str) -> str:
+    lines = text.splitlines()
+    kept: list[str] = []
+    left = BUDGET
+    for line in reversed(lines):
+        left -= len(line) + 1
+        if left < 0 and kept:
+            break
+        kept.append(line)
+    if len(kept) == len(lines):
+        return "\n".join(lines)
+    kept.reverse()
+    return "\n".join([f"[{len(lines) - len(kept)} earlier lines omitted]", *kept])
+
+
 # Both streams: a task that dies before it starts says so on stderr and nowhere
 # else, and an empty complaint is the one thing a repair agent cannot work with.
+# Each stream gets the budget on its own rather than sharing one, because mise
+# puts its own task chatter on stderr and the tool's verdict on stdout, and a
+# shared budget is won by whichever stream is longer — which is the chatter.
 # Trimmed here rather than at each prompt, because every caller does the same
 # two things with this — hand it to an agent, or put it in the report — and both
 # want the verdict, not the transcript.
 def said(result: ShellResult) -> str:
-    joined = "\n".join(part for part in (result.stdout, result.stderr) if part.strip())
-    lines = joined.split("\n")
-    if len(lines) <= TAIL:
-        return joined
-    dropped = len(lines) - TAIL
-    return "\n".join([f"[{dropped} earlier lines omitted]", *lines[-TAIL:]])
+    return "\n".join(
+        _tail(part) for part in (result.stdout, result.stderr) if part.strip()
+    )
+
+
+# Cutting at diff-cover's own banner drops the suite transcript above it whole
+# and hands on the listing entire, however many files it names. A budget has no
+# business here: this listing is not something an agent reads for a verdict, it
+# is the work list, and a tail of it is an agent asked to cover lines it was
+# never shown — then another full unit and e2e run to reveal the rest. Only
+# where the report never got printed does the trimmed log stand in for it.
+def coverage_report(result: ShellResult) -> str:
+    _, banner, rest = result.stdout.partition(BANNER)
+    return banner + rest if banner else said(result)
 
 
 def commit(message: str) -> str:

--- a/src/ludamus/edges/rituals/shell.py
+++ b/src/ludamus/edges/rituals/shell.py
@@ -38,6 +38,14 @@ WAIT_LABEL = "pr::wait"
 
 STASHED = "stashed"
 
+# How much of a gate's output is worth paying for. A mise task list stops at the
+# first failure, and every tool in it puts its verdict last — pytest's short
+# summary, diff-cover's missing lines — so the tail is the part that says what
+# is wrong. What sits above it is a suite naming three and a half thousand tests
+# that passed, and an agent told to re-run one failing test by name does not
+# need to read them.
+TAIL = 20
+
 
 def quoted(value: str) -> str:
     return shlex.quote(value)
@@ -45,8 +53,16 @@ def quoted(value: str) -> str:
 
 # Both streams: a task that dies before it starts says so on stderr and nowhere
 # else, and an empty complaint is the one thing a repair agent cannot work with.
+# Trimmed here rather than at each prompt, because every caller does the same
+# two things with this — hand it to an agent, or put it in the report — and both
+# want the verdict, not the transcript.
 def said(result: ShellResult) -> str:
-    return "\n".join(part for part in (result.stdout, result.stderr) if part.strip())
+    joined = "\n".join(part for part in (result.stdout, result.stderr) if part.strip())
+    lines = joined.split("\n")
+    if len(lines) <= TAIL:
+        return joined
+    dropped = len(lines) - TAIL
+    return "\n".join([f"[{dropped} earlier lines omitted]", *lines[-TAIL:]])
 
 
 def commit(message: str) -> str:

--- a/tests/unit/rituals/test_pr_check_gates.py
+++ b/tests/unit/rituals/test_pr_check_gates.py
@@ -11,7 +11,7 @@ from ludamus.edges.rituals.pr_check import (
     quality_review,
     set_aside,
 )
-from ludamus.edges.rituals.shell import COVERAGE, PR_FIX
+from ludamus.edges.rituals.shell import BUDGET, COVERAGE, PR_FIX
 
 if TYPE_CHECKING:
     from vekna.trial import Trial
@@ -19,6 +19,17 @@ if TYPE_CHECKING:
     from ludamus.edges.rituals.state import Work
 
 _MISSING = "src/ludamus/thing.py (80.0%): Missing lines 12-14"
+_CLEAN = """-------------
+Diff Coverage
+Diff: main...HEAD
+-------------
+src/ludamus/thing.py (100%)
+-------------
+Total:   10 lines
+Missing: 0 lines
+Coverage: 100%
+-------------
+"""
 _MERGE_COMMIT = (
     "git add -A && (git diff --cached --quiet || "
     "git commit -m 'chore: merge main and fix the gates')"
@@ -131,6 +142,46 @@ class TestCover:
         assert _MISSING in trial.coding.prompts[0]
         assert "Do not run the whole-repository sweeps" in trial.coding.prompts[0]
         assert trial.shell.commands == [COVERAGE]
+
+    # The whole listing is the work list. A tail of it is an agent asked to
+    # cover lines it was never shown, and then another full unit and e2e run to
+    # reveal the next few.
+    def test_every_file_reaches_the_agent_out_from_under_the_suite(
+        self, trial: Trial, work: Work
+    ) -> None:
+        # Longer than the budget on its own, which is the whole point: what a
+        # branch has left uncovered is not something a token count can bound.
+        listing = "\n".join(
+            f"src/ludamus/thing{index}.py (80.0%): Missing lines 12-14"
+            for index in range(BUDGET // 20)
+        )
+        transcript = "\n".join(f"tests/test_{index}.py PASSED" for index in range(4000))
+        trial.shell.replies(
+            when=COVERAGE,
+            exit_code=1,
+            stdout=f"{transcript}\n-------------\nDiff Coverage\n{listing}\n",
+        )
+        trial.coding.replies("wrote the tests")
+
+        transition = trial.walk(cover, work)
+
+        assert transition == goto(
+            cover, work.model_copy(update={"budgets": {"cover": 1}})
+        )
+        assert listing in trial.coding.prompts[0]
+        assert "tests/test_0.py PASSED" not in trial.coding.prompts[0]
+
+    # diff-cover's summary block says "Missing: 0 lines" on a clean report too,
+    # so the bare word would send every green run round the loop again.
+    def test_a_clean_report_is_not_read_as_missing_lines(
+        self, trial: Trial, work: Work
+    ) -> None:
+        trial.shell.replies(when=COVERAGE, stdout=_CLEAN)
+
+        transition = trial.walk(cover, work)
+
+        assert transition == goto(quality_review, work)
+        assert not trial.coding.prompts
 
     def test_a_first_pass_with_nothing_missing_commits_nothing(
         self, trial: Trial, work: Work

--- a/tests/unit/rituals/test_shell.py
+++ b/tests/unit/rituals/test_shell.py
@@ -2,11 +2,31 @@
 
 from vekna.folio.shell import ShellResult
 
-from ludamus.edges.rituals.shell import TAIL, said
+from ludamus.edges.rituals.shell import BUDGET, coverage_report, said
+
+# Ten characters once its newline is counted, so a whole number of these is
+# exactly the budget and the boundary can be named rather than approached.
+_ROW = "x" * 9
+_FITS = BUDGET // 10
+
+_REPORT = """Diff Coverage
+Diff: main...HEAD
+-------------
+src/ludamus/thing.py (80.0%): Missing lines 12-14
+-------------
+Total:   10 lines
+Missing: 5 lines
+Coverage: 50%
+-------------
+"""
 
 
 def _ran(*, stdout: str = "", stderr: str = "") -> ShellResult:
     return ShellResult(stdout=stdout, stderr=stderr, exit_code=1)
+
+
+def _rows(count: int) -> str:
+    return "\n".join([_ROW] * count)
 
 
 class TestSaid:
@@ -15,12 +35,57 @@ class TestSaid:
             "E501 too long\n1 failed"
         )
 
+    def test_a_trailing_newline_is_not_a_line(self) -> None:
+        assert said(_ran(stdout="E501 too long\n", stderr="1 failed\n")) == (
+            "E501 too long\n1 failed"
+        )
+
+    def test_a_log_that_fits_the_budget_comes_back_whole(self) -> None:
+        fits = _rows(_FITS)
+
+        assert said(_ran(stdout=fits)) == fits
+
+    def test_one_line_over_the_budget_drops_exactly_one(self) -> None:
+        over = _rows(_FITS + 1)
+
+        trimmed = said(_ran(stdout=over))
+
+        assert trimmed == f"[1 earlier lines omitted]\n{_rows(_FITS)}"
+
     def test_a_long_log_keeps_its_tail_and_says_what_it_dropped(self) -> None:
-        run = "\n".join([f"tests/test_{index}.py PASSED" for index in range(TAIL + 50)])
+        run = "\n".join(
+            [f"tests/test_{index}.py PASSED" for index in range(_FITS)] + ["1 failed"]
+        )
 
-        trimmed = said(_ran(stdout=run, stderr="1 failed"))
+        trimmed = said(_ran(stdout=run))
 
-        assert trimmed.startswith("[51 earlier lines omitted]\n")
+        assert trimmed.startswith("[")
         assert trimmed.endswith("1 failed")
         assert "tests/test_0.py PASSED" not in trimmed
-        assert len(trimmed.split("\n")) == TAIL + 1
+
+    # mise puts its own task chatter on stderr and the tool's verdict on stdout,
+    # so a budget shared between the streams is won by the chatter and the
+    # repair agent is handed a progress log with no diagnosis in it.
+    def test_a_long_stderr_cannot_evict_what_stdout_said(self) -> None:
+        chatter = _rows(_FITS * 2)
+
+        trimmed = said(_ran(stdout="E501 too long", stderr=chatter))
+
+        assert trimmed.startswith("E501 too long\n[")
+
+    def test_a_stream_that_said_nothing_is_left_out(self) -> None:
+        assert said(_ran(stdout="1 failed", stderr="\n")) == "1 failed"
+
+
+class TestCoverageReport:
+    # The listing is the work list, so it goes to the agent entire however many
+    # files it names — and the suite that printed it goes nowhere at all.
+    def test_the_report_outlives_the_suite_that_printed_it(self) -> None:
+        transcript = _rows(_FITS * 3)
+
+        report = coverage_report(_ran(stdout=f"{transcript}\n-------------\n{_REPORT}"))
+
+        assert report == _REPORT
+
+    def test_a_run_that_printed_no_report_falls_back_to_the_trimmed_log(self) -> None:
+        assert coverage_report(_ran(stderr="no coverage data")) == "no coverage data"

--- a/tests/unit/rituals/test_shell.py
+++ b/tests/unit/rituals/test_shell.py
@@ -1,0 +1,26 @@
+"""What the ritual hands on from a command it ran."""
+
+from vekna.folio.shell import ShellResult
+
+from ludamus.edges.rituals.shell import TAIL, said
+
+
+def _ran(*, stdout: str = "", stderr: str = "") -> ShellResult:
+    return ShellResult(stdout=stdout, stderr=stderr, exit_code=1)
+
+
+class TestSaid:
+    def test_both_streams_are_kept(self) -> None:
+        assert said(_ran(stdout="E501 too long", stderr="1 failed")) == (
+            "E501 too long\n1 failed"
+        )
+
+    def test_a_long_log_keeps_its_tail_and_says_what_it_dropped(self) -> None:
+        run = "\n".join([f"tests/test_{index}.py PASSED" for index in range(TAIL + 50)])
+
+        trimmed = said(_ran(stdout=run, stderr="1 failed"))
+
+        assert trimmed.startswith("[51 earlier lines omitted]\n")
+        assert trimmed.endswith("1 failed")
+        assert "tests/test_0.py PASSED" not in trimmed
+        assert len(trimmed.split("\n")) == TAIL + 1


### PR DESCRIPTION
pr_check fed every line of `mise run pr-fix` and `mise run diff-cover` into a coding call — thousands of lines of passing tests, e2e output and coverage tables.

A mise task list stops at the first failure and every tool puts its verdict last, so `said` now keeps the end of what a gate wrote. The budget is **4000 characters per stream**, not a line count: what is being spent is tokens, and a line has no fixed price — twenty lines of ruff is a couple of hundred bytes, twenty carrying a pytest assertion repr is orders of magnitude more.

Per stream, and not on the two joined together. mise puts its own task chatter on stderr and the tool's verdict on stdout — `mise run lint` alone is 35 lines of stdout against 125 of stderr — so a shared budget is won by whichever stream is longer, which is the chatter. A repair agent would have been handed progress banners and no diagnosis at all.

`cover` is not a caller that wants a tail. It routes on the output (`if "Missing lines" in output`) and hands it to the agent as the work list, so a trimmed listing is an agent asked to cover lines it was never shown — and then another full unit and e2e run to reveal the next few. diff-cover's report is self-delimiting, so `coverage_report` cuts at its own `Diff Coverage` banner instead: the listing entire however many files it names, the suite transcript dropped whole. Where the run died before printing a report, the trimmed log stands in.

Routing reads `Missing lines` and not `Missing`, which diff-cover's summary block says on a clean report too (`Missing: 0 lines`) — that one is a pre-existing bug, fixed here because this change touches the same line.
