### PR TITLE
Fix/pr check blocked branches still reviewed

### DIFF
--- a/src/ludamus/edges/rituals/agent.py
+++ b/src/ludamus/edges/rituals/agent.py
@@ -184,11 +184,14 @@ code on its own terms.
     )
 
 
-def thermo(*, number: int, base: str, blocked: str = "") -> str:
+# `reason`, not `blocked`: what this takes is the sentence saying what stopped
+# the branch, and `Work.blocked` a module over is the boolean saying that one
+# did. Two different things are not going to share a name across two files.
+def thermo(*, number: int, base: str, reason: str = "") -> str:
     return f"""\
 Review the changes this pull request adds ({base}...HEAD) with the
 thermo-nuclear code quality review: read {_THERMO_SKILL} and follow it.
-{_already_known(blocked)}
+{_already_known(reason)}
 
 Post every action item as an inline review comment of its own on pull request
 #{number}, anchored to the code it is about, so each one is a thread that can be

--- a/src/ludamus/edges/rituals/agent.py
+++ b/src/ludamus/edges/rituals/agent.py
@@ -163,10 +163,32 @@ threads are a review like any other: triage what they say.
 """
 
 
-def thermo(*, number: int, base: str) -> str:
+# A branch the gates could not make green is reviewed anyway, and then the
+# review's first instinct is to report the red gate — an action item saying what
+# the report already says, on a thread somebody has to close by hand. So the
+# reason is quoted in, as a thing already known rather than a thing to find.
+def _already_known(reason: str) -> str:
+    return (
+        f"""\
+
+This branch is already known not to be green, and that is being handled apart
+from this review:
+
+{reason}
+
+Do not raise that, or anything downstream of it, as an action item. Review the
+code on its own terms.
+"""
+        if reason
+        else ""
+    )
+
+
+def thermo(*, number: int, base: str, blocked: str = "") -> str:
     return f"""\
 Review the changes this pull request adds ({base}...HEAD) with the
 thermo-nuclear code quality review: read {_THERMO_SKILL} and follow it.
+{_already_known(blocked)}
 
 Post every action item as an inline review comment of its own on pull request
 #{number}, anchored to the code it is about, so each one is a thread that can be
@@ -210,8 +232,8 @@ def resolve(*, base: str, branch: str, files: str) -> str:
 # Concatenated, not formatted: the gate's own output is full of braces the
 # moment an assertion diff over a dict lands in it, and str.format would raise
 # on the first one.
-def fix_gates(output: str) -> str:
-    return f"`{PR_FIX}` is this project's gate, and it is red.\n\n{_FIX_GATES}{output}"
+def fix_gates(output: str, *, gate: str = PR_FIX) -> str:
+    return f"`{gate}` is this project's gate, and it is red.\n\n{_FIX_GATES}{output}"
 
 
 class Fallen(BaseModel):

--- a/src/ludamus/edges/rituals/pr_check.py
+++ b/src/ludamus/edges/rituals/pr_check.py
@@ -29,6 +29,12 @@ about, and the branch is labelled ``pr::thermo`` once it is posted. That label
 is the only thing standing between a branch and another review: drop it after
 changing the branch meaningfully, and the next run reviews it again.
 
+A blocked branch's review is provisional, and the label goes on all the same.
+The code it read is by construction about to change — you fix the gate in the
+morning, and that is a meaningful change, so this is one of the times to take
+the label off. It is kept rather than withheld because a branch that stays red
+for a week would otherwise be reviewed from scratch every night of it.
+
 It runs unattended, so it asks you nothing. That is a deliberate break with the
 usual bargain, where spending another agent attempt is a ``decide``: at 3am a
 prompt is a hang, so the budgets below take that decision instead. Agents still
@@ -77,6 +83,7 @@ from .shell import (
     THERMO_LABEL,
     WAIT_LABEL,
     ahead,
+    already_seen,
     commit,
     coverage_report,
     label,
@@ -84,7 +91,6 @@ from .shell import (
     quoted,
     release,
     said,
-    same_verdict,
     stash_name,
     verdict,
 )
@@ -108,6 +114,7 @@ from .state import (
     run_with,
     spent,
     summary,
+    telling,
     wears,
     work_with,
 )
@@ -214,7 +221,7 @@ async def resolve_conflicts(work: Work) -> Transition:
         return goto(gate_check, cleared(work, resolve_conflicts.name))
     if exhausted(work, resolve_conflicts.name):
         return goto(
-            stand_down, work_with(work, note="the merge conflicts were not resolved")
+            stand_down, work_with(work, reason="the merge conflicts were not resolved")
         )
     if fallen := await ask(
         resolve(base=work.pr.base, branch=work.pr.branch, files=unmerged.stdout),
@@ -237,18 +244,18 @@ async def gate_check(work: Work) -> Transition:
     said_now = verdict(gates)
     # Asked before the first repair and not after, so this reads "the branch
     # arrived broken the same way", never "the agent failed to fix it twice".
-    if not spent(work, gate_check.name) and same_verdict(said_now, work.run.seen):
+    if not spent(work, gate_check.name) and already_seen(said_now, work.run.seen):
         return goto(
             stand_down,
-            work_with(work, note=f"`{PR_FIX}` is red as it already was:\n{said_now}"),
+            work_with(work, reason=f"`{PR_FIX}` is red as it already was:\n{said_now}"),
         )
     if exhausted(work, gate_check.name):
         return goto(
             stand_down,
             work_with(
                 work,
-                note=f"`{PR_FIX}` is still red:\n{said_now}",
-                run=run_with(work.run, seen=said_now),
+                reason=f"`{PR_FIX}` is still red:\n{said_now}",
+                run=run_with(work.run, seen=[*work.run.seen, said_now]),
             ),
         )
     if fallen := await ask(fix_gates(said(gates)), key=f"gates-{work.pr.number}"):
@@ -301,35 +308,40 @@ async def cover(work: Work) -> Transition:
                 )
         return goto(quality_review, cleared(work, cover.name))
     said_now = verdict(measured)
-    # Only ever a red suite, never a coverage gap: what lines a branch left
-    # uncovered is that branch's own business, and two of them missing lines in
-    # the same file look identical from here. A suite that will not pass is the
-    # thing that repeats across a night.
-    if (
-        not missing
-        and not spent(work, cover.name)
-        and same_verdict(said_now, work.run.seen)
-    ):
-        return goto(
-            stand_down,
-            work_with(work, note=f"`{COVERAGE}` failed as it already did:\n{said_now}"),
-        )
-    if exhausted(work, cover.name):
-        left = "still reports missing lines" if missing else "is still red"
-        return goto(
-            stand_down,
-            work_with(
-                work,
-                note=f"`{COVERAGE}` {left}:\n{said_now}",
-                run=work.run if missing else run_with(work.run, seen=said_now),
-            ),
-        )
     # Two different jobs down one budget, because they are the same step going
     # round: lines this branch left uncovered are written up as tests, and a
     # suite that will not pass at all is repaired like any other red gate. The
     # second used to end the branch here — a red suite names no missing lines,
     # so it was read as the coverage tool failing rather than the branch.
-    asking = COVER + output if missing else fix_gates(said(measured), gate=COVERAGE)
+    # Which of the two this is decides four things, so it is asked once here and
+    # the branches below read straight. Only a red suite is worth remembering
+    # across the night: what lines a branch left uncovered is that branch's own
+    # business, and two of them missing lines in the same file look identical
+    # from here. A suite that will not pass is the thing that repeats.
+    if missing:
+        left, asking, run = "still reports missing lines", COVER + output, work.run
+    else:
+        left = "is still red"
+        asking = fix_gates(said(measured), gate=COVERAGE)
+        run = run_with(work.run, seen=[*work.run.seen, said_now])
+    # Against what the run knew on the way in, never `run` above: that one has
+    # this verdict in it already and would recognise nothing but itself.
+    if (
+        not missing
+        and not spent(work, cover.name)
+        and already_seen(said_now, work.run.seen)
+    ):
+        return goto(
+            stand_down,
+            work_with(
+                work, reason=f"`{COVERAGE}` failed as it already did:\n{said_now}"
+            ),
+        )
+    if exhausted(work, cover.name):
+        return goto(
+            stand_down,
+            work_with(work, reason=f"`{COVERAGE}` {left}:\n{said_now}", run=run),
+        )
     if fallen := await ask(asking, key=f"cover-{work.pr.number}"):
         return goto(report, abandoned(work, fallen.reason))
     return goto(cover, charged(work, cover.name))
@@ -361,11 +373,7 @@ async def quality_review(work: Work) -> Transition:
     if any(one.name == THERMO_LABEL for one in labels.labels):
         return goto(read_comments, work)
     if fallen := await ask(
-        thermo(
-            number=work.pr.number,
-            base=work.pr.base,
-            blocked=work.note if work.blocked else "",
-        ),
+        thermo(number=work.pr.number, base=work.pr.base, reason=work.reason),
         key=f"review-{work.pr.number}",
     ):
         return goto(report, abandoned(work, fallen.reason))
@@ -439,13 +447,14 @@ async def write_triage(triaged: Triaged) -> Transition:
     if marked.exit_code:
         reason = f"could not add the {CR_LABEL} label: {said(marked)}"
         return goto(set_aside, work_with(work, note=reason))
-    # Both, where the branch is blocked: what stopped it and what its reviewers
-    # want are two different things the morning needs, and the row has one note.
-    told = "; ".join(part for part in (work.note, counted(triaged.notes)) if part)
+    # The tally joins the note rather than replacing it, so a branch that stood
+    # down keeps the stash its work went into. What stopped it rides in `reason`
+    # and needs no help from here.
+    tallied = "; ".join(part for part in (work.note, counted(triaged.notes)) if part)
     return goto(
         finish_pr,
         Closed(
-            work=work_with(work, note=told),
+            work=work_with(work, note=tallied),
             outcome="blocked" if work.blocked else "triage",
         ),
     )
@@ -462,22 +471,23 @@ async def finish_pr(closed: Closed) -> Transition:
         # Asked of git rather than tracked in the payload: what needs pushing is
         # what origin has not got, whoever put it there.
         unpushed=await ahead(work.pr.branch),
-        note=work.note,
+        note=telling(work),
     )
     run = work.run
     return goto(next_pr, run_with(run, checked=[*run.checked, row]))
 
 
 # Giving the worktree back, and what that has to say for itself. Both endings
-# below do this and only one of them stops here, so it is written once.
+# below do this and only one of them stops here, so it is written once. What
+# comes back is this act's own bookkeeping and nothing else — the callers join
+# it to whatever else the row is carrying.
 async def _released(work: Work) -> str:
     released = await shell(release(work.pr.branch))
-    parts = [work.note]
     if released.exit_code:
-        parts.append(f"the worktree could not be released: {said(released)}")
-    elif released.stdout.strip() == STASHED:
-        parts.append(f'stashed as "{stash_name(work.pr.branch)}"')
-    return "; ".join(part for part in parts if part)
+        return f"the worktree could not be released: {said(released)}"
+    if released.stdout.strip() == STASHED:
+        return f'stashed as "{stash_name(work.pr.branch)}"'
+    return ""
 
 
 # A branch that will not go green, which is not the same as a branch that
@@ -495,14 +505,24 @@ async def stand_down(work: Work) -> Transition:
 
 @step
 async def set_aside(work: Work) -> Transition:
-    note = await _released(work)
+    # The worktree goes back before the count, not as an argument alongside it:
+    # what is left to push is asked of a tree this step has finished with.
+    released = await _released(work)
     row = Checked(
         number=work.pr.number,
         branch=work.pr.branch,
         url=work.pr.url,
         outcome="blocked",
         unpushed=await ahead(work.pr.branch),
-        note=note,
+        # A branch that stood down and then failed one of the reading steps
+        # arrives here with two things to say, and the second must not cost it
+        # the first: the morning needs to hear the red gate, not only the `gh`
+        # call that came after it.
+        # ponytail: that branch does lose the stash name its first release
+        # wrote, because the reading step's own note replaced it. `stash_name`
+        # is the branch and the row says the branch, so the name is still
+        # derivable; a third slot to keep it whole is not worth the field.
+        note=telling(work, released),
     )
     run = work.run
     return goto(next_pr, run_with(run, checked=[*run.checked, row]))

--- a/src/ludamus/edges/rituals/pr_check.py
+++ b/src/ludamus/edges/rituals/pr_check.py
@@ -12,6 +12,13 @@ read — a quality review it posted, a triage it wrote — also earns the branch
 ``pr::cr``. Nothing is ever pushed: the report says which branches are waiting
 for that, and pushing stays yours.
 
+A branch the gates would not go green on is still read. It stands down rather
+than stopping: the worktree is released, so the reading happens on the last
+commit that was any good, and then it is reviewed and triaged like any other
+before being reported blocked. What it does not get is ``pr::qa``, because
+nobody can test a branch that will not build. This is not a gate and does not
+try to fail fast — an hour more spent is worth a pull request read properly.
+
 A pull request labelled ``pr::wait`` is left alone entirely: it is dropped at
 the listing, so nothing checks it out and it appears nowhere in the report.
 That is how you park a branch for a night — or for a month — without closing
@@ -34,8 +41,11 @@ Both still print the report first, then fail the cast.
 
 Budgets are per step and per branch: a step may be retried ``--bound`` times,
 going green clears its count, and moving to the next pull request clears them
-all. A step that runs out gives up on that pull request only — the worktree is
-released, the branch is reported blocked, and the next one starts.
+all. A step that runs out stops trying to fix that pull request only: the
+worktree is released, the branch stands down into the reading above, and it is
+reported blocked. A verdict a step already gave up on once is not paid for
+twice — the next branch whose gate says the same thing stands down without
+spending its budget on an answer this run already has.
 """
 
 from pydantic import ValidationError
@@ -70,10 +80,13 @@ from .shell import (
     commit,
     coverage_report,
     label,
+    plain,
     quoted,
     release,
     said,
+    same_verdict,
     stash_name,
+    verdict,
 )
 from .state import (
     PULLS,
@@ -201,7 +214,7 @@ async def resolve_conflicts(work: Work) -> Transition:
         return goto(gate_check, cleared(work, resolve_conflicts.name))
     if exhausted(work, resolve_conflicts.name):
         return goto(
-            set_aside, work_with(work, note="the merge conflicts were not resolved")
+            stand_down, work_with(work, note="the merge conflicts were not resolved")
         )
     if fallen := await ask(
         resolve(base=work.pr.base, branch=work.pr.branch, files=unmerged.stdout),
@@ -215,11 +228,29 @@ async def resolve_conflicts(work: Work) -> Transition:
 
 @step
 async def gate_check(work: Work) -> Transition:
-    gates = await shell(PR_FIX)
+    # Captured rather than streamed, and run `plain`: what comes back here is
+    # read twice over — once by an agent, once by you in the morning — and a
+    # terminal recording is neither.
+    gates = await shell(plain(PR_FIX), stream=False)
     if gates.exit_code == 0:
         return goto(finish_merge, cleared(work, gate_check.name))
+    said_now = verdict(gates)
+    # Asked before the first repair and not after, so this reads "the branch
+    # arrived broken the same way", never "the agent failed to fix it twice".
+    if not spent(work, gate_check.name) and same_verdict(said_now, work.run.seen):
+        return goto(
+            stand_down,
+            work_with(work, note=f"`{PR_FIX}` is red as it already was:\n{said_now}"),
+        )
     if exhausted(work, gate_check.name):
-        return goto(set_aside, work_with(work, note=f"`{PR_FIX}` is still red"))
+        return goto(
+            stand_down,
+            work_with(
+                work,
+                note=f"`{PR_FIX}` is still red:\n{said_now}",
+                run=run_with(work.run, seen=said_now),
+            ),
+        )
     if fallen := await ask(fix_gates(said(gates)), key=f"gates-{work.pr.number}"):
         return goto(report, abandoned(work, fallen.reason))
     return goto(gate_check, charged(work, gate_check.name))
@@ -248,36 +279,60 @@ async def finish_merge(work: Work) -> Transition:
 
 @step
 async def cover(work: Work) -> Transition:
-    measured = await shell(COVERAGE)
+    measured = await shell(plain(COVERAGE), stream=False)
     output = coverage_report(measured)
-    # The report's own words for a line no test reached. Read from the output
-    # rather than the exit code, which is also non-zero for a threshold this
-    # ritual has no business moving. Both words and not just "Missing": the
-    # summary block below the listing says "Missing: 0 lines" on a clean report
-    # too, so the bare word matches every run there is.
-    if "Missing lines" in output:
-        if exhausted(work, cover.name):
-            return goto(
-                set_aside,
-                work_with(work, note=f"`{COVERAGE}` still reports missing lines"),
-            )
-        if fallen := await ask(COVER + output, key=f"cover-{work.pr.number}"):
-            return goto(report, abandoned(work, fallen.reason))
-        return goto(cover, charged(work, cover.name))
-    if measured.exit_code:
-        reason = f"`{COVERAGE}` failed without naming missing lines"
-        return goto(set_aside, work_with(work, note=f"{reason}: {output}"))
-    # Only where tests were actually written: most branches pass here first
-    # time, and a commit rite that can never commit anything is noise in the
-    # tree.
-    if spent(work, cover.name):
-        landed = await shell(commit("test: cover the lines this branch changes"))
-        if landed.exit_code:
-            return goto(
-                set_aside,
-                work_with(work, note=f"could not commit the tests: {said(landed)}"),
-            )
-    return goto(quality_review, cleared(work, cover.name))
+    # The report's own words for a line no test reached, and read from the
+    # output rather than the exit code because the exit code does not carry it:
+    # this task runs `diff-cover` with no `--fail-under`, so a run that names
+    # missing lines still ends 0. Both words and not just "Missing": the summary
+    # block below the listing says "Missing: 0 lines" on a clean report too, so
+    # the bare word matches every run there is.
+    missing = "Missing lines" in output
+    if not missing and measured.exit_code == 0:
+        # Only where tests were actually written: most branches pass here first
+        # time, and a commit rite that can never commit anything is noise in the
+        # tree.
+        if spent(work, cover.name):
+            landed = await shell(commit("test: cover the lines this branch changes"))
+            if landed.exit_code:
+                return goto(
+                    set_aside,
+                    work_with(work, note=f"could not commit the tests: {said(landed)}"),
+                )
+        return goto(quality_review, cleared(work, cover.name))
+    said_now = verdict(measured)
+    # Only ever a red suite, never a coverage gap: what lines a branch left
+    # uncovered is that branch's own business, and two of them missing lines in
+    # the same file look identical from here. A suite that will not pass is the
+    # thing that repeats across a night.
+    if (
+        not missing
+        and not spent(work, cover.name)
+        and same_verdict(said_now, work.run.seen)
+    ):
+        return goto(
+            stand_down,
+            work_with(work, note=f"`{COVERAGE}` failed as it already did:\n{said_now}"),
+        )
+    if exhausted(work, cover.name):
+        left = "still reports missing lines" if missing else "is still red"
+        return goto(
+            stand_down,
+            work_with(
+                work,
+                note=f"`{COVERAGE}` {left}:\n{said_now}",
+                run=work.run if missing else run_with(work.run, seen=said_now),
+            ),
+        )
+    # Two different jobs down one budget, because they are the same step going
+    # round: lines this branch left uncovered are written up as tests, and a
+    # suite that will not pass at all is repaired like any other red gate. The
+    # second used to end the branch here — a red suite names no missing lines,
+    # so it was read as the coverage tool failing rather than the branch.
+    asking = COVER + output if missing else fix_gates(said(measured), gate=COVERAGE)
+    if fallen := await ask(asking, key=f"cover-{work.pr.number}"):
+        return goto(report, abandoned(work, fallen.reason))
+    return goto(cover, charged(work, cover.name))
 
 
 # The one step with no budget and no loop, because there is nothing here to
@@ -306,7 +361,12 @@ async def quality_review(work: Work) -> Transition:
     if any(one.name == THERMO_LABEL for one in labels.labels):
         return goto(read_comments, work)
     if fallen := await ask(
-        thermo(number=work.pr.number, base=work.pr.base), key=f"review-{work.pr.number}"
+        thermo(
+            number=work.pr.number,
+            base=work.pr.base,
+            blocked=work.note if work.blocked else "",
+        ),
+        key=f"review-{work.pr.number}",
     ):
         return goto(report, abandoned(work, fallen.reason))
     marked = await shell(label(THERMO_LABEL, CR_LABEL, number=work.pr.number))
@@ -328,8 +388,12 @@ async def read_comments(work: Work) -> Transition:
     if isinstance(notes, Misread):
         unreadable = f"the triage was unreadable: {notes.reason}"
         return goto(set_aside, work_with(work, note=unreadable))
-    # Nothing to triage is an answer, and the good one: the branch goes to QA.
+    # Nothing to triage is an answer, and the good one: the branch goes to QA —
+    # unless it is one nobody can build, which is not a branch to hand a tester
+    # however clean its reviews are.
     if not notes.items:
+        if work.blocked:
+            return goto(finish_pr, Closed(work=work, outcome="blocked"))
         return goto(mark_qa, work)
     return goto(write_triage, Triaged(work=work, notes=notes))
 
@@ -375,9 +439,15 @@ async def write_triage(triaged: Triaged) -> Transition:
     if marked.exit_code:
         reason = f"could not add the {CR_LABEL} label: {said(marked)}"
         return goto(set_aside, work_with(work, note=reason))
+    # Both, where the branch is blocked: what stopped it and what its reviewers
+    # want are two different things the morning needs, and the row has one note.
+    told = "; ".join(part for part in (work.note, counted(triaged.notes)) if part)
     return goto(
         finish_pr,
-        Closed(work=work_with(work, note=counted(triaged.notes)), outcome="triage"),
+        Closed(
+            work=work_with(work, note=told),
+            outcome="blocked" if work.blocked else "triage",
+        ),
     )
 
 
@@ -398,15 +468,34 @@ async def finish_pr(closed: Closed) -> Transition:
     return goto(next_pr, run_with(run, checked=[*run.checked, row]))
 
 
-@step
-async def set_aside(work: Work) -> Transition:
+# Giving the worktree back, and what that has to say for itself. Both endings
+# below do this and only one of them stops here, so it is written once.
+async def _released(work: Work) -> str:
     released = await shell(release(work.pr.branch))
     parts = [work.note]
     if released.exit_code:
         parts.append(f"the worktree could not be released: {said(released)}")
     elif released.stdout.strip() == STASHED:
         parts.append(f'stashed as "{stash_name(work.pr.branch)}"')
-    note = "; ".join(part for part in parts if part)
+    return "; ".join(part for part in parts if part)
+
+
+# A branch that will not go green, which is not the same as a branch that
+# cannot be read. The worktree goes back first — half a repair is not something
+# to review and not something to commit a triage on top of — and then it takes
+# the same reading every other pull request gets. It is the steps above this
+# that cannot come here: a checkout that failed leaves you standing on the base
+# branch, and there is nothing there to review.
+@step
+async def stand_down(work: Work) -> Transition:
+    return goto(
+        quality_review, work_with(work, note=await _released(work), blocked=True)
+    )
+
+
+@step
+async def set_aside(work: Work) -> Transition:
+    note = await _released(work)
     row = Checked(
         number=work.pr.number,
         branch=work.pr.branch,

--- a/src/ludamus/edges/rituals/shell.py
+++ b/src/ludamus/edges/rituals/shell.py
@@ -4,6 +4,7 @@ Command text and nothing else: every function here builds a string a step runs,
 so what a step does stays readable as a decision rather than as quoting.
 """
 
+import re
 import shlex
 
 from vekna.folio.shell import ShellResult, shell
@@ -11,6 +12,16 @@ from vekna.folio.shell import ShellResult, shell
 # This project's two gates, by the names this project gives them.
 PR_FIX = "mise run pr-fix"
 COVERAGE = "mise run diff-cover"
+
+
+# What a step actually runs a gate as. `CI=1` puts every tool in the chain into
+# its log shape rather than its terminal one — no colour, no cursor tricks, and
+# Playwright's own CI settings, which retry a failure before calling it one.
+# Held apart from the names above because those are what the prompts say and
+# what you would type yourself; nobody needs to read the prefix.
+def plain(task: str) -> str:
+    return f"CI=1 {task}"
+
 
 # `labels` rides along so the wait label can be read without a call per pull
 # request: the listing is the only place every open branch is in hand at once.
@@ -82,9 +93,10 @@ def _tail(text: str) -> str:
 # Each stream gets the budget on its own rather than sharing one, because mise
 # puts its own task chatter on stderr and the tool's verdict on stdout, and a
 # shared budget is won by whichever stream is longer — which is the chatter.
-# Trimmed here rather than at each prompt, because every caller does the same
-# two things with this — hand it to an agent, or put it in the report — and both
-# want the verdict, not the transcript.
+# Trimmed here rather than at each prompt, because every caller of this hands it
+# to an agent and they all want the same thing: enough of the end to diagnose
+# from. What the report puts in front of a person is `verdict` below, which is a
+# different question and a much smaller answer.
 def said(result: ShellResult) -> str:
     return "\n".join(
         _tail(part) for part in (result.stdout, result.stderr) if part.strip()
@@ -100,6 +112,46 @@ def said(result: ShellResult) -> str:
 def coverage_report(result: ShellResult) -> str:
     _, banner, rest = result.stdout.partition(BANNER)
     return banner + rest if banner else said(result)
+
+
+# What a report row can carry, counted in lines because this one is read by a
+# person: a dozen is the tail every tool in these chains puts its tally in.
+VERDICT_LINES = 12
+
+# Cursor moves and colour. `plain` above stops most of these being written at
+# all; this is for the tools that colour anyway, and for a log captured before
+# anyone thought about it.
+_ANSI = re.compile(r"\x1b\[[0-9;?]*[a-zA-Z]")
+
+
+# The one-screen answer to "what went wrong", for the report rather than for an
+# agent. Only one stream, unlike `said`: stdout is where every tool in these
+# chains says how it ended — pytest's short summary, ruff's count, Playwright's
+# tally — while stderr carries mise's task chatter and, under e2e, a web server
+# logging every request it served, which is thousands of lines of nothing.
+# Where stdout said nothing at all, stderr is all there is, and that is the task
+# that died before it started.
+# Blank lines go too: a progress reporter writing over itself leaves hundreds of
+# them, and they would spend the whole allowance saying nothing.
+def verdict(result: ShellResult) -> str:
+    spoken = result.stdout if result.stdout.strip() else result.stderr
+    lines = [
+        stripped
+        for line in _ANSI.sub("", spoken).splitlines()
+        if (stripped := line.rstrip())
+    ]
+    return "\n".join(lines[-VERDICT_LINES:])
+
+
+# Timings, counts and timestamps differ on every run, so two runs of the same
+# broken suite never match character for character. What is left once the digits
+# go is the failing test's name and the tool that named it, which is the thing
+# worth recognising twice.
+# ponytail: a different failure at the same file and a different line collides
+# with this. What that costs is one branch's repair attempts skipped, and the
+# report still says what it saw — worth more than a check that never fires.
+def same_verdict(one: str, other: str) -> bool:
+    return bool(one) and re.sub(r"\d+", "", one) == re.sub(r"\d+", "", other)
 
 
 def commit(message: str) -> str:

--- a/src/ludamus/edges/rituals/shell.py
+++ b/src/ludamus/edges/rituals/shell.py
@@ -15,10 +15,18 @@ COVERAGE = "mise run diff-cover"
 
 
 # What a step actually runs a gate as. `CI=1` puts every tool in the chain into
-# its log shape rather than its terminal one — no colour, no cursor tricks, and
-# Playwright's own CI settings, which retry a failure before calling it one.
+# its log shape rather than its terminal one — no colour, no cursor tricks.
 # Held apart from the names above because those are what the prompts say and
 # what you would type yourself; nobody needs to read the prefix.
+# It is not only the rendering, and the rest is worth knowing before you read a
+# gate's answer as the answer you would have got yourself. `tests/e2e` reads the
+# same variable in five places: a failure is retried twice before it counts, so
+# green here means green within three tries; workers are pinned to two rather
+# than half the cores, so the e2e half of `COVERAGE` is slower; the reporter
+# becomes GitHub's; `test.only` is refused; and Playwright will not attach to a
+# server already on the port, which holds only because `COVERAGE` kills one
+# first. `global-teardown.ts` reads it too, and turns an empty client-coverage
+# report from a shrug into a failure.
 def plain(task: str) -> str:
     return f"CI=1 {task}"
 
@@ -70,6 +78,18 @@ def quoted(value: str) -> str:
     return shlex.quote(value)
 
 
+# Cursor moves and colour. `plain` above stops most of these being written at
+# all; this is for the tools that colour anyway, and for a log captured before
+# anyone thought about it. Stripped off everything this module hands on, agent
+# and report alike: an escape code is not something either reader wants, and in
+# `said` it is budget spent on cursor positions.
+_ANSI = re.compile(r"\x1b\[[0-9;?]*[a-zA-Z]")
+
+
+def _plain_text(text: str) -> str:
+    return _ANSI.sub("", text)
+
+
 # The budget buys whole lines, and the last line is bought whether it fits or
 # not: a tool that pretty-prints a value onto one long line would otherwise
 # spend the budget and hand back nothing.
@@ -99,7 +119,9 @@ def _tail(text: str) -> str:
 # different question and a much smaller answer.
 def said(result: ShellResult) -> str:
     return "\n".join(
-        _tail(part) for part in (result.stdout, result.stderr) if part.strip()
+        _tail(_plain_text(part))
+        for part in (result.stdout, result.stderr)
+        if part.strip()
     )
 
 
@@ -118,11 +140,6 @@ def coverage_report(result: ShellResult) -> str:
 # person: a dozen is the tail every tool in these chains puts its tally in.
 VERDICT_LINES = 12
 
-# Cursor moves and colour. `plain` above stops most of these being written at
-# all; this is for the tools that colour anyway, and for a log captured before
-# anyone thought about it.
-_ANSI = re.compile(r"\x1b\[[0-9;?]*[a-zA-Z]")
-
 
 # The one-screen answer to "what went wrong", for the report rather than for an
 # agent. Only one stream, unlike `said`: stdout is where every tool in these
@@ -137,7 +154,7 @@ def verdict(result: ShellResult) -> str:
     spoken = result.stdout if result.stdout.strip() else result.stderr
     lines = [
         stripped
-        for line in _ANSI.sub("", spoken).splitlines()
+        for line in _plain_text(spoken).splitlines()
         if (stripped := line.rstrip())
     ]
     return "\n".join(lines[-VERDICT_LINES:])
@@ -152,6 +169,13 @@ def verdict(result: ShellResult) -> str:
 # report still says what it saw — worth more than a check that never fires.
 def same_verdict(one: str, other: str) -> bool:
     return bool(one) and re.sub(r"\d+", "", one) == re.sub(r"\d+", "", other)
+
+
+# Against everything the run has given up on, not just the last one: two things
+# broken at once — a host that will not resolve and a browser that will not
+# start — alternate down the queue, and a memo of one recognises neither.
+def already_seen(one: str, seen: list[str]) -> bool:
+    return any(same_verdict(one, other) for other in seen)
 
 
 def commit(message: str) -> str:

--- a/src/ludamus/edges/rituals/state.py
+++ b/src/ludamus/edges/rituals/state.py
@@ -73,11 +73,15 @@ class Run(BaseModel):
     queue: list[PullRequest] = []
     checked: list[Checked] = []
     stopped: str = ""
-    # The verdict of the last gate this run gave up on, carried across branches
+    # Every verdict a gate on this run has given up on, carried across branches
     # so the next one can recognise it. A night where the same thing is broken
     # everywhere — an unreachable host, a browser that will not start — is a
     # night that should pay for that answer once, not once per pull request.
-    seen: str = ""
+    # One list for both gates rather than one apiece: `pr-fix` and `diff-cover`
+    # run the same unit suite, so a test that kills one kills the other, and a
+    # branch whose coverage run says what last branch's gate run said is stopped
+    # by the same thing. Recognising it across the two is the point, not a leak.
+    seen: list[str] = []
 
 
 # One pull request in flight. `budgets` dies with this payload, which is what "a
@@ -89,6 +93,13 @@ class Work(BaseModel):
     budgets: dict[str, int] = {}
     merging: bool = False
     note: str = ""
+    # What stopped this branch, in the words of whatever stopped it. Written
+    # once, by the step that gave up, and never written over: a branch that
+    # stands down goes on to be reviewed and triaged like any other, and every
+    # ending down there sets `note` for its own purposes. Read by two people who
+    # want different things — the review agent, which is told not to raise it,
+    # and the morning, which is told it first.
+    reason: str = ""
     # This branch will not be made green tonight, and is being read anyway. The
     # reading steps that follow need to know: a branch nobody can merge must not
     # come out labelled ready to test.
@@ -137,7 +148,7 @@ def run_with(
     queue: list[PullRequest] | None = None,
     checked: list[Checked] | None = None,
     stopped: str | None = None,
-    seen: str | None = None,
+    seen: list[str] | None = None,
 ) -> Run:
     return Run(
         bound=run.bound,
@@ -155,6 +166,7 @@ def work_with(
     budgets: dict[str, int] | None = None,
     merging: bool | None = None,
     note: str | None = None,
+    reason: str | None = None,
     blocked: bool | None = None,
 ) -> Work:
     return Work(
@@ -163,6 +175,7 @@ def work_with(
         budgets=work.budgets if budgets is None else budgets,
         merging=work.merging if merging is None else merging,
         note=work.note if note is None else note,
+        reason=work.reason if reason is None else reason,
         blocked=work.blocked if blocked is None else blocked,
     )
 
@@ -172,6 +185,13 @@ def work_with(
 # only shape of the three that carries a type.
 def modified(pull: PullRequest) -> str:
     return pull.updated_at
+
+
+# What a row has to say, in the order the morning wants it: why the branch
+# stopped first, then whatever the ending that built the row has to add. Every
+# ending goes through here, so no ending can write over another's half.
+def telling(work: Work, *extra: str) -> str:
+    return "; ".join(part for part in (work.reason, work.note, *extra) if part)
 
 
 def counted(notes: TriageNotes) -> str:
@@ -242,7 +262,12 @@ def _names(items: list[str]) -> str:
 
 def _line(row: Checked) -> str:
     ahead = "unknown" if row.unpushed is None else f"{row.unpushed} unpushed"
-    note = f" — {row.note}" if row.note else ""
+    # A blocked row's note carries the gate's verdict, which is a dozen lines of
+    # someone else's output. Indented under the row rather than run into it: the
+    # rows are a scannable list, and a note that starts in column zero ends that
+    # list wherever it lands.
+    wrapped = row.note.replace("\n", "\n      ")
+    note = f" — {wrapped}" if row.note else ""
     return f"  #{row.number} {row.branch}: {_OUTCOME[row.outcome]}, {ahead}{note}"
 
 
@@ -254,7 +279,12 @@ def report_card(run: Run) -> Report:
         to_push=[
             row.branch for row in run.checked if row.unpushed is None or row.unpushed
         ],
-        to_fix=[row.branch for row in run.checked if row.outcome == "triage"],
+        # Blocked counts as needing fixing, whether or not a triage was written:
+        # a branch nobody could make green is the clearest thing on the list
+        # there is to do, and one that also carries a triage.md has two.
+        to_fix=[
+            row.branch for row in run.checked if row.outcome in {"triage", "blocked"}
+        ],
         ready=[row.branch for row in run.checked if row.outcome == "qa"],
         not_reached=[pull.branch for pull in run.queue],
         failed=run.stopped,

--- a/src/ludamus/edges/rituals/state.py
+++ b/src/ludamus/edges/rituals/state.py
@@ -73,6 +73,11 @@ class Run(BaseModel):
     queue: list[PullRequest] = []
     checked: list[Checked] = []
     stopped: str = ""
+    # The verdict of the last gate this run gave up on, carried across branches
+    # so the next one can recognise it. A night where the same thing is broken
+    # everywhere — an unreachable host, a browser that will not start — is a
+    # night that should pay for that answer once, not once per pull request.
+    seen: str = ""
 
 
 # One pull request in flight. `budgets` dies with this payload, which is what "a
@@ -84,6 +89,10 @@ class Work(BaseModel):
     budgets: dict[str, int] = {}
     merging: bool = False
     note: str = ""
+    # This branch will not be made green tonight, and is being read anyway. The
+    # reading steps that follow need to know: a branch nobody can merge must not
+    # come out labelled ready to test.
+    blocked: bool = False
 
 
 class TriageItem(BaseModel):
@@ -105,7 +114,7 @@ class Triaged(BaseModel):
 
 class Closed(BaseModel):
     work: Work
-    outcome: Literal["qa", "triage"]
+    outcome: Literal["qa", "triage", "blocked"]
 
 
 class Report(BaseModel):
@@ -128,28 +137,33 @@ def run_with(
     queue: list[PullRequest] | None = None,
     checked: list[Checked] | None = None,
     stopped: str | None = None,
+    seen: str | None = None,
 ) -> Run:
     return Run(
         bound=run.bound,
         queue=run.queue if queue is None else queue,
         checked=run.checked if checked is None else checked,
         stopped=run.stopped if stopped is None else stopped,
+        seen=run.seen if seen is None else seen,
     )
 
 
 def work_with(
     work: Work,
     *,
+    run: Run | None = None,
     budgets: dict[str, int] | None = None,
     merging: bool | None = None,
     note: str | None = None,
+    blocked: bool | None = None,
 ) -> Work:
     return Work(
-        run=work.run,
+        run=work.run if run is None else run,
         pr=work.pr,
         budgets=work.budgets if budgets is None else budgets,
         merging=work.merging if merging is None else merging,
         note=work.note if note is None else note,
+        blocked=work.blocked if blocked is None else blocked,
     )
 
 

--- a/src/ludamus/edges/settings.py
+++ b/src/ludamus/edges/settings.py
@@ -552,6 +552,15 @@ LOGGING = {
             "level": "WARNING" if IS_PRODUCTION else "INFO",
             "propagate": False,
         },
+        # runserver logs a line per request, every static asset included. A
+        # human watching a dev server wants that; the e2e suite produces
+        # thousands of them around the one line saying which test failed, and
+        # they are what a captured run hands on to whoever reads it next.
+        "django.server": {
+            "handlers": ["console"],
+            "level": "WARNING" if IN_TESTS else "INFO",
+            "propagate": False,
+        },
     },
 }
 

--- a/tests/unit/rituals/test_pr_check_endings.py
+++ b/tests/unit/rituals/test_pr_check_endings.py
@@ -13,6 +13,7 @@ from ludamus.edges.rituals.pr_check import (
     report,
     set_aside,
 )
+from ludamus.edges.rituals.shell import COVERAGE, PR_FIX, QA_LABEL, plain
 from ludamus.edges.rituals.state import (
     Checked,
     Closed,
@@ -20,6 +21,7 @@ from ludamus.edges.rituals.state import (
     PullRequest,
     Report,
     Run,
+    TriageItem,
     TriageNotes,
     Work,
 )
@@ -203,8 +205,8 @@ class TestWholeCast:
         trial.shell.replies(when="git fetch*")
         trial.shell.replies(when="git checkout feature*")
         trial.shell.replies(when="git merge --no-edit*")
-        trial.shell.replies(when="mise run pr-fix")
-        trial.shell.replies(when="mise run diff-cover")
+        trial.shell.replies(when=plain(PR_FIX))
+        trial.shell.replies(when=plain(COVERAGE))
         trial.shell.replies(when="gh pr view 7 --json labels", stdout='{"labels": []}')
         trial.shell.replies(when="gh pr edit*", always=True)
         trial.shell.replies(when="git add -A*", always=True)
@@ -248,10 +250,10 @@ class TestWholeCast:
         trial.shell.replies(when="git fetch*")
         trial.shell.replies(when="git checkout feature*")
         trial.shell.replies(when="git merge --no-edit*")
-        trial.shell.replies(when="mise run pr-fix", exit_code=1, stdout="red")
-        trial.shell.replies(when="mise run pr-fix", exit_code=1, stdout="still red")
-        trial.shell.replies(when="mise run pr-fix")
-        trial.shell.replies(when="mise run diff-cover")
+        trial.shell.replies(when=plain(PR_FIX), exit_code=1, stdout="red")
+        trial.shell.replies(when=plain(PR_FIX), exit_code=1, stdout="still red")
+        trial.shell.replies(when=plain(PR_FIX))
+        trial.shell.replies(when=plain(COVERAGE))
         trial.shell.replies(when="gh pr view 7 --json labels", stdout='{"labels": []}')
         trial.shell.replies(when="gh pr edit*", always=True)
         trial.shell.replies(when="git add -A*", always=True)
@@ -270,6 +272,80 @@ class TestWholeCast:
         assert trial.steps.count("gate_check") == _GATE_ROUNDS
         assert trial.coding.calls[0].resume is None
         assert trial.coding.calls[1].resume == "s1"
+
+    # This is not a gate and does not fail fast: a pull request nobody can build
+    # still has reviewers waiting on it, so the branch stands down and takes the
+    # same reading as any other before it is reported blocked.
+    def test_a_branch_that_will_not_go_green_is_still_reviewed_and_triaged(
+        self, trial: Trial, pull: PullRequest
+    ) -> None:
+        trial.shell.replies(
+            when="gh pr list*", stdout=json.dumps([pull.model_dump(by_alias=True)])
+        )
+        trial.shell.replies(when="git status --porcelain")
+        trial.shell.replies(when="git fetch*")
+        trial.shell.replies(when="git checkout feature*")
+        trial.shell.replies(when="git merge --no-edit*")
+        trial.shell.replies(
+            when=plain(PR_FIX), exit_code=1, stdout="1 failed", always=True
+        )
+        trial.shell.replies(when=_RELEASE)
+        trial.shell.replies(when="gh pr view 7 --json labels", stdout='{"labels": []}')
+        trial.shell.replies(when="gh pr edit*", always=True)
+        trial.shell.replies(when="git add -A*", always=True)
+        trial.shell.replies(when=_AHEAD, stdout="3\n")
+        trial.coding.replies("tried", when="*is this project's gate*", always=True)
+        trial.coding.replies("posted the review", when="Review the changes*")
+        trial.coding.replies(
+            TriageNotes(
+                items=[
+                    TriageItem(
+                        where="src/thing.py", what="the guard is missing", priority="p1"
+                    )
+                ]
+            ),
+            when="Read the open*",
+        )
+        trial.coding.replies("wrote triage.md", when="Write triage.md*")
+
+        result = trial.cast(pr_check, PrCheck(bound=1))
+
+        assert result == Report(
+            checked=[
+                _QA_ROW.model_copy(
+                    update={
+                        "outcome": "blocked",
+                        "unpushed": 3,
+                        "note": (
+                            "`mise run pr-fix` is still red:\n1 failed; "
+                            "p1: 1, p2: 0, p3: 0"
+                        ),
+                    }
+                )
+            ],
+            to_push=["feature"],
+        )
+        assert trial.steps == [
+            "list_prs",
+            "next_pr",
+            "check_clean",
+            "sync_branch",
+            "merge_base",
+            "gate_check",
+            "gate_check",
+            "stand_down",
+            "quality_review",
+            "read_comments",
+            "write_triage",
+            "finish_pr",
+            "next_pr",
+            "report",
+        ]
+        # Never `pr::qa`: nobody can test a branch that will not build.
+        assert not any(QA_LABEL in command for command in trial.shell.commands)
+        # And the review is told what already stopped it, so it does not spend an
+        # action item on a thing the report says.
+        assert "already known not to be green" in trial.coding.prompts[1]
 
     # Fatal by design, and the report still comes out first.
     def test_a_dirty_worktree_fails_the_cast_after_the_report(

--- a/tests/unit/rituals/test_pr_check_endings.py
+++ b/tests/unit/rituals/test_pr_check_endings.py
@@ -125,6 +125,43 @@ class TestSetAside:
             ),
         )
 
+    # A branch that stood down and then failed a reading step has two things to
+    # say, and the second must not cost it the first: the morning has to hear
+    # the red gate, not only the `gh` call that came after it.
+    def test_a_branch_that_stood_down_keeps_its_reason_through_a_later_failure(
+        self, trial: Trial, work: Work
+    ) -> None:
+        stood = work.model_copy(
+            update={
+                "reason": f"`{PR_FIX}` is still red:\n1 failed",
+                "note": "gh could not read the labels: no such pull request",
+                "blocked": True,
+            }
+        )
+        trial.shell.replies(when=_RELEASE)
+        trial.shell.replies(when=_AHEAD, stdout="1\n")
+
+        transition = trial.walk(set_aside, stood)
+
+        assert transition == goto(
+            next_pr,
+            Run(
+                bound=3,
+                checked=[
+                    _QA_ROW.model_copy(
+                        update={
+                            "outcome": "blocked",
+                            "unpushed": 1,
+                            "note": (
+                                f"`{PR_FIX}` is still red:\n1 failed; "
+                                "gh could not read the labels: no such pull request"
+                            ),
+                        }
+                    )
+                ],
+            ),
+        )
+
     def test_a_worktree_that_will_not_release_says_so_in_the_note(
         self, trial: Trial, work: Work
     ) -> None:
@@ -180,6 +217,20 @@ class TestReport:
             Report(checked=[unknown], to_push=["feature"], to_fix=["feature"])
         )
         assert "unknown" in trial.deltas[0]
+
+    # The rows are a scannable list, and a verdict is a dozen lines of someone
+    # else's output. It goes under the row, not through it.
+    def test_a_verdict_in_a_note_is_indented_under_its_row(self, trial: Trial) -> None:
+        blocked = _QA_ROW.model_copy(
+            update={
+                "outcome": "blocked",
+                "note": f"`{PR_FIX}` is still red:\n1 failed\n2 passed",
+            }
+        )
+
+        trial.walk(report, Run(bound=3, checked=[blocked]))
+
+        assert "is still red:\n      1 failed\n      2 passed" in trial.deltas[0]
 
     # The summary goes out before the failure is raised, which is the whole
     # reason every ending routes here rather than raising where it happened.
@@ -324,6 +375,9 @@ class TestWholeCast:
                 )
             ],
             to_push=["feature"],
+            # A branch nobody could make green is the clearest thing on the list
+            # there is to do, and this one carries a triage.md as well.
+            to_fix=["feature"],
         )
         assert trial.steps == [
             "list_prs",

--- a/tests/unit/rituals/test_pr_check_gates.py
+++ b/tests/unit/rituals/test_pr_check_gates.py
@@ -10,8 +10,10 @@ from ludamus.edges.rituals.pr_check import (
     gate_check,
     quality_review,
     set_aside,
+    stand_down,
 )
-from ludamus.edges.rituals.shell import BUDGET, COVERAGE, PR_FIX
+from ludamus.edges.rituals.shell import BUDGET, COVERAGE, PR_FIX, plain
+from ludamus.edges.rituals.state import Run
 
 if TYPE_CHECKING:
     from vekna.trial import Trial
@@ -19,6 +21,10 @@ if TYPE_CHECKING:
     from ludamus.edges.rituals.state import Work
 
 _MISSING = "src/ludamus/thing.py (80.0%): Missing lines 12-14"
+# The same suite failing the same way on two branches, an hour and two commits
+# apart: only the timing and the tally moved.
+_RED = "1 failed\n  panel.spec.ts:77:5 > redirects when empty\n210 passed (6.8m)"
+_RED_AGAIN = "1 failed\n  panel.spec.ts:77:5 > redirects when empty\n212 passed (5.5m)"
 _CLEAN = """-------------
 Diff Coverage
 Diff: main...HEAD
@@ -45,18 +51,22 @@ class TestGateCheck:
         self, trial: Trial, work: Work
     ) -> None:
         spent = work.model_copy(update={"budgets": {"gate_check": 2}})
-        trial.shell.replies(when=PR_FIX)
+        trial.shell.replies(when=plain(PR_FIX))
 
         transition = trial.walk(gate_check, spent)
 
         assert transition == goto(finish_merge, work)
-        assert trial.shell.commands == [PR_FIX]
+        # `CI=1`, so what comes back is a log rather than a terminal recording.
+        assert trial.shell.commands == [plain(PR_FIX)]
 
     def test_a_red_gate_hands_both_streams_to_the_agent(
         self, trial: Trial, work: Work
     ) -> None:
         trial.shell.replies(
-            when=PR_FIX, exit_code=1, stdout="E501 line too long", stderr="1 failed"
+            when=plain(PR_FIX),
+            exit_code=1,
+            stdout="E501 line too long",
+            stderr="1 failed",
         )
         trial.coding.replies("fixed it")
 
@@ -74,18 +84,63 @@ class TestGateCheck:
         assert "Do not run the whole-repository sweeps" in trial.coding.prompts[0]
         assert "one linter" in trial.coding.prompts[0]
 
-    def test_a_spent_budget_sets_the_branch_aside_without_asking_again(
+    # It stands down rather than stopping: a branch that will not go green is
+    # still a branch to review, and the verdict rides along so the morning is
+    # told what was red without being handed the whole log.
+    def test_a_spent_budget_stands_the_branch_down_without_asking_again(
         self, trial: Trial, work: Work
     ) -> None:
         spent = work.model_copy(update={"budgets": {"gate_check": 3}})
-        trial.shell.replies(when=PR_FIX, exit_code=1, stdout="still red")
+        trial.shell.replies(when=plain(PR_FIX), exit_code=1, stdout="still red")
 
         transition = trial.walk(gate_check, spent)
 
         assert transition == goto(
-            set_aside, spent.model_copy(update={"note": f"`{PR_FIX}` is still red"})
+            stand_down,
+            spent.model_copy(
+                update={
+                    "note": f"`{PR_FIX}` is still red:\nstill red",
+                    "run": Run(bound=3, seen="still red"),
+                }
+            ),
         )
         assert not trial.coding.prompts
+
+    # Timings and tallies move between branches; the failing test does not. A
+    # night where one thing is broken everywhere pays for that answer once.
+    def test_a_failure_this_run_gave_up_on_is_not_repaired_again(
+        self, trial: Trial, work: Work
+    ) -> None:
+        again = work.model_copy(update={"run": Run(bound=3, seen=_RED)})
+        trial.shell.replies(when=plain(PR_FIX), exit_code=1, stdout=_RED_AGAIN)
+
+        transition = trial.walk(gate_check, again)
+
+        assert transition == goto(
+            stand_down,
+            again.model_copy(
+                update={"note": f"`{PR_FIX}` is red as it already was:\n{_RED_AGAIN}"}
+            ),
+        )
+        assert not trial.coding.prompts
+
+    # Asked before the first repair and not after, or a branch whose gate says
+    # the same thing twice running would be read as the night's standing
+    # failure and dropped mid-loop.
+    def test_a_repair_that_changed_nothing_still_gets_its_budget(
+        self, trial: Trial, work: Work
+    ) -> None:
+        tried = work.model_copy(
+            update={"budgets": {"gate_check": 1}, "run": Run(bound=3, seen=_RED)}
+        )
+        trial.shell.replies(when=plain(PR_FIX), exit_code=1, stdout=_RED_AGAIN)
+        trial.coding.replies("tried again")
+
+        transition = trial.walk(gate_check, tried)
+
+        assert transition == goto(
+            gate_check, tried.model_copy(update={"budgets": {"gate_check": 2}})
+        )
 
 
 class TestFinishMerge:
@@ -128,10 +183,11 @@ class TestFinishMerge:
 
 
 class TestCover:
-    # Read off the report's own word rather than the exit code, which is also
-    # non-zero for a threshold this ritual has no business moving.
+    # Read off the report's own word and not the exit code, which does not carry
+    # this: the task runs `diff-cover` with no `--fail-under`, so a run that
+    # names missing lines still ends 0.
     def test_missing_lines_reach_the_agent(self, trial: Trial, work: Work) -> None:
-        trial.shell.replies(when=COVERAGE, exit_code=1, stdout=_MISSING)
+        trial.shell.replies(when=plain(COVERAGE), stdout=_MISSING)
         trial.coding.replies("wrote the tests")
 
         transition = trial.walk(cover, work)
@@ -141,7 +197,44 @@ class TestCover:
         )
         assert _MISSING in trial.coding.prompts[0]
         assert "Do not run the whole-repository sweeps" in trial.coding.prompts[0]
-        assert trial.shell.commands == [COVERAGE]
+        assert trial.shell.commands == [plain(COVERAGE)]
+
+    # This is what let a red suite through: it names no missing lines, so it was
+    # read as the coverage tool failing rather than the branch, and the pull
+    # request was dropped instead of repaired.
+    def test_a_red_suite_is_repaired_like_any_other_gate(
+        self, trial: Trial, work: Work
+    ) -> None:
+        trial.shell.replies(when=plain(COVERAGE), exit_code=1, stdout=_RED)
+        trial.coding.replies("fixed the test")
+
+        transition = trial.walk(cover, work)
+
+        assert transition == goto(
+            cover, work.model_copy(update={"budgets": {"cover": 1}})
+        )
+        # Named for what is actually red, not for the other gate.
+        assert trial.coding.prompts[0].startswith(f"`{COVERAGE}` is this project")
+        assert "do not disable a lint rule" in trial.coding.prompts[0]
+
+    def test_a_red_suite_that_stays_red_stands_the_branch_down(
+        self, trial: Trial, work: Work
+    ) -> None:
+        spent = work.model_copy(update={"budgets": {"cover": 3}})
+        trial.shell.replies(when=plain(COVERAGE), exit_code=1, stdout=_RED)
+
+        transition = trial.walk(cover, spent)
+
+        assert transition == goto(
+            stand_down,
+            spent.model_copy(
+                update={
+                    "note": f"`{COVERAGE}` is still red:\n{_RED}",
+                    "run": Run(bound=3, seen=_RED),
+                }
+            ),
+        )
+        assert not trial.coding.prompts
 
     # The whole listing is the work list. A tail of it is an agent asked to
     # cover lines it was never shown, and then another full unit and e2e run to
@@ -157,8 +250,7 @@ class TestCover:
         )
         transcript = "\n".join(f"tests/test_{index}.py PASSED" for index in range(4000))
         trial.shell.replies(
-            when=COVERAGE,
-            exit_code=1,
+            when=plain(COVERAGE),
             stdout=f"{transcript}\n-------------\nDiff Coverage\n{listing}\n",
         )
         trial.coding.replies("wrote the tests")
@@ -176,7 +268,7 @@ class TestCover:
     def test_a_clean_report_is_not_read_as_missing_lines(
         self, trial: Trial, work: Work
     ) -> None:
-        trial.shell.replies(when=COVERAGE, stdout=_CLEAN)
+        trial.shell.replies(when=plain(COVERAGE), stdout=_CLEAN)
 
         transition = trial.walk(cover, work)
 
@@ -186,60 +278,60 @@ class TestCover:
     def test_a_first_pass_with_nothing_missing_commits_nothing(
         self, trial: Trial, work: Work
     ) -> None:
-        trial.shell.replies(when=COVERAGE)
+        trial.shell.replies(when=plain(COVERAGE))
 
         transition = trial.walk(cover, work)
 
         # A commit rite that can never commit anything is noise in the tree.
         assert transition == goto(quality_review, work)
-        assert trial.shell.commands == [COVERAGE]
+        assert trial.shell.commands == [plain(COVERAGE)]
 
     def test_tests_that_were_written_are_committed_and_the_budget_cleared(
         self, trial: Trial, work: Work
     ) -> None:
         spent = work.model_copy(update={"budgets": {"cover": 1}})
-        trial.shell.replies(when=COVERAGE)
+        trial.shell.replies(when=plain(COVERAGE))
         trial.shell.replies(when="git add -A*")
 
         transition = trial.walk(cover, spent)
 
         assert transition == goto(quality_review, work)
-        assert trial.shell.commands == [COVERAGE, _TEST_COMMIT]
+        assert trial.shell.commands == [plain(COVERAGE), _TEST_COMMIT]
 
-    def test_a_spent_budget_sets_the_branch_aside(
+    def test_a_spent_budget_stands_the_branch_down(
         self, trial: Trial, work: Work
     ) -> None:
         spent = work.model_copy(update={"budgets": {"cover": 3}})
-        trial.shell.replies(when=COVERAGE, exit_code=1, stdout=_MISSING)
+        trial.shell.replies(when=plain(COVERAGE), stdout=_MISSING)
 
         transition = trial.walk(cover, spent)
 
         assert transition == goto(
-            set_aside,
+            stand_down,
             spent.model_copy(
-                update={"note": f"`{COVERAGE}` still reports missing lines"}
-            ),
-        )
-        assert not trial.coding.prompts
-
-    # A red run that names no missing lines is the tool failing, not the branch:
-    # handing that to an agent would spend a turn on nothing.
-    def test_a_report_that_failed_without_naming_lines_is_set_aside(
-        self, trial: Trial, work: Work
-    ) -> None:
-        trial.shell.replies(when=COVERAGE, exit_code=2, stderr="no coverage data")
-
-        transition = trial.walk(cover, work)
-
-        assert transition == goto(
-            set_aside,
-            work.model_copy(
+                # No `seen`: what lines a branch left uncovered is that branch's
+                # own business, and two of them missing lines in the same file
+                # would look like one standing failure from here.
                 update={
-                    "note": (
-                        f"`{COVERAGE}` failed without naming missing lines: "
-                        "no coverage data"
-                    )
+                    "note": f"`{COVERAGE}` still reports missing lines:\n{_MISSING}"
                 }
             ),
         )
         assert not trial.coding.prompts
+
+    # The tool falling over rather than the branch — no report at all, so the
+    # trimmed log is what there is to hand on.
+    def test_a_run_that_printed_no_report_is_still_repaired(
+        self, trial: Trial, work: Work
+    ) -> None:
+        trial.shell.replies(
+            when=plain(COVERAGE), exit_code=2, stderr="no coverage data"
+        )
+        trial.coding.replies("looked at it")
+
+        transition = trial.walk(cover, work)
+
+        assert transition == goto(
+            cover, work.model_copy(update={"budgets": {"cover": 1}})
+        )
+        assert "no coverage data" in trial.coding.prompts[0]

--- a/tests/unit/rituals/test_pr_check_gates.py
+++ b/tests/unit/rituals/test_pr_check_gates.py
@@ -99,8 +99,8 @@ class TestGateCheck:
             stand_down,
             spent.model_copy(
                 update={
-                    "note": f"`{PR_FIX}` is still red:\nstill red",
-                    "run": Run(bound=3, seen="still red"),
+                    "reason": f"`{PR_FIX}` is still red:\nstill red",
+                    "run": Run(bound=3, seen=["still red"]),
                 }
             ),
         )
@@ -111,7 +111,7 @@ class TestGateCheck:
     def test_a_failure_this_run_gave_up_on_is_not_repaired_again(
         self, trial: Trial, work: Work
     ) -> None:
-        again = work.model_copy(update={"run": Run(bound=3, seen=_RED)})
+        again = work.model_copy(update={"run": Run(bound=3, seen=[_RED])})
         trial.shell.replies(when=plain(PR_FIX), exit_code=1, stdout=_RED_AGAIN)
 
         transition = trial.walk(gate_check, again)
@@ -119,7 +119,7 @@ class TestGateCheck:
         assert transition == goto(
             stand_down,
             again.model_copy(
-                update={"note": f"`{PR_FIX}` is red as it already was:\n{_RED_AGAIN}"}
+                update={"reason": f"`{PR_FIX}` is red as it already was:\n{_RED_AGAIN}"}
             ),
         )
         assert not trial.coding.prompts
@@ -131,7 +131,7 @@ class TestGateCheck:
         self, trial: Trial, work: Work
     ) -> None:
         tried = work.model_copy(
-            update={"budgets": {"gate_check": 1}, "run": Run(bound=3, seen=_RED)}
+            update={"budgets": {"gate_check": 1}, "run": Run(bound=3, seen=[_RED])}
         )
         trial.shell.replies(when=plain(PR_FIX), exit_code=1, stdout=_RED_AGAIN)
         trial.coding.replies("tried again")
@@ -229,8 +229,8 @@ class TestCover:
             stand_down,
             spent.model_copy(
                 update={
-                    "note": f"`{COVERAGE}` is still red:\n{_RED}",
-                    "run": Run(bound=3, seen=_RED),
+                    "reason": f"`{COVERAGE}` is still red:\n{_RED}",
+                    "run": Run(bound=3, seen=[_RED]),
                 }
             ),
         )
@@ -313,7 +313,7 @@ class TestCover:
                 # own business, and two of them missing lines in the same file
                 # would look like one standing failure from here.
                 update={
-                    "note": f"`{COVERAGE}` still reports missing lines:\n{_MISSING}"
+                    "reason": f"`{COVERAGE}` still reports missing lines:\n{_MISSING}"
                 }
             ),
         )

--- a/tests/unit/rituals/test_pr_check_merge.py
+++ b/tests/unit/rituals/test_pr_check_merge.py
@@ -270,6 +270,8 @@ class TestResolveConflicts:
 
         assert transition == goto(
             stand_down,
-            spent.model_copy(update={"note": "the merge conflicts were not resolved"}),
+            spent.model_copy(
+                update={"reason": "the merge conflicts were not resolved"}
+            ),
         )
         assert not trial.coding.prompts

--- a/tests/unit/rituals/test_pr_check_merge.py
+++ b/tests/unit/rituals/test_pr_check_merge.py
@@ -14,6 +14,7 @@ from ludamus.edges.rituals.pr_check import (
     report,
     resolve_conflicts,
     set_aside,
+    stand_down,
     sync_branch,
 )
 from ludamus.edges.rituals.shell import LIST, WAIT_LABEL
@@ -257,7 +258,9 @@ class TestResolveConflicts:
         assert transition == goto(gate_check, work)
         assert not trial.coding.prompts
 
-    def test_a_spent_budget_sets_the_branch_aside_without_asking_again(
+    # The merge is abandoned, not the pull request: the branch goes back to
+    # where it stood and is read there.
+    def test_a_spent_budget_stands_the_branch_down_without_asking_again(
         self, trial: Trial, work: Work
     ) -> None:
         spent = work.model_copy(update={"budgets": {"resolve_conflicts": 3}})
@@ -266,7 +269,7 @@ class TestResolveConflicts:
         transition = trial.walk(resolve_conflicts, spent)
 
         assert transition == goto(
-            set_aside,
+            stand_down,
             spent.model_copy(update={"note": "the merge conflicts were not resolved"}),
         )
         assert not trial.coding.prompts

--- a/tests/unit/rituals/test_shell.py
+++ b/tests/unit/rituals/test_shell.py
@@ -5,6 +5,7 @@ from vekna.folio.shell import ShellResult
 from ludamus.edges.rituals.shell import (
     BUDGET,
     VERDICT_LINES,
+    already_seen,
     coverage_report,
     said,
     same_verdict,
@@ -41,6 +42,12 @@ class TestSaid:
         assert said(_ran(stdout="E501 too long", stderr="1 failed")) == (
             "E501 too long\n1 failed"
         )
+
+    # The agent pays for what it reads, and a cursor move is not worth a token.
+    def test_colour_and_cursor_moves_are_stripped(self) -> None:
+        coloured = "\x1b[1A\x1b[2K\x1b[31m1 failed\x1b[39m"
+
+        assert said(_ran(stdout=coloured)) == "1 failed"
 
     def test_a_trailing_newline_is_not_a_line(self) -> None:
         assert said(_ran(stdout="E501 too long\n", stderr="1 failed\n")) == (
@@ -132,6 +139,21 @@ class TestSameVerdict:
     # round the repair loop like any other.
     def test_an_empty_verdict_matches_nothing(self) -> None:
         assert not same_verdict("", "")
+
+
+class TestAlreadySeen:
+    # Two things broken at once alternate down the queue, and a memo of one
+    # recognises neither.
+    def test_a_verdict_the_run_gave_up_on_earlier_is_still_recognised(self) -> None:
+        assert already_seen(
+            "1 failed (6.8m)", ["could not resolve host", "1 failed (5.5m)"]
+        )
+
+    def test_a_new_failure_is_not(self) -> None:
+        assert not already_seen("2 errors", ["could not resolve host", "1 failed"])
+
+    def test_a_run_that_has_given_up_on_nothing_recognises_nothing(self) -> None:
+        assert not already_seen("1 failed", [])
 
 
 class TestCoverageReport:

--- a/tests/unit/rituals/test_shell.py
+++ b/tests/unit/rituals/test_shell.py
@@ -2,7 +2,14 @@
 
 from vekna.folio.shell import ShellResult
 
-from ludamus.edges.rituals.shell import BUDGET, coverage_report, said
+from ludamus.edges.rituals.shell import (
+    BUDGET,
+    VERDICT_LINES,
+    coverage_report,
+    said,
+    same_verdict,
+    verdict,
+)
 
 # Ten characters once its newline is counted, so a whole number of these is
 # exactly the budget and the boundary can be named rather than approached.
@@ -75,6 +82,56 @@ class TestSaid:
 
     def test_a_stream_that_said_nothing_is_left_out(self) -> None:
         assert said(_ran(stdout="1 failed", stderr="\n")) == "1 failed"
+
+
+class TestVerdict:
+    def test_the_tail_is_what_comes_back(self) -> None:
+        run = "\n".join([f"line {index}" for index in range(50)] + ["1 failed"])
+
+        assert verdict(_ran(stdout=run)).splitlines() == [
+            *[f"line {index}" for index in range(50 - VERDICT_LINES + 1, 50)],
+            "1 failed",
+        ]
+
+    # A progress reporter writing over itself leaves hundreds of these, and they
+    # would spend the whole allowance saying nothing.
+    def test_blank_lines_do_not_count_against_the_allowance(self) -> None:
+        padded = "1 failed" + "\n" * 200 + "\n210 passed"
+
+        assert verdict(_ran(stdout=padded)) == "1 failed\n210 passed"
+
+    def test_colour_and_cursor_moves_are_stripped(self) -> None:
+        coloured = "\x1b[1A\x1b[2K\x1b[31m1 failed\x1b[39m"
+
+        assert verdict(_ran(stdout=coloured)) == "1 failed"
+
+    # Under e2e, stderr is a web server logging every request it served. The
+    # tools put their tally on stdout, and that is the whole answer.
+    def test_a_stderr_transcript_cannot_bury_what_stdout_said(self) -> None:
+        chatter = _rows(_FITS * 2)
+
+        assert verdict(_ran(stdout="1 failed", stderr=chatter)) == "1 failed"
+
+    # The task that died before it started says so on stderr and nowhere else.
+    def test_a_silent_stdout_falls_back_to_stderr(self) -> None:
+        assert verdict(_ran(stderr="mise: no such task")) == "mise: no such task"
+
+
+class TestSameVerdict:
+    # Timings and tallies move between branches; the failing test does not.
+    def test_the_same_failure_counted_differently_is_the_same_failure(self) -> None:
+        assert same_verdict(
+            "1 failed\n  panel.spec.ts:77:5 > redirects\n210 passed (6.8m)",
+            "1 failed\n  panel.spec.ts:77:5 > redirects\n212 passed (5.5m)",
+        )
+
+    def test_a_different_failure_is_not(self) -> None:
+        assert not same_verdict("panel.spec.ts > redirects", "panel.spec.ts > assigns")
+
+    # Nothing recognises nothing: a run with no verdict to compare has to go
+    # round the repair loop like any other.
+    def test_an_empty_verdict_matches_nothing(self) -> None:
+        assert not same_verdict("", "")
 
 
 class TestCoverageReport:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Persistently failing checks and coverage issues are now reported as blocked instead of silently skipped.
  - Blocking details are preserved through review and triage, without repeating identical failure messages.
  - Workspace cleanup is handled consistently after blocked or exhausted work.

- **Improvements**
  - Coverage failures now distinguish missing coverage from failing test suites and support more reliable repairs.
  - Diagnostic output is cleaner and more consistent, including improved command and failure summaries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->